### PR TITLE
Implement retry-safe multi-update responses for Telegram

### DIFF
--- a/app/applier/__init__.py
+++ b/app/applier/__init__.py
@@ -4,6 +4,7 @@ from app.applier.base import Applier
 from app.applier.integrated import (
     EmailSender,
     IntegratedApplier,
+    MessageDispatchError,
     SmtpEmailSender,
     TelegramMessageSender,
     TelegramSender,
@@ -14,6 +15,7 @@ __all__ = [
     "Applier",
     "EmailSender",
     "IntegratedApplier",
+    "MessageDispatchError",
     "NoOpApplier",
     "SmtpEmailSender",
     "TelegramMessageSender",

--- a/app/applier/integrated.py
+++ b/app/applier/integrated.py
@@ -32,6 +32,17 @@ class TelegramSender(Protocol):
 
 
 @dataclass(frozen=True)
+class MessageDispatchError(RuntimeError):
+    """Raised when message dispatch fails after one or more successful sends."""
+
+    reason_code: str
+    dispatched_messages: list[OutboundMessage]
+
+    def __str__(self) -> str:
+        return self.reason_code
+
+
+@dataclass(frozen=True)
 class SmtpEmailSender:
     """SMTP email sender used by the integrated applier."""
 
@@ -209,7 +220,10 @@ class IntegratedApplier:
                         dispatch_channel,
                         dispatch_target,
                     )
-                    reason_codes.append("email_dispatch_failed")
+                    raise MessageDispatchError(
+                        reason_code="email_dispatch_failed",
+                        dispatched_messages=list(dispatched_messages),
+                    ) from None
                 continue
             if dispatch_channel == "telegram":
                 if self.telegram_sender is None:
@@ -229,7 +243,10 @@ class IntegratedApplier:
                         dispatch_channel,
                         dispatch_target,
                     )
-                    reason_codes.append("telegram_dispatch_failed")
+                    raise MessageDispatchError(
+                        reason_code="telegram_dispatch_failed",
+                        dispatched_messages=list(dispatched_messages),
+                    ) from None
                 continue
             LOGGER.warning(
                 "drop_dispatch reason=unsupported_message_channel channel=%s target=%s",
@@ -373,6 +390,7 @@ def _is_telegram_parse_mode_error(response: dict[str, object]) -> bool:
 __all__ = [
     "EmailSender",
     "IntegratedApplier",
+    "MessageDispatchError",
     "SmtpEmailSender",
     "TelegramMessageSender",
     "TelegramSender",

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from typing import Mapping, Sequence
 
 from app.applier import (
     IntegratedApplier,
+    MessageDispatchError,
     NoOpApplier,
     SmtpEmailSender,
     TelegramMessageSender,
@@ -35,7 +36,7 @@ from app.connectors import (
     TelegramConnector,
 )
 from app.executor import CodexExecutor, Executor, StubExecutor
-from app.models import AuditEvent, DeadLetterRecord, RunRecord, TaskEnvelope
+from app.models import AuditEvent, DeadLetterRecord, OutboundMessage, PolicyDecision, RunRecord, TaskEnvelope
 from app.policy import AllowlistPolicyEngine
 from app.router import RuleBasedRouter
 from app.queue import InMemoryQueueBackend, QueueBackend
@@ -399,8 +400,36 @@ def _process_envelope(
                     config_path=update.path,
                     config_value=update.value,
                 )
+            dispatched_event_indices = store.list_dispatched_event_indices(run_id=base_run_id)
+            pending_message_start_index = _first_undelivered_event_index(dispatched_event_indices)
+            pending_messages = decision.approved_messages[pending_message_start_index:]
+            apply_decision = PolicyDecision(
+                approved_actions=decision.approved_actions,
+                blocked_actions=decision.blocked_actions,
+                approved_messages=pending_messages,
+                config_updates=decision.config_updates,
+                reason_codes=decision.reason_codes,
+                schema_version=decision.schema_version,
+            )
             error_stage = "applier"
-            apply_result = applier.apply(decision, envelope=envelope)
+            try:
+                apply_result = applier.apply(apply_decision, envelope=envelope)
+            except MessageDispatchError as dispatch_error:
+                for event_index in _resolve_dispatched_event_indices(
+                    original_messages=pending_messages,
+                    dispatched_messages=dispatch_error.dispatched_messages,
+                    envelope=envelope,
+                    start_index=pending_message_start_index,
+                ):
+                    store.mark_dispatched_event(run_id=base_run_id, event_index=event_index)
+                raise
+            for event_index in _resolve_dispatched_event_indices(
+                original_messages=pending_messages,
+                dispatched_messages=apply_result.dispatched_messages,
+                envelope=envelope,
+                start_index=pending_message_start_index,
+            ):
+                store.mark_dispatched_event(run_id=base_run_id, event_index=event_index)
             apply_result_payload = apply_result.to_dict()
             if store_telegram_memory:
                 for message in apply_result.dispatched_messages:
@@ -421,7 +450,9 @@ def _process_envelope(
             approved_message_count = len(decision.approved_messages)
             applied_action_count = len(apply_result.applied_actions)
             skipped_action_count = len(apply_result.skipped_actions)
-            dispatched_message_count = len(apply_result.dispatched_messages)
+            dispatched_message_count = len(
+                store.list_dispatched_event_indices(run_id=base_run_id)
+            )
             apply_reason_codes = apply_result.reason_codes
             result_status = _result_status(reason_codes)
             break
@@ -610,6 +641,63 @@ def _result_status(reason_codes: list[str]) -> str:
     if "executor_reported_errors" in reason_codes:
         return "execution_error"
     return "success"
+
+
+def _first_undelivered_event_index(dispatched_event_indices: list[int]) -> int:
+    expected_index = 0
+    for index in dispatched_event_indices:
+        if index != expected_index:
+            break
+        expected_index += 1
+    return expected_index
+
+
+def _resolve_dispatched_event_indices(
+    *,
+    original_messages: list[OutboundMessage],
+    dispatched_messages: list[OutboundMessage],
+    envelope: TaskEnvelope,
+    start_index: int,
+) -> list[int]:
+    if not original_messages or not dispatched_messages:
+        return []
+
+    matched_indices: list[int] = []
+    dispatched_cursor = 0
+    for offset, message in enumerate(original_messages):
+        if dispatched_cursor >= len(dispatched_messages):
+            break
+        normalized_message = _normalize_outbound_message_for_dispatch(
+            message=message,
+            envelope=envelope,
+        )
+        if not _outbound_messages_match(normalized_message, dispatched_messages[dispatched_cursor]):
+            continue
+        matched_indices.append(start_index + offset)
+        dispatched_cursor += 1
+    return matched_indices
+
+
+def _normalize_outbound_message_for_dispatch(
+    *,
+    message: OutboundMessage,
+    envelope: TaskEnvelope,
+) -> OutboundMessage:
+    if message.channel != "final":
+        return message
+    return OutboundMessage(
+        channel=envelope.reply_channel.type,
+        target=envelope.reply_channel.target,
+        body=message.body,
+    )
+
+
+def _outbound_messages_match(expected: OutboundMessage, actual: OutboundMessage) -> bool:
+    return (
+        expected.channel == actual.channel
+        and expected.target == actual.target
+        and expected.body == actual.body
+    )
 
 
 def _should_store_telegram_memory(envelope: TaskEnvelope) -> bool:

--- a/app/state/base.py
+++ b/app/state/base.py
@@ -108,5 +108,11 @@ class StateStore(Protocol):
     ) -> list[tuple[str, str]]:
         """Return recent conversation turns as (role, content), oldest first."""
 
+    def mark_dispatched_event(self, *, run_id: str, event_index: int) -> None:
+        """Persist one dispatched outbound event checkpoint for idempotent retry."""
+
+    def list_dispatched_event_indices(self, *, run_id: str) -> list[int]:
+        """Return dispatched event indexes for one run in ascending order."""
+
 
 __all__ = ["StateStore"]

--- a/app/state/sqlite_store.py
+++ b/app/state/sqlite_store.py
@@ -134,6 +134,16 @@ class SQLiteStateStore:
                 )
                 """
             )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS dispatched_events (
+                    run_id TEXT NOT NULL,
+                    event_index INTEGER NOT NULL,
+                    dispatched_at TEXT NOT NULL,
+                    PRIMARY KEY (run_id, event_index)
+                )
+                """
+            )
             connection.commit()
 
     def _initialize_idempotency_table(self, connection: sqlite3.Connection) -> None:
@@ -762,6 +772,37 @@ class SQLiteStateStore:
                 (channel, target, limit),
             ).fetchall()
         return [(row["role"], row["content"]) for row in reversed(rows)]
+
+    def mark_dispatched_event(self, *, run_id: str, event_index: int) -> None:
+        if not run_id:
+            raise ValueError("run_id is required")
+        if event_index < 0:
+            raise ValueError("event_index must be non-negative")
+        dispatched_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO dispatched_events (run_id, event_index, dispatched_at)
+                VALUES (?, ?, ?)
+                """,
+                (run_id, event_index, dispatched_at),
+            )
+            connection.commit()
+
+    def list_dispatched_event_indices(self, *, run_id: str) -> list[int]:
+        if not run_id:
+            raise ValueError("run_id is required")
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT event_index
+                FROM dispatched_events
+                WHERE run_id = ?
+                ORDER BY event_index ASC
+                """,
+                (run_id,),
+            ).fetchall()
+        return [int(row["event_index"]) for row in rows]
 
 
 def _parse_rfc3339_utc(value: str) -> datetime:

--- a/tests/test_applier.py
+++ b/tests/test_applier.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 
 from app.applier import (
     IntegratedApplier,
+    MessageDispatchError,
     NoOpApplier,
     SmtpEmailSender,
     TelegramMessageSender,
@@ -302,6 +303,29 @@ class IntegratedApplierTests(unittest.TestCase):
             )
             self.assertEqual(result.reason_codes, [])
 
+    def test_apply_raises_dispatch_error_with_partial_progress_on_telegram_failure(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            sender = _FailingTelegramSender()
+            decision = PolicyDecision(
+                approved_actions=[],
+                blocked_actions=[],
+                approved_messages=[
+                    OutboundMessage(channel="telegram", target="12345", body="👀"),
+                    OutboundMessage(channel="telegram", target="12345", body="working"),
+                ],
+                config_updates=ConfigUpdateDecision(),
+                reason_codes=[],
+            )
+
+            with self.assertRaises(MessageDispatchError) as context:
+                IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+
+            self.assertEqual(context.exception.reason_code, "telegram_dispatch_failed")
+            self.assertEqual(
+                context.exception.dispatched_messages,
+                [OutboundMessage(channel="telegram", target="12345", body="👀")],
+            )
+
 
 class SmtpEmailSenderTests(unittest.TestCase):
     def test_send_uses_smtp_client(self) -> None:
@@ -419,6 +443,16 @@ class _RecordingTelegramSender:
 
     def send(self, target: str, body: str) -> None:
         self.sent.append((target, body))
+
+
+class _FailingTelegramSender:
+    def __init__(self) -> None:
+        self._count = 0
+
+    def send(self, target: str, body: str) -> None:
+        self._count += 1
+        if self._count == 2:
+            raise RuntimeError("simulated dispatch failure")
 
 
 def _email_envelope(*, subject: str, body: str):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,6 +90,24 @@ class RecordingTelegramExecutor:
         )
 
 
+@dataclass(frozen=True)
+class MultiUpdateTelegramExecutor:
+    """Executor that emits three ordered updates for one Telegram task."""
+
+    def execute(self, task: RoutedTask):
+        return ExecutionResult(
+            messages=[
+                OutboundMessage(channel="final", target="user", body="👀"),
+                OutboundMessage(channel="final", target="user", body="working on a pr"),
+                OutboundMessage(channel="final", target="user", body="done: https://example.com/pr/1"),
+            ],
+            actions=[],
+            config_updates=[],
+            requires_human_review=False,
+            errors=[],
+        )
+
+
 class MainBootstrapFlowTests(unittest.TestCase):
     def test_run_bootstrap_processes_unique_events_and_records_blocked_action(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -325,6 +343,18 @@ class RecordingTelegramSender:
         self.sent.append((target, body))
 
 
+@dataclass
+class FailSecondTelegramSendOnce:
+    sent: list[tuple[str, str]] = field(default_factory=list)
+    _failed: bool = False
+
+    def send(self, target: str, body: str) -> None:
+        if body == "working on a pr" and not self._failed:
+            self._failed = True
+            raise RuntimeError("simulated transient telegram failure")
+        self.sent.append((target, body))
+
+
 @dataclass(frozen=True)
 class FailingPolicyEngine:
     error_message: str = "policy evaluation failure"
@@ -420,6 +450,43 @@ class MainLiveFlowTests(unittest.TestCase):
             self.assertIn("Current user message:", executor.seen_contents[1])
             self.assertIn("What continent is that in?", executor.seen_contents[1])
 
+    def test_run_live_retries_multi_update_telegram_without_duplicate_prior_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            envelope = _telegram_envelope(event_id="telegram:multi-1", content="Do a thing")
+            sender = FailSecondTelegramSendOnce()
+
+            runs = run_live(
+                db_path,
+                connectors=[OneShotConnector(envelopes=[envelope])],
+                executor=MultiUpdateTelegramExecutor(),
+                max_loops=1,
+                max_attempts=2,
+                poll_interval_seconds=0.1,
+                base_dir=tmpdir,
+                telegram_sender=sender,
+            )
+
+            self.assertEqual(len(runs), 1)
+            self.assertEqual(runs[0].result_status, "success")
+            self.assertEqual(
+                sender.sent,
+                [
+                    ("8605042448", "👀"),
+                    ("8605042448", "working on a pr"),
+                    ("8605042448", "done: https://example.com/pr/1"),
+                ],
+            )
+
+            audit_events = SQLiteStateStore(db_path).list_audit_events()
+            self.assertEqual(len(audit_events), 1)
+            self.assertEqual(audit_events[0].detail["attempt_count"], 2)
+            self.assertEqual(audit_events[0].detail["dispatched_message_count"], 3)
+
+            dispatched_indices = SQLiteStateStore(db_path).list_dispatched_event_indices(
+                run_id="run:telegram:multi-1"
+            )
+            self.assertEqual(dispatched_indices, [0, 1, 2])
 
     def test_run_live_sends_error_notification_on_dead_letter(self) -> None:
         """Error notification email is sent when executor error exhausts retries."""

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -213,6 +213,24 @@ class SQLiteStateStoreTests(unittest.TestCase):
                 ],
             )
 
+    def test_dispatched_event_checkpoint_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            store = SQLiteStateStore(db_path)
+
+            store.mark_dispatched_event(run_id="run:telegram:1", event_index=1)
+            store.mark_dispatched_event(run_id="run:telegram:1", event_index=0)
+            store.mark_dispatched_event(run_id="run:telegram:1", event_index=1)
+
+            self.assertEqual(
+                store.list_dispatched_event_indices(run_id="run:telegram:1"),
+                [0, 1],
+            )
+            self.assertEqual(
+                store.list_dispatched_event_indices(run_id="run:telegram:other"),
+                [],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `dispatched_events` checkpoints in `SQLiteStateStore` keyed by `(run_id, event_index)`
- make `IntegratedApplier` raise `MessageDispatchError` on real email/telegram send failures with partial progress attached
- update `_process_envelope` retry flow to resume from the first undelivered message index and persist dispatched checkpoints after partial/full applies
- keep ordered 1..N outbound updates while preventing duplicate earlier updates on retry
- add regression tests for applier partial-dispatch failures, store checkpoint roundtrip, and live Telegram multi-update retry behavior

Closes #5

## Validation
- `python3 -m unittest tests.test_applier tests.test_sqlite_store tests.test_main`