### PR TITLE
Support owner/* GitHub assignment polling and assignee auto-detection

### DIFF
--- a/app/github_ingress_runtime.py
+++ b/app/github_ingress_runtime.py
@@ -60,6 +60,49 @@ query (
 }
 """
 
+VIEWER_LOGIN_QUERY = """
+query {
+  viewer {
+    login
+  }
+}
+"""
+
+OWNER_REPOSITORIES_QUERY = """
+query (
+  $owner: String!
+  $after: String
+) {
+  organization(login: $owner) {
+    repositories(first: 100, after: $after, orderBy: { field: UPDATED_AT, direction: DESC }) {
+      nodes {
+        nameWithOwner
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+  user(login: $owner) {
+    repositories(
+      first: 100
+      after: $after
+      ownerAffiliations: OWNER
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      nodes {
+        nameWithOwner
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+"""
+
 
 @dataclass(frozen=True)
 class AssignmentCheckpoint:
@@ -245,16 +288,101 @@ def default_graphql_runner(query: str, variables: Mapping[str, object]) -> dict[
         command.extend(["-f", f"{key}={value}"])
 
     completed = subprocess.run(command, capture_output=True, text=True, check=False)
-    if completed.returncode != 0:
-        stderr = completed.stderr.strip() or completed.stdout.strip()
+
+    parsed: dict[str, object] | None = None
+    stdout = completed.stdout.strip()
+    if stdout:
+        try:
+            candidate = json.loads(stdout)
+        except json.JSONDecodeError:
+            candidate = None
+        if isinstance(candidate, dict):
+            parsed = candidate
+
+    if completed.returncode != 0 and parsed is None:
+        stderr = completed.stderr.strip() or stdout
         raise RuntimeError(f"github_graphql_failed:{stderr}")
-    try:
-        parsed = json.loads(completed.stdout)
-    except json.JSONDecodeError as error:
-        raise RuntimeError("github_graphql_invalid_json") from error
-    if not isinstance(parsed, dict):
-        raise RuntimeError("github_graphql_invalid_shape")
+    if parsed is None:
+        raise RuntimeError("github_graphql_invalid_json")
     return parsed
+
+
+def fetch_authenticated_viewer_login(
+    *,
+    graphql_runner: Callable[[str, Mapping[str, object]], dict[str, object]],
+) -> str:
+    """Fetch authenticated `gh` viewer login."""
+    payload = graphql_runner(VIEWER_LOGIN_QUERY, {})
+    if payload.get("errors"):
+        raise RuntimeError(f"github_graphql_errors:{payload['errors']}")
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise RuntimeError("github_graphql_missing_data")
+    viewer = data.get("viewer")
+    if not isinstance(viewer, dict):
+        raise RuntimeError("github_graphql_invalid_viewer")
+    return _require_non_empty_string(viewer.get("login"), field_name="viewer.login")
+
+
+def list_owner_repositories(
+    *,
+    owner: str,
+    graphql_runner: Callable[[str, Mapping[str, object]], dict[str, object]],
+) -> list[str]:
+    """List repositories for owner login from GitHub GraphQL."""
+    if not isinstance(owner, str) or not owner.strip():
+        raise ValueError("owner must be a non-empty string")
+
+    repositories: list[str] = []
+    after: str | None = None
+    while True:
+        variables: dict[str, object] = {"owner": owner}
+        if after is not None:
+            variables["after"] = after
+        payload = graphql_runner(OWNER_REPOSITORIES_QUERY, variables)
+
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            raise RuntimeError("github_graphql_missing_data")
+
+        owner_node = data.get("organization")
+        if not isinstance(owner_node, dict):
+            owner_node = data.get("user")
+        if owner_node is None:
+            if payload.get("errors"):
+                raise RuntimeError(f"github_graphql_errors:{payload['errors']}")
+            return []
+        if not isinstance(owner_node, dict):
+            raise RuntimeError("github_graphql_invalid_owner")
+
+        repositories_conn = owner_node.get("repositories")
+        if not isinstance(repositories_conn, dict):
+            raise RuntimeError("github_graphql_invalid_owner_repositories")
+        nodes = repositories_conn.get("nodes")
+        if not isinstance(nodes, list):
+            raise RuntimeError("github_graphql_invalid_owner_repository_nodes")
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            repo_slug = node.get("nameWithOwner")
+            if isinstance(repo_slug, str) and repo_slug.strip():
+                repositories.append(repo_slug.strip())
+
+        page_info = repositories_conn.get("pageInfo")
+        if not isinstance(page_info, dict):
+            raise RuntimeError("github_graphql_invalid_owner_repositories_page_info")
+        has_next_page = page_info.get("hasNextPage")
+        if not isinstance(has_next_page, bool):
+            raise RuntimeError("github_graphql_invalid_owner_repositories_has_next_page")
+        if not has_next_page:
+            break
+        end_cursor = page_info.get("endCursor")
+        if not isinstance(end_cursor, str) or not end_cursor.strip():
+            raise RuntimeError("github_graphql_invalid_owner_repositories_end_cursor")
+        after = end_cursor
+
+    return repositories
 
 
 def fetch_assignment_events_for_repository(
@@ -379,6 +507,41 @@ def checkpoint_scope_key(*, repositories: list[str], assignee_login: str) -> str
     return f"{assignee_login.casefold()}:{','.join(normalized_repos)}"
 
 
+def expand_repository_patterns(
+    *,
+    repository_patterns: list[str],
+    graphql_runner: Callable[[str, Mapping[str, object]], dict[str, object]],
+) -> list[str]:
+    """Expand `owner/*` patterns to concrete `owner/repo` repository slugs."""
+    if not repository_patterns:
+        raise ValueError("repository_patterns are required")
+
+    expanded: list[str] = []
+    seen: set[str] = set()
+    for pattern in repository_patterns:
+        owner, repo = _parse_repository_pattern(pattern)
+        if repo == "*":
+            owner_repositories = list_owner_repositories(
+                owner=owner,
+                graphql_runner=graphql_runner,
+            )
+            for repository in owner_repositories:
+                normalized_owner, normalized_name = parse_repo_slug(repository)
+                normalized = f"{normalized_owner}/{normalized_name}"
+                if normalized in seen:
+                    continue
+                seen.add(normalized)
+                expanded.append(normalized)
+            continue
+
+        normalized = f"{owner}/{repo}"
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        expanded.append(normalized)
+    return expanded
+
+
 def select_events_after_checkpoint(
     events: list[GitHubIssueAssignmentEvent],
     *,
@@ -444,6 +607,18 @@ def parse_repo_slug(value: str) -> tuple[str, str]:
     return parts[0], parts[1]
 
 
+def _parse_repository_pattern(value: str) -> tuple[str, str]:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("repository selector must be non-empty")
+    parts = value.strip().split("/", maxsplit=1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError("repository selector must be owner/repo or owner/*")
+    owner, repo = parts
+    if repo != "*" and "*" in repo:
+        raise ValueError("repository selector must be owner/repo or owner/*")
+    return owner, repo
+
+
 def _parse_labels(raw_labels: object) -> list[str]:
     if not isinstance(raw_labels, dict):
         return []
@@ -494,12 +669,17 @@ def _serialize_utc_datetime(value: datetime) -> str:
 
 __all__ = [
     "ASSIGNED_EVENTS_QUERY",
+    "OWNER_REPOSITORIES_QUERY",
     "AssignmentCheckpoint",
     "GitHubAssignmentCheckpointStore",
     "GitHubIssueAssignmentEvent",
+    "VIEWER_LOGIN_QUERY",
     "checkpoint_scope_key",
     "default_graphql_runner",
+    "expand_repository_patterns",
     "fetch_assignment_events_for_repository",
+    "fetch_authenticated_viewer_login",
+    "list_owner_repositories",
     "parse_repo_slug",
     "publish_assignment_events",
     "select_events_after_checkpoint",

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -27,7 +27,9 @@ from app.github_ingress_runtime import (
     GitHubAssignmentCheckpointStore,
     checkpoint_scope_key,
     default_graphql_runner,
+    expand_repository_patterns,
     fetch_assignment_events_for_repository,
+    fetch_authenticated_viewer_login,
     parse_repo_slug,
     publish_assignment_events,
     select_events_after_checkpoint,
@@ -374,7 +376,14 @@ def _resolve_github_repositories(args: argparse.Namespace, config: dict[str, obj
     deduped: list[str] = []
     seen: set[str] = set()
     for repository in repositories:
-        owner, name = parse_repo_slug(repository)
+        if not repository.strip():
+            raise ValueError("github_repositories entries must not be empty")
+        parts = repository.strip().split("/", maxsplit=1)
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise ValueError("github_repositories entries must be owner/repo or owner/*")
+        owner, name = parts
+        if name != "*" and "*" in name:
+            raise ValueError("github_repositories entries must be owner/repo or owner/*")
         normalized = f"{owner}/{name}"
         if normalized in seen:
             continue
@@ -404,13 +413,26 @@ def _resolve_github_ingress_settings(
     if not repositories:
         return None
 
+    assignee_login = _resolve_str(
+        args.github_assignee_login,
+        config.get("github_assignee_login"),
+        default_value="",
+        setting_name="github_assignee_login",
+    ).strip()
+    if not assignee_login:
+        try:
+            assignee_login = fetch_authenticated_viewer_login(
+                graphql_runner=default_graphql_runner,
+            )
+        except Exception as error:  # noqa: BLE001
+            raise ValueError(
+                "github_assignee_login is required when github_repositories is configured "
+                "unless it can be derived from authenticated gh user"
+            ) from error
+
     return GitHubIngressSettings(
         repositories=repositories,
-        assignee_login=_resolve_required_str(
-            args.github_assignee_login,
-            config.get("github_assignee_login"),
-            setting_name="github_assignee_login",
-        ),
+        assignee_login=assignee_login,
         reply_channel_type=_resolve_required_str(
             args.github_reply_channel_type,
             config.get("github_reply_channel_type"),
@@ -457,7 +479,11 @@ def _poll_github_assignment_ingress(
     checkpoint = checkpoint_store.get_checkpoint(scope_key)
     events = []
     scanned_event_count = 0
-    for repository in settings.repositories:
+    repositories_to_scan = expand_repository_patterns(
+        repository_patterns=settings.repositories,
+        graphql_runner=default_graphql_runner,
+    )
+    for repository in repositories_to_scan:
         owner, name = parse_repo_slug(repository)
         try:
             repository_events = fetch_assignment_events_for_repository(

--- a/configs/message-handler-runtime.example.json
+++ b/configs/message-handler-runtime.example.json
@@ -26,7 +26,7 @@
   "telegram_allowed_channel_ids": ["-1001234567890"],
   "telegram_context_refs": ["repo:/home/edward/chatting"],
   "context_ref": ["repo:/home/edward/chatting"],
-  "github_repositories": ["brokensbone/chatting"],
+  "github_repositories": ["brokensbone/*"],
   "github_assignee_login": "BillyAcachofa",
   "github_reply_channel_type": "telegram",
   "github_reply_channel_target": "8605042448",

--- a/docs/connectors/github-issue-assignments.md
+++ b/docs/connectors/github-issue-assignments.md
@@ -14,8 +14,12 @@ timeline items, filters by assignee login, and publishes normalized `TaskQueueMe
 
 ## Required config
 
-- `github_repositories`: list of `owner/repo` strings to scan.
+- `github_repositories`: list of `owner/repo` and/or `owner/*` selectors to scan.
+
+## Optional config
+
 - `github_assignee_login`: only assignments to this GitHub login are emitted.
+  If omitted, message-handler uses the authenticated `gh` user login (`viewer.login`).
 - `github_reply_channel_type`: reply channel type for generated tasks (for example `telegram`).
 - `github_reply_channel_target`: reply channel target for generated tasks.
 

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -65,7 +65,9 @@ python3 -m app.main_worker
 ## 4) Configure GitHub assignment polling (in message-handler)
 
 ```bash
-# edit message-handler config: github_repositories, github_assignee_login, and reply channel settings
+# edit message-handler config: github_repositories (owner/repo or owner/*)
+# optional: github_assignee_login (defaults to authenticated gh user)
+# required for assignment-generated tasks: github_reply_channel_type and github_reply_channel_target
 python3 -m app.main_message_handler --config /tmp/message-handler.json
 ```
 

--- a/tests/test_github_ingress_runtime.py
+++ b/tests/test_github_ingress_runtime.py
@@ -3,13 +3,19 @@ import unittest
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
 
 from app.github_ingress_runtime import (
     AssignmentCheckpoint,
     GitHubAssignmentCheckpointStore,
     GitHubIssueAssignmentEvent,
     checkpoint_scope_key,
+    default_graphql_runner,
+    expand_repository_patterns,
     fetch_assignment_events_for_repository,
+    fetch_authenticated_viewer_login,
+    list_owner_repositories,
     parse_repo_slug,
     publish_assignment_events,
     select_events_after_checkpoint,
@@ -192,6 +198,105 @@ class GitHubIngressRuntimeTests(unittest.TestCase):
     def test_parse_repo_slug_requires_owner_repo(self) -> None:
         with self.assertRaisesRegex(ValueError, "owner/repo"):
             parse_repo_slug("brokensbone")
+
+    def test_fetch_authenticated_viewer_login_parses_login(self) -> None:
+        login = fetch_authenticated_viewer_login(
+            graphql_runner=lambda _query, _variables: {
+                "data": {
+                    "viewer": {
+                        "login": "BillyAcachofa",
+                    }
+                }
+            }
+        )
+        self.assertEqual(login, "BillyAcachofa")
+
+    def test_expand_repository_patterns_supports_owner_wildcard(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        def _graphql_runner(_query: str, variables: dict[str, object]) -> dict[str, object]:
+            calls.append(dict(variables))
+            if variables.get("after") is None:
+                return {
+                    "data": {
+                        "organization": {
+                            "repositories": {
+                                "nodes": [{"nameWithOwner": "brokensbone/chatting"}],
+                                "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                            }
+                        },
+                        "user": None,
+                    }
+                }
+            return {
+                "data": {
+                    "organization": {
+                        "repositories": {
+                            "nodes": [{"nameWithOwner": "brokensbone/bbmb"}],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    },
+                    "user": None,
+                }
+            }
+
+        repositories = expand_repository_patterns(
+            repository_patterns=["brokensbone/*", "brokensbone/chatting"],
+            graphql_runner=_graphql_runner,
+        )
+
+        self.assertEqual(repositories, ["brokensbone/chatting", "brokensbone/bbmb"])
+        self.assertEqual(
+            calls,
+            [
+                {"owner": "brokensbone"},
+                {"owner": "brokensbone", "after": "cursor-1"},
+            ],
+        )
+
+    def test_expand_repository_patterns_rejects_partial_wildcard(self) -> None:
+        with self.assertRaisesRegex(ValueError, "owner/repo or owner/\\*"):
+            expand_repository_patterns(
+                repository_patterns=["brokensbone/chat*"],
+                graphql_runner=lambda _query, _variables: {"data": {}},
+            )
+
+    def test_list_owner_repositories_handles_partial_not_found_error(self) -> None:
+        repositories = list_owner_repositories(
+            owner="brokensbone",
+            graphql_runner=lambda _query, _variables: {
+                "data": {
+                    "organization": None,
+                    "user": {
+                        "repositories": {
+                            "nodes": [{"nameWithOwner": "brokensbone/chatting"}],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    },
+                },
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "path": ["organization"],
+                        "message": "Could not resolve to an Organization",
+                    }
+                ],
+            },
+        )
+        self.assertEqual(repositories, ["brokensbone/chatting"])
+
+    def test_default_graphql_runner_parses_json_when_gh_exits_non_zero(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=CompletedProcess(
+                args=["gh", "api", "graphql"],
+                returncode=1,
+                stdout='{"data":{"viewer":{"login":"BillyAcachofa"}},"errors":[{"path":["organization"]}]}',
+                stderr="gh: Could not resolve to an Organization",
+            ),
+        ):
+            payload = default_graphql_runner("query { viewer { login } }", {})
+        self.assertIn("data", payload)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_github_ingress.py
+++ b/tests/test_main_github_ingress.py
@@ -67,6 +67,10 @@ class MainGitHubIngressTests(unittest.TestCase):
                     "app.main_message_handler.fetch_assignment_events_for_repository",
                     side_effect=[[event], [event]],
                 ),
+                patch(
+                    "app.main_message_handler.expand_repository_patterns",
+                    return_value=["brokensbone/chatting"],
+                ),
                 patch("app.main_message_handler._build_live_connectors", return_value=[]),
                 patch(
                     "sys.argv",
@@ -101,7 +105,78 @@ class MainGitHubIngressTests(unittest.TestCase):
                 broker.published[0][1]["task_id"],
                 "task:github-assignment:brokensbone/chatting:12:AE_1",
             )
+            self.assertEqual(
+                broker.published[0][1]["envelope"]["reply_channel"],
+                {
+                    "type": "telegram",
+                    "target": "8605042448",
+                },
+            )
 
+    def test_main_message_handler_resolves_assignee_from_authenticated_gh_user(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            broker = _FakeBroker()
+            event = GitHubIssueAssignmentEvent(
+                event_id="AE_1",
+                event_created_at=datetime(2026, 3, 7, 10, 47, 35, tzinfo=timezone.utc),
+                repository_id="R_1",
+                repository_name_with_owner="brokensbone/chatting",
+                issue_id="I_1",
+                issue_number=12,
+                issue_title="Plan milestone 5",
+                issue_body="Body",
+                issue_url="https://github.com/brokensbone/chatting/issues/12",
+                assignee_login="BillyAcachofa",
+                actor_login="edward",
+                labels=["enhancement"],
+            )
+
+            with (
+                patch(
+                    "app.main_message_handler.BBMBQueueAdapter",
+                    return_value=broker,
+                ),
+                patch(
+                    "app.main_message_handler.fetch_authenticated_viewer_login",
+                    return_value="BillyAcachofa",
+                ),
+                patch(
+                    "app.main_message_handler.expand_repository_patterns",
+                    return_value=["brokensbone/chatting"],
+                ),
+                patch(
+                    "app.main_message_handler.fetch_assignment_events_for_repository",
+                    return_value=[event],
+                ),
+                patch("app.main_message_handler._build_live_connectors", return_value=[]),
+                patch(
+                    "sys.argv",
+                    [
+                        "main_message_handler.py",
+                        "--db-path",
+                        db_path,
+                        "--bbmb-address",
+                        "127.0.0.1:9876",
+                        "--github-repository",
+                        "brokensbone/*",
+                        "--github-reply-channel-type",
+                        "telegram",
+                        "--github-reply-channel-target",
+                        "8605042448",
+                        "--max-loops",
+                        "1",
+                        "--poll-interval-seconds",
+                        "0.01",
+                    ],
+                ),
+            ):
+                exit_code = main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(broker.ensured, ["chatting.tasks.v1", "chatting.egress.v1"])
+            self.assertEqual(len(broker.published), 1)
+            self.assertEqual(broker.published[0][0], "chatting.tasks.v1")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add support for `github_repositories` entries in `owner/*` form, expanded via GitHub GraphQL with pagination
- make `github_assignee_login` optional by deriving it from the authenticated `gh` user (`viewer.login`) when omitted
- make GraphQL handling tolerant of partial GraphQL errors when usable JSON data is still returned (needed for wildcard expansion on user owners)
- update docs and runtime config examples for wildcard repository selectors and optional assignee login

## Why
- avoids listing every repository individually when polling assignments across one owner
- removes redundant assignee configuration when service identity already matches the intended assignee

## Validation
- `python3 -m unittest tests.test_github_ingress_runtime tests.test_main_github_ingress tests.test_message_handler_runtime`
- `python3 -m unittest discover -s tests`

## Notes
- opened from a fresh branch off `origin/main` to avoid stacking follow-up work onto already merged PR branches
