### PR TITLE
Increase default task timeout to 30 minutes

### DIFF
--- a/app/router/rule_based.py
+++ b/app/router/rule_based.py
@@ -11,7 +11,7 @@ from app.models import ExecutionConstraints, RoutedTask, TaskEnvelope
 class RuleBasedRouter:
     """Map canonical envelopes to routed tasks using simple source rules."""
 
-    default_timeout_seconds: int = 180
+    default_timeout_seconds: int = 1800
     default_max_tokens: int = 12000
     cron_timeout_seconds: int = 120
     cron_max_tokens: int = 8000

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -26,7 +26,7 @@ class RuleBasedRouterTests(unittest.TestCase):
         self.assertEqual(task.envelope_id, envelope.id)
         self.assertEqual(task.workflow, "respond_and_optionally_edit")
         self.assertEqual(task.priority, "normal")
-        self.assertEqual(task.execution_constraints.timeout_seconds, 180)
+        self.assertEqual(task.execution_constraints.timeout_seconds, 1800)
         self.assertEqual(task.execution_constraints.max_tokens, 12000)
         self.assertEqual(task.policy_profile, "default")
         self.assertEqual(task.source, "email")


### PR DESCRIPTION
## Summary
- increase rule-based router default task timeout from 180s to 1800s (30 minutes)
- keep cron timeout unchanged at 120s
- update router unit test expectation for the new default

## Verification
- python3 -m unittest tests.test_router