### PR TITLE
Bump CI Python version to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Run unit tests
         run: python3 -m unittest discover -s tests

--- a/docs/debug-and-test.md
+++ b/docs/debug-and-test.md
@@ -100,4 +100,4 @@ Use these with DB queries to correlate outcomes.
 
 - Workflow file: `.github/workflows/ci.yml`
 - Triggers: push to `main`, and pull requests targeting `main`
-- Python version: `3.11`
+- Python version: `3.13`

--- a/plans/ci-workflow-plan.md
+++ b/plans/ci-workflow-plan.md
@@ -21,6 +21,7 @@ Add a GitHub Actions CI workflow that runs the project test suite on pull reques
 - 2026-03-04: Created `feat/ci-workflow` from `origin/main`.
 - 2026-03-04: Added initial plan/checklist for resumable execution.
 - 2026-03-05: Added `.github/workflows/ci.yml` with push/PR to `main` triggers and unittest discovery execution on Python 3.11.
+- 2026-03-05: Updated CI workflow baseline from Python 3.11 to 3.13.
 - 2026-03-05: Fixed env-sensitive Telegram CLI test to be deterministic when `CHATTING_TELEGRAM_BOT_TOKEN` is set locally.
 - 2026-03-05: Added CI notes to `docs/debug-and-test.md` and linked workflow in `docs/README.md`.
 - 2026-03-05: Fixed CLI IMAP validation test isolation so local `CHATTING_CONFIG_PATH` does not cause real network attempts.


### PR DESCRIPTION
## Summary
- bump GitHub Actions CI Python version from 3.11 to 3.13
- update debug/testing docs to reflect CI runtime version
- record the version bump in CI workflow progress notes

## Testing
- python3 -m unittest discover -s tests