### PR TITLE
worker: allow configuring codex subprocess working directory

### DIFF
--- a/app/executor/codex.py
+++ b/app/executor/codex.py
@@ -42,6 +42,7 @@ class CodexExecutor:
     """Run Codex as a subprocess and parse strict JSON output."""
 
     command: tuple[str, ...] = ("codex", "exec", "--json")
+    cwd: str | None = None
 
     def execute(self, task: RoutedTask) -> ExecutionResult:
         payload = json.dumps(_task_payload(task))
@@ -53,6 +54,7 @@ class CodexExecutor:
                 text=True,
                 timeout=task.execution_constraints.timeout_seconds,
                 check=False,
+                cwd=self.cwd,
             )
         except subprocess.TimeoutExpired:
             return _error_result("executor_timeout")

--- a/app/main_worker.py
+++ b/app/main_worker.py
@@ -26,6 +26,7 @@ ALLOWED_WORKER_CONFIG_KEYS = frozenset(
     {
         "bbmb_address",
         "codex_command",
+        "codex_working_dir",
         "db_path",
         "max_attempts",
         "max_loops",
@@ -71,6 +72,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--sleep-seconds", type=_positive_float, help="Sleep duration after empty pickup.")
     parser.add_argument("--codex-command", help="Command used for Codex executor.")
     parser.add_argument(
+        "--codex-working-dir",
+        help="Working directory used only for launching Codex subprocesses.",
+    )
+    parser.add_argument(
         "--use-stub-executor",
         action="store_true",
         help="Use deterministic stub executor.",
@@ -106,6 +111,18 @@ def _resolve_str(cli_value: str | None, config_value: object, *, default_value: 
         return cli_value
     if config_value is None:
         return default_value
+    if not isinstance(config_value, str) or not config_value.strip():
+        raise ValueError(f"config {setting_name} must be a non-empty string")
+    return config_value
+
+
+def _resolve_optional_str(cli_value: str | None, config_value: object, *, setting_name: str) -> str | None:
+    if cli_value is not None:
+        if not cli_value.strip():
+            raise ValueError(f"{setting_name} must not be empty")
+        return cli_value
+    if config_value is None:
+        return None
     if not isinstance(config_value, str) or not config_value.strip():
         raise ValueError(f"config {setting_name} must be a non-empty string")
     return config_value
@@ -168,7 +185,12 @@ def _build_executor(args: argparse.Namespace, config: dict[str, object]) -> Exec
     split_command = tuple(shlex.split(command))
     if not split_command:
         raise ValueError("codex_command must not be empty")
-    return CodexExecutor(command=split_command)
+    codex_working_dir = _resolve_optional_str(
+        args.codex_working_dir,
+        config.get("codex_working_dir"),
+        setting_name="codex_working_dir",
+    )
+    return CodexExecutor(command=split_command, cwd=codex_working_dir)
 
 
 def main() -> int:

--- a/configs/worker-runtime.example.json
+++ b/configs/worker-runtime.example.json
@@ -6,5 +6,6 @@
   "sleep_seconds": 1.0,
   "max_loops": 1,
   "codex_command": "codex exec --json",
+  "codex_working_dir": "/opt/chatting",
   "use_stub_executor": true
 }

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -41,6 +41,10 @@ cp configs/worker-runtime.example.json /tmp/worker.json
 python3 -m app.main_worker --config /tmp/worker.json
 ```
 
+If the service/user shell working directory is not where you want Codex to run, set
+`codex_working_dir` in worker config (or pass `--codex-working-dir`) to control only
+the Codex subprocess cwd without changing the worker service `WorkingDirectory`.
+
 Optional env-based config path:
 
 ```bash

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -537,6 +537,30 @@ class CodexExecutorTests(unittest.TestCase):
         run_mock.assert_called_once()
         self.assertEqual(run_mock.call_args.kwargs["timeout"], task.execution_constraints.timeout_seconds)
 
+    @patch("app.executor.codex.subprocess.run")
+    def test_execute_passes_configured_working_directory(self, run_mock) -> None:
+        run_mock.return_value = subprocess.CompletedProcess(
+            args=["codex", "exec", "--json"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "messages": [],
+                    "actions": [],
+                    "config_updates": [],
+                    "requires_human_review": False,
+                    "errors": [],
+                }
+            ),
+            stderr="",
+        )
+        executor = CodexExecutor(command=("codex", "exec", "--json"), cwd="/opt/chatting")
+
+        executor.execute(_task())
+
+        run_mock.assert_called_once()
+        self.assertEqual(run_mock.call_args.kwargs["cwd"], "/opt/chatting")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add cwd support to CodexExecutor so Codex can run in an explicit working directory
- add worker config key codex_working_dir and CLI flag --codex-working-dir
- wire worker executor construction to pass configured working dir into Codex subprocess launch
- update worker runtime example and split-mode docs
- add executor test coverage for subprocess cwd

## Testing
- python3 -m unittest tests.test_executor