### PR TITLE
Implement milestone 4 egress v2 idempotency checkpoints

### DIFF
--- a/app/broker/messages.py
+++ b/app/broker/messages.py
@@ -9,7 +9,8 @@ from typing import Any
 from app.models import AttachmentRef, OutboundMessage, ReplyChannel, SCHEMA_VERSION, TaskEnvelope
 
 _TASK_MESSAGE_TYPE = "chatting.task.v1"
-_EGRESS_MESSAGE_TYPE = "chatting.egress.v1"
+_EGRESS_MESSAGE_TYPE_V1 = "chatting.egress.v1"
+_EGRESS_MESSAGE_TYPE_V2 = "chatting.egress.v2"
 
 
 def _require_non_empty_string(value: object, *, field_name: str) -> str:
@@ -45,6 +46,16 @@ def _parse_event_index(value: object) -> int:
     if not isinstance(value, int) or isinstance(value, bool) or value < 0:
         raise ValueError("event_index must be a non-negative integer")
     return value
+
+
+def _parse_sequence(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError("sequence must be a non-negative integer")
+    return value
+
+
+def _event_id_for_v1(*, task_id: str, event_index: int) -> str:
+    return f"v1:{task_id}:{event_index}"
 
 
 @dataclass(frozen=True)
@@ -180,33 +191,69 @@ class EgressQueueMessage:
     event_count: int
     message: OutboundMessage
     emitted_at: datetime
+    event_id: str | None = None
+    sequence: int | None = None
+    event_kind: str = "final"
     schema_version: str = SCHEMA_VERSION
-    message_type: str = _EGRESS_MESSAGE_TYPE
+    message_type: str = _EGRESS_MESSAGE_TYPE_V1
 
     def __post_init__(self) -> None:
         if self.schema_version != SCHEMA_VERSION:
             raise ValueError(f"unsupported_schema_version:{self.schema_version}")
-        if self.message_type != _EGRESS_MESSAGE_TYPE:
-            raise ValueError("message_type must be chatting.egress.v1")
+        if self.message_type not in {_EGRESS_MESSAGE_TYPE_V1, _EGRESS_MESSAGE_TYPE_V2}:
+            raise ValueError("message_type must be chatting.egress.v1 or chatting.egress.v2")
         _require_non_empty_string(self.task_id, field_name="task_id")
         _require_non_empty_string(self.envelope_id, field_name="envelope_id")
         _require_non_empty_string(self.trace_id, field_name="trace_id")
-        _require_positive_int(self.event_index + 1, field_name="event_index")
-        _require_positive_int(self.event_count, field_name="event_count")
-        if self.event_index >= self.event_count:
-            raise ValueError("event_index must be less than event_count")
         if self.emitted_at.tzinfo is None:
             raise ValueError("emitted_at must be timezone-aware")
+        if self.message_type == _EGRESS_MESSAGE_TYPE_V1:
+            _require_positive_int(self.event_index + 1, field_name="event_index")
+            _require_positive_int(self.event_count, field_name="event_count")
+            if self.event_index >= self.event_count:
+                raise ValueError("event_index must be less than event_count")
+            if self.event_id is None:
+                object.__setattr__(
+                    self,
+                    "event_id",
+                    _event_id_for_v1(task_id=self.task_id, event_index=self.event_index),
+                )
+            if self.sequence is None:
+                object.__setattr__(self, "sequence", self.event_index)
+            if self.event_kind not in {"final", "incremental"}:
+                raise ValueError("event_kind must be final or incremental")
+            return
+
+        _require_non_empty_string(self.event_id, field_name="event_id")
+        if self.sequence is None:
+            raise ValueError("sequence is required")
+        _parse_sequence(self.sequence)
+        if self.event_kind not in {"final", "incremental"}:
+            raise ValueError("event_kind must be final or incremental")
+        object.__setattr__(self, "event_index", self.sequence)
 
     def to_dict(self) -> dict[str, Any]:
+        if self.message_type == _EGRESS_MESSAGE_TYPE_V1:
+            return {
+                "schema_version": self.schema_version,
+                "message_type": self.message_type,
+                "task_id": self.task_id,
+                "envelope_id": self.envelope_id,
+                "trace_id": self.trace_id,
+                "event_index": self.event_index,
+                "event_count": self.event_count,
+                "emitted_at": _serialize_utc_datetime(self.emitted_at),
+                "message": self.message.to_dict(),
+            }
         return {
             "schema_version": self.schema_version,
             "message_type": self.message_type,
             "task_id": self.task_id,
             "envelope_id": self.envelope_id,
             "trace_id": self.trace_id,
-            "event_index": self.event_index,
-            "event_count": self.event_count,
+            "event_id": self.event_id,
+            "sequence": self.sequence,
+            "event_kind": self.event_kind,
             "emitted_at": _serialize_utc_datetime(self.emitted_at),
             "message": self.message.to_dict(),
         }
@@ -216,30 +263,46 @@ class EgressQueueMessage:
         if not isinstance(payload, dict):
             raise ValueError("egress_message_payload_must_be_object")
         message_type = _require_non_empty_string(payload.get("message_type"), field_name="message_type")
-        if message_type != _EGRESS_MESSAGE_TYPE:
+        if message_type not in {_EGRESS_MESSAGE_TYPE_V1, _EGRESS_MESSAGE_TYPE_V2}:
             raise ValueError("egress_message_type_invalid")
 
         message_payload = payload.get("message")
         if not isinstance(message_payload, dict):
             raise ValueError("message must be an object")
 
-        event_index = _parse_event_index(payload.get("event_index"))
+        event_index = 0
+        event_count = 1
+        event_id: str | None = None
+        sequence: int | None = None
+        event_kind = "final"
+        if message_type == _EGRESS_MESSAGE_TYPE_V1:
+            event_index = _parse_event_index(payload.get("event_index"))
+            event_count = _require_positive_int(payload.get("event_count"), field_name="event_count")
+        else:
+            event_id = _require_non_empty_string(payload.get("event_id"), field_name="event_id")
+            sequence = _parse_sequence(payload.get("sequence"))
+            event_kind = _require_non_empty_string(payload.get("event_kind"), field_name="event_kind")
+
         return cls(
             task_id=_require_non_empty_string(payload.get("task_id"), field_name="task_id"),
             envelope_id=_require_non_empty_string(payload.get("envelope_id"), field_name="envelope_id"),
             trace_id=_require_non_empty_string(payload.get("trace_id"), field_name="trace_id"),
             event_index=event_index,
-            event_count=_require_positive_int(payload.get("event_count"), field_name="event_count"),
+            event_count=event_count,
             message=OutboundMessage(
                 channel=_require_non_empty_string(message_payload.get("channel"), field_name="message.channel"),
                 target=_require_non_empty_string(message_payload.get("target"), field_name="message.target"),
                 body=_require_non_empty_string(message_payload.get("body"), field_name="message.body"),
             ),
             emitted_at=_parse_utc_datetime(payload.get("emitted_at"), field_name="emitted_at"),
+            event_id=event_id,
+            sequence=sequence,
+            event_kind=event_kind,
             schema_version=_require_non_empty_string(
                 payload.get("schema_version", SCHEMA_VERSION),
                 field_name="schema_version",
             ),
+            message_type=message_type,
         )
 
 

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -20,9 +20,16 @@ from app.broker import (
     TASK_QUEUE_NAME,
     TaskQueueMessage,
 )
-from app.main import _build_email_sender, _build_live_connectors, _build_telegram_sender
+from app.main import (
+    TELEGRAM_MEMORY_TURN_LIMIT,
+    _build_email_sender,
+    _build_live_connectors,
+    _build_telegram_sender,
+    _enrich_telegram_envelope_with_memory,
+    _should_store_telegram_memory,
+)
 from app.message_handler_runtime import TaskLedgerStore
-from app.models import ConfigUpdateDecision, PolicyDecision
+from app.models import ConfigUpdateDecision, PolicyDecision, TaskEnvelope
 from app.state import SQLiteStateStore
 
 MESSAGE_HANDLER_CONFIG_PATH_ENV_VAR = "CHATTING_MESSAGE_HANDLER_CONFIG_PATH"
@@ -230,6 +237,30 @@ def _build_policy_decision_for_message(egress_message: EgressQueueMessage) -> Po
     )
 
 
+def _prepare_ingress_envelope(
+    *,
+    store: SQLiteStateStore,
+    envelope: TaskEnvelope,
+    run_id: str,
+) -> TaskEnvelope:
+    if not _should_store_telegram_memory(envelope):
+        return envelope
+
+    enriched_envelope = _enrich_telegram_envelope_with_memory(
+        store=store,
+        envelope=envelope,
+        turn_limit=TELEGRAM_MEMORY_TURN_LIMIT,
+    )
+    store.append_conversation_turn(
+        channel="telegram",
+        target=envelope.reply_channel.target,
+        role="user",
+        content=envelope.content,
+        run_id=run_id,
+    )
+    return enriched_envelope
+
+
 def _handle_egress_message(
     *,
     picked_guid: str,
@@ -268,12 +299,20 @@ def _handle_egress_message(
         ack_callback(picked_guid)
         return
 
-    dispatched_indices = set(store.list_dispatched_event_indices(run_id=egress_message.task_id))
-    if egress_message.event_index in dispatched_indices:
-        LOGGER.info(
-            "egress_skip_already_dispatched task_id=%s event_index=%s guid=%s",
+    if egress_message.event_id is None:
+        LOGGER.error(
+            "egress_drop_missing_event_id task_id=%s guid=%s",
             egress_message.task_id,
-            egress_message.event_index,
+            picked_guid,
+        )
+        ack_callback(picked_guid)
+        return
+
+    if store.has_dispatched_event_id(task_id=egress_message.task_id, event_id=egress_message.event_id):
+        LOGGER.info(
+            "egress_skip_already_dispatched task_id=%s event_id=%s guid=%s",
+            egress_message.task_id,
+            egress_message.event_id,
             picked_guid,
         )
         ack_callback(picked_guid)
@@ -285,15 +324,34 @@ def _handle_egress_message(
         envelope=ledger_record.task_message.envelope,
     )
     if apply_result.dispatched_messages:
+        store.mark_dispatched_event_id(
+            task_id=egress_message.task_id,
+            event_id=egress_message.event_id,
+        )
         store.mark_dispatched_event(
             run_id=egress_message.task_id,
             event_index=egress_message.event_index,
         )
+        if _should_store_telegram_memory(ledger_record.task_message.envelope):
+            for message in apply_result.dispatched_messages:
+                if message.channel != "telegram":
+                    continue
+                if message.target != ledger_record.task_message.envelope.reply_channel.target:
+                    continue
+                store.append_conversation_turn(
+                    channel="telegram",
+                    target=message.target,
+                    role="assistant",
+                    content=message.body,
+                    run_id=egress_message.task_id,
+                )
     ack_callback(picked_guid)
     LOGGER.info(
-        "egress_dispatched task_id=%s event_index=%s channel=%s",
+        "egress_dispatched task_id=%s event_id=%s sequence=%s event_kind=%s channel=%s",
         egress_message.task_id,
-        egress_message.event_index,
+        egress_message.event_id,
+        egress_message.sequence,
+        egress_message.event_kind,
         egress_message.message.channel,
     )
 
@@ -357,8 +415,14 @@ def main() -> int:
             for envelope in connector.poll():
                 if store.seen(envelope.source, envelope.dedupe_key):
                     continue
+                task_id = f"task:{envelope.id}"
+                task_envelope = _prepare_ingress_envelope(
+                    store=store,
+                    envelope=envelope,
+                    run_id=task_id,
+                )
                 task_message = TaskQueueMessage.from_envelope(
-                    envelope,
+                    task_envelope,
                     trace_id=f"trace:{envelope.id}",
                 )
                 broker.publish_json(TASK_QUEUE_NAME, task_message.to_dict())

--- a/app/state/base.py
+++ b/app/state/base.py
@@ -114,5 +114,11 @@ class StateStore(Protocol):
     def list_dispatched_event_indices(self, *, run_id: str) -> list[int]:
         """Return dispatched event indexes for one run in ascending order."""
 
+    def mark_dispatched_event_id(self, *, task_id: str, event_id: str) -> None:
+        """Persist one dispatched outbound event ID checkpoint for idempotent retry."""
+
+    def has_dispatched_event_id(self, *, task_id: str, event_id: str) -> bool:
+        """Return whether one outbound event ID was already dispatched."""
+
 
 __all__ = ["StateStore"]

--- a/app/state/sqlite_store.py
+++ b/app/state/sqlite_store.py
@@ -144,6 +144,16 @@ class SQLiteStateStore:
                 )
                 """
             )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS dispatched_event_ids (
+                    task_id TEXT NOT NULL,
+                    event_id TEXT NOT NULL,
+                    dispatched_at TEXT NOT NULL,
+                    PRIMARY KEY (task_id, event_id)
+                )
+                """
+            )
             connection.commit()
 
     def _initialize_idempotency_table(self, connection: sqlite3.Connection) -> None:
@@ -803,6 +813,38 @@ class SQLiteStateStore:
                 (run_id,),
             ).fetchall()
         return [int(row["event_index"]) for row in rows]
+
+    def mark_dispatched_event_id(self, *, task_id: str, event_id: str) -> None:
+        if not task_id:
+            raise ValueError("task_id is required")
+        if not event_id:
+            raise ValueError("event_id is required")
+        dispatched_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO dispatched_event_ids (task_id, event_id, dispatched_at)
+                VALUES (?, ?, ?)
+                """,
+                (task_id, event_id, dispatched_at),
+            )
+            connection.commit()
+
+    def has_dispatched_event_id(self, *, task_id: str, event_id: str) -> bool:
+        if not task_id:
+            raise ValueError("task_id is required")
+        if not event_id:
+            raise ValueError("event_id is required")
+        with closing(self._connect()) as connection:
+            row = connection.execute(
+                """
+                SELECT 1
+                FROM dispatched_event_ids
+                WHERE task_id = ? AND event_id = ?
+                """,
+                (task_id, event_id),
+            ).fetchone()
+        return row is not None
 
 
 def _parse_rfc3339_utc(value: str) -> datetime:

--- a/tests/test_broker_messages.py
+++ b/tests/test_broker_messages.py
@@ -50,7 +50,33 @@ class EgressQueueMessageTests(unittest.TestCase):
         self.assertEqual(parsed.task_id, message.task_id)
         self.assertEqual(parsed.event_index, 0)
         self.assertEqual(parsed.event_count, 2)
+        self.assertEqual(parsed.event_id, "v1:task:email:1:0")
+        self.assertEqual(parsed.sequence, 0)
+        self.assertEqual(parsed.event_kind, "final")
         self.assertEqual(parsed.message.target, "alice@example.com")
+
+    def test_egress_v2_message_round_trip(self) -> None:
+        message = EgressQueueMessage(
+            task_id="task:email:2",
+            envelope_id="email:2",
+            trace_id="trace:email:2",
+            event_index=0,
+            event_count=1,
+            message=OutboundMessage(channel="email", target="alice@example.com", body="hello"),
+            emitted_at=datetime(2026, 3, 6, 11, 1, tzinfo=timezone.utc),
+            event_id="evt:task:email:2:1",
+            sequence=1,
+            event_kind="incremental",
+            message_type="chatting.egress.v2",
+        )
+
+        parsed = EgressQueueMessage.from_dict(message.to_dict())
+
+        self.assertEqual(parsed.task_id, message.task_id)
+        self.assertEqual(parsed.event_id, "evt:task:email:2:1")
+        self.assertEqual(parsed.sequence, 1)
+        self.assertEqual(parsed.event_kind, "incremental")
+        self.assertEqual(parsed.event_index, 1)
 
     def test_egress_message_rejects_event_index_out_of_range(self) -> None:
         with self.assertRaises(ValueError):
@@ -62,6 +88,21 @@ class EgressQueueMessageTests(unittest.TestCase):
                 event_count=2,
                 message=OutboundMessage(channel="email", target="alice@example.com", body="hello"),
                 emitted_at=datetime(2026, 3, 6, 11, 1, tzinfo=timezone.utc),
+            )
+
+    def test_egress_v2_message_requires_event_id(self) -> None:
+        with self.assertRaises(ValueError):
+            EgressQueueMessage(
+                task_id="task:email:2",
+                envelope_id="email:2",
+                trace_id="trace:email:2",
+                event_index=0,
+                event_count=1,
+                message=OutboundMessage(channel="email", target="alice@example.com", body="hello"),
+                emitted_at=datetime(2026, 3, 6, 11, 1, tzinfo=timezone.utc),
+                sequence=0,
+                event_kind="final",
+                message_type="chatting.egress.v2",
             )
 
 

--- a/tests/test_message_handler_runtime.py
+++ b/tests/test_message_handler_runtime.py
@@ -1,10 +1,10 @@
 import tempfile
 import unittest
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-from app.main_message_handler import _handle_egress_message
+from app.main_message_handler import _handle_egress_message, _prepare_ingress_envelope
 from app.broker import EgressQueueMessage, TaskQueueMessage
 from app.message_handler_runtime import TaskLedgerStore
 from app.models import ApplyResult, OutboundMessage, ReplyChannel, TaskEnvelope
@@ -43,6 +43,20 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             dedupe_key="email:1",
         )
         return TaskQueueMessage.from_envelope(envelope, trace_id="trace:email:1")
+
+    def _build_telegram_envelope(self, *, envelope_id: str, content: str, target: str = "12345") -> TaskEnvelope:
+        return TaskEnvelope(
+            id=envelope_id,
+            source="im",
+            received_at=datetime(2026, 3, 6, 12, 0, tzinfo=timezone.utc),
+            actor="77:alice",
+            content=content,
+            attachments=[],
+            context_refs=[],
+            policy_profile="default",
+            reply_channel=ReplyChannel(type="telegram", target=target),
+            dedupe_key=envelope_id,
+        )
 
     def test_handle_egress_message_drops_unknown_task(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -141,6 +155,143 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             self.assertEqual(acked, ["guid-3"])
             self.assertEqual(applier.apply_calls, 1)
             self.assertEqual(store.list_dispatched_event_indices(run_id=task_message.task_id), [0])
+            self.assertTrue(
+                store.has_dispatched_event_id(
+                    task_id=task_message.task_id,
+                    event_id="v1:task:email:1:0",
+                )
+            )
+
+    def test_handle_egress_message_skips_duplicate_event_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            store = SQLiteStateStore(db_path)
+            ledger = TaskLedgerStore(db_path)
+            task_message = self._build_task_message()
+            ledger.record_task(task_message)
+            applier = _RecordingApplier()
+            acked: list[str] = []
+
+            payload = EgressQueueMessage(
+                task_id=task_message.task_id,
+                envelope_id=task_message.envelope.id,
+                trace_id=task_message.trace_id,
+                event_index=0,
+                event_count=1,
+                message=OutboundMessage(channel="email", target="alice@example.com", body="reply"),
+                emitted_at=datetime(2026, 3, 6, 12, 1, tzinfo=timezone.utc),
+                event_id="evt:task:email:1:1",
+                sequence=1,
+                event_kind="incremental",
+                message_type="chatting.egress.v2",
+            ).to_dict()
+
+            _handle_egress_message(
+                picked_guid="guid-4",
+                picked_payload=payload,
+                ledger=ledger,
+                store=store,
+                allowed_egress_channels={"email"},
+                applier=applier,
+                ack_callback=acked.append,
+            )
+            _handle_egress_message(
+                picked_guid="guid-5",
+                picked_payload=payload,
+                ledger=ledger,
+                store=store,
+                allowed_egress_channels={"email"},
+                applier=applier,
+                ack_callback=acked.append,
+            )
+
+            self.assertEqual(acked, ["guid-4", "guid-5"])
+            self.assertEqual(applier.apply_calls, 1)
+
+    def test_prepare_ingress_envelope_enriches_telegram_with_last_20_turns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            store = SQLiteStateStore(db_path)
+            for index in range(25):
+                store.append_conversation_turn(
+                    channel="telegram",
+                    target="12345",
+                    role="user",
+                    content=f"turn-{index}",
+                    run_id=f"run:{index}",
+                )
+
+            envelope = self._build_telegram_envelope(envelope_id="telegram:100", content="latest-turn")
+
+            prepared = _prepare_ingress_envelope(
+                store=store,
+                envelope=envelope,
+                run_id="task:telegram:100",
+            )
+
+            self.assertIn("Recent conversation context (oldest first):", prepared.content)
+            self.assertIn("user: turn-5", prepared.content)
+            self.assertIn("user: turn-24", prepared.content)
+            self.assertNotIn("user: turn-4", prepared.content)
+            self.assertIn("Current user message:\nlatest-turn", prepared.content)
+            turns = store.list_recent_conversation_turns(channel="telegram", target="12345", limit=1)
+            self.assertEqual(turns, [("user", "latest-turn")])
+
+    def test_handle_egress_message_persists_matching_telegram_dispatch_as_assistant_turn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            store = SQLiteStateStore(db_path)
+            ledger = TaskLedgerStore(db_path)
+            task_message = TaskQueueMessage.from_envelope(
+                self._build_telegram_envelope(envelope_id="telegram:200", content="hello"),
+                trace_id="trace:telegram:200",
+            )
+            ledger.record_task(task_message)
+
+            @dataclass
+            class _TelegramApplier:
+                apply_calls: int = 0
+
+                def apply(self, decision, envelope=None):
+                    del decision, envelope
+                    self.apply_calls += 1
+                    return ApplyResult(
+                        applied_actions=[],
+                        skipped_actions=[],
+                        dispatched_messages=[
+                            OutboundMessage(channel="telegram", target="12345", body="reply-1"),
+                            OutboundMessage(channel="telegram", target="99999", body="reply-2"),
+                        ],
+                        reason_codes=[],
+                    )
+
+            applier = _TelegramApplier()
+            acked: list[str] = []
+
+            payload = EgressQueueMessage(
+                task_id=task_message.task_id,
+                envelope_id=task_message.envelope.id,
+                trace_id=task_message.trace_id,
+                event_index=0,
+                event_count=1,
+                message=OutboundMessage(channel="telegram", target="12345", body="reply"),
+                emitted_at=datetime(2026, 3, 6, 12, 1, tzinfo=timezone.utc),
+            ).to_dict()
+
+            _handle_egress_message(
+                picked_guid="guid-6",
+                picked_payload=payload,
+                ledger=ledger,
+                store=store,
+                allowed_egress_channels={"telegram"},
+                applier=applier,
+                ack_callback=acked.append,
+            )
+
+            self.assertEqual(acked, ["guid-6"])
+            self.assertEqual(applier.apply_calls, 1)
+            turns = store.list_recent_conversation_turns(channel="telegram", target="12345", limit=5)
+            self.assertEqual(turns, [("assistant", "reply-1")])
 
 
 if __name__ == "__main__":

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -231,6 +231,24 @@ class SQLiteStateStoreTests(unittest.TestCase):
                 [],
             )
 
+    def test_dispatched_event_id_checkpoint_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            store = SQLiteStateStore(db_path)
+
+            self.assertFalse(
+                store.has_dispatched_event_id(task_id="task:telegram:1", event_id="evt:1")
+            )
+            store.mark_dispatched_event_id(task_id="task:telegram:1", event_id="evt:1")
+            store.mark_dispatched_event_id(task_id="task:telegram:1", event_id="evt:1")
+
+            self.assertTrue(
+                store.has_dispatched_event_id(task_id="task:telegram:1", event_id="evt:1")
+            )
+            self.assertFalse(
+                store.has_dispatched_event_id(task_id="task:telegram:1", event_id="evt:2")
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `chatting.egress.v2` support in `EgressQueueMessage` while preserving v1 compatibility
- introduce stable event identity handling (`event_id`, `sequence`, `event_kind`) with v1 fallback IDs
- add SQLite checkpointing APIs and storage for `(task_id, event_id)` dedupe in message handler dispatch
- enrich Telegram ingress with recent memory context and persist user/assistant Telegram turns in split message-handler flow
- extend runtime and store tests for v2 parsing, event-id dedupe, and Telegram memory persistence paths

## Validation
- `python3 -m unittest tests.test_broker_messages tests.test_message_handler_runtime tests.test_sqlite_store`
- `python3 -m unittest discover -s tests`