### PR TITLE
Refactor GitHub ingress into a connector

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -3,6 +3,7 @@
 from app.connectors.base import Connector
 from app.connectors.fake_cron_connector import CronTrigger, FakeCronConnector
 from app.connectors.fake_email_connector import EmailMessage, FakeEmailConnector
+from app.connectors.github_issue_assignment_connector import GitHubIssueAssignmentConnector
 from app.connectors.imap_email_connector import ImapEmailConnector
 from app.connectors.interval_schedule_connector import (
     IntervalScheduleConnector,
@@ -18,6 +19,7 @@ __all__ = [
     "EmailMessage",
     "FakeCronConnector",
     "FakeEmailConnector",
+    "GitHubIssueAssignmentConnector",
     "ImapEmailConnector",
     "IntervalScheduleConnector",
     "IntervalScheduleJob",

--- a/app/connectors/github_issue_assignment_connector.py
+++ b/app/connectors/github_issue_assignment_connector.py
@@ -1,0 +1,148 @@
+"""GitHub issue-assignment polling connector."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, Mapping
+
+from app.github_ingress_runtime import (
+    AssignmentCheckpoint,
+    GitHubAssignmentCheckpointStore,
+    GitHubIssueAssignmentEvent,
+    checkpoint_scope_key,
+    default_graphql_runner,
+    expand_repository_patterns,
+    fetch_assignment_events_for_repository,
+    parse_repo_slug,
+    select_events_after_checkpoint,
+)
+from app.models import TaskEnvelope
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GitHubIssueAssignmentConnector:
+    """Poll GitHub assigned events and normalize them into task envelopes."""
+
+    repository_patterns: list[str]
+    assignee_login: str
+    reply_channel_type: str
+    reply_channel_target: str
+    context_refs: list[str]
+    checkpoint_store: GitHubAssignmentCheckpointStore
+    policy_profile: str = "default"
+    max_issues: int = 25
+    max_timeline_events: int = 10
+    graphql_runner: Callable[[str, Mapping[str, object]], dict[str, object]] = default_graphql_runner
+
+    def __post_init__(self) -> None:
+        if not self.repository_patterns:
+            raise ValueError("repository_patterns are required")
+        if not self.assignee_login:
+            raise ValueError("assignee_login is required")
+        if not self.reply_channel_type:
+            raise ValueError("reply_channel_type is required")
+        if not self.reply_channel_target:
+            raise ValueError("reply_channel_target is required")
+        if self.max_issues <= 0:
+            raise ValueError("max_issues must be positive")
+        if self.max_timeline_events <= 0:
+            raise ValueError("max_timeline_events must be positive")
+        object.__setattr__(self, "_pending_checkpoint", None)
+        object.__setattr__(self, "_last_poll_scanned_events", 0)
+        object.__setattr__(self, "_last_poll_new_events", 0)
+        object.__setattr__(self, "_last_poll_checkpoint_id", "disabled")
+
+    @property
+    def last_poll_scanned_events(self) -> int:
+        return self._last_poll_scanned_events
+
+    @property
+    def last_poll_new_events(self) -> int:
+        return self._last_poll_new_events
+
+    @property
+    def last_poll_checkpoint_id(self) -> str:
+        return self._last_poll_checkpoint_id
+
+    def poll(self) -> list[TaskEnvelope]:
+        self._flush_pending_checkpoint()
+
+        scope_key = checkpoint_scope_key(
+            repositories=self.repository_patterns,
+            assignee_login=self.assignee_login,
+        )
+        checkpoint = self.checkpoint_store.get_checkpoint(scope_key)
+        repositories = expand_repository_patterns(
+            repository_patterns=self.repository_patterns,
+            graphql_runner=self.graphql_runner,
+        )
+
+        events: list[GitHubIssueAssignmentEvent] = []
+        scanned_event_count = 0
+        for repository in repositories:
+            owner, name = parse_repo_slug(repository)
+            try:
+                repository_events = fetch_assignment_events_for_repository(
+                    repo_owner=owner,
+                    repo_name=name,
+                    assignee_login=self.assignee_login,
+                    issue_limit=self.max_issues,
+                    timeline_limit=self.max_timeline_events,
+                    graphql_runner=self.graphql_runner,
+                )
+            except Exception:  # noqa: BLE001
+                LOGGER.exception(
+                    "github_assignment_poll_failed repository=%s assignee=%s",
+                    repository,
+                    self.assignee_login,
+                )
+                continue
+            scanned_event_count += len(repository_events)
+            events.extend(repository_events)
+
+        new_events = select_events_after_checkpoint(events, checkpoint=checkpoint)
+        object.__setattr__(self, "_last_poll_scanned_events", scanned_event_count)
+        object.__setattr__(self, "_last_poll_new_events", len(new_events))
+
+        checkpoint_id = checkpoint.event_id if checkpoint else "none"
+        if new_events:
+            latest = new_events[-1]
+            object.__setattr__(
+                self,
+                "_pending_checkpoint",
+                AssignmentCheckpoint(
+                    event_created_at=latest.event_created_at,
+                    event_id=latest.event_id,
+                ),
+            )
+            checkpoint_id = latest.event_id
+        object.__setattr__(self, "_last_poll_checkpoint_id", checkpoint_id)
+
+        return [
+            event.to_task_envelope(
+                reply_channel_type=self.reply_channel_type,
+                reply_channel_target=self.reply_channel_target,
+                context_refs=self.context_refs,
+                policy_profile=self.policy_profile,
+            )
+            for event in new_events
+        ]
+
+    def _flush_pending_checkpoint(self) -> None:
+        pending_checkpoint = self._pending_checkpoint
+        if pending_checkpoint is None:
+            return
+        self.checkpoint_store.set_checkpoint(
+            checkpoint_scope_key(
+                repositories=self.repository_patterns,
+                assignee_login=self.assignee_login,
+            ),
+            checkpoint=pending_checkpoint,
+        )
+        object.__setattr__(self, "_pending_checkpoint", None)
+
+
+__all__ = ["GitHubIssueAssignmentConnector"]

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -24,17 +24,11 @@ from app.broker import (
     TASK_QUEUE_NAME,
     TaskQueueMessage,
 )
+from app.connectors import GitHubIssueAssignmentConnector
 from app.github_ingress_runtime import (
-    AssignmentCheckpoint,
     GitHubAssignmentCheckpointStore,
-    checkpoint_scope_key,
     default_graphql_runner,
-    expand_repository_patterns,
-    fetch_assignment_events_for_repository,
     fetch_authenticated_viewer_login,
-    parse_repo_slug,
-    publish_assignment_events,
-    select_events_after_checkpoint,
 )
 from app.main import (
     TELEGRAM_MEMORY_TURN_LIMIT,
@@ -741,12 +735,16 @@ def _is_connector_configured(args: argparse.Namespace, config: dict[str, object]
             return False
         configured_value = config.get("telegram_enabled")
         return configured_value is not None and configured_value is not False
+    if connector == "github":
+        return bool(args.github_repository) or config.get("github_repositories") is not None
     raise ValueError(f"unsupported connector: {connector}")
 
 
 def _build_live_connectors_fail_open(
     args: argparse.Namespace,
     config: dict[str, object],
+    *,
+    db_path: str,
 ) -> tuple[list[object], list[DisabledIngressComponent]]:
     connectors: list[object] = []
     disabled_components: list[DisabledIngressComponent] = []
@@ -800,6 +798,28 @@ def _build_live_connectors_fail_open(
                 "context_refs",
             ),
         ),
+        "github": (
+            (
+                "github_repository",
+                "github_assignee_login",
+                "github_reply_channel_type",
+                "github_reply_channel_target",
+                "github_context_ref",
+                "github_policy_profile",
+                "github_max_issues",
+                "github_max_timeline_events",
+            ),
+            (
+                "github_repositories",
+                "github_assignee_login",
+                "github_reply_channel_type",
+                "github_reply_channel_target",
+                "github_context_refs",
+                "github_policy_profile",
+                "github_max_issues",
+                "github_max_timeline_events",
+            ),
+        ),
     }
 
     base_args = vars(args).copy()
@@ -820,10 +840,18 @@ def _build_live_connectors_fail_open(
             "telegram_allowed_channel_id": [],
             "telegram_context_ref": [],
             "context_ref": [],
+            "github_repository": [],
+            "github_assignee_login": None,
+            "github_reply_channel_type": None,
+            "github_reply_channel_target": None,
+            "github_context_ref": [],
+            "github_policy_profile": None,
+            "github_max_issues": None,
+            "github_max_timeline_events": None,
         }
     )
 
-    for connector_name in ("schedule", "imap", "telegram"):
+    for connector_name in ("schedule", "imap", "telegram", "github"):
         if not _is_connector_configured(args, config, connector=connector_name):
             continue
         selected_arg_keys, selected_config_keys = connector_args[connector_name]
@@ -837,6 +865,25 @@ def _build_live_connectors_fail_open(
         scoped_args = argparse.Namespace(**scoped_args_payload)
         scoped_config = {key: config[key] for key in selected_config_keys if key in config}
         try:
+            if connector_name == "github":
+                settings = _resolve_github_ingress_settings(scoped_args, scoped_config)
+                if settings is None:
+                    continue
+                connectors.append(
+                    GitHubIssueAssignmentConnector(
+                        repository_patterns=settings.repositories,
+                        assignee_login=settings.assignee_login,
+                        reply_channel_type=settings.reply_channel_type,
+                        reply_channel_target=settings.reply_channel_target,
+                        context_refs=settings.context_refs,
+                        policy_profile=settings.policy_profile,
+                        max_issues=settings.max_issues,
+                        max_timeline_events=settings.max_timeline_events,
+                        checkpoint_store=GitHubAssignmentCheckpointStore(db_path),
+                        graphql_runner=default_graphql_runner,
+                    )
+                )
+                continue
             connectors.extend(_build_live_connectors(scoped_args, scoped_config))
         except Exception as error:  # noqa: BLE001
             LOGGER.exception("ingress_connector_startup_failed connector=%s", connector_name)
@@ -847,70 +894,6 @@ def _build_live_connectors_fail_open(
                 )
             )
     return connectors, disabled_components
-
-
-def _poll_github_assignment_ingress(
-    *,
-    settings: GitHubIngressSettings,
-    checkpoint_store: GitHubAssignmentCheckpointStore,
-    store: SQLiteStateStore,
-    broker: BBMBQueueAdapter,
-) -> tuple[int, int, int, str]:
-    scope_key = checkpoint_scope_key(
-        repositories=settings.repositories,
-        assignee_login=settings.assignee_login,
-    )
-    checkpoint = checkpoint_store.get_checkpoint(scope_key)
-    events = []
-    scanned_event_count = 0
-    repositories_to_scan = expand_repository_patterns(
-        repository_patterns=settings.repositories,
-        graphql_runner=default_graphql_runner,
-    )
-    for repository in repositories_to_scan:
-        owner, name = parse_repo_slug(repository)
-        try:
-            repository_events = fetch_assignment_events_for_repository(
-                repo_owner=owner,
-                repo_name=name,
-                assignee_login=settings.assignee_login,
-                issue_limit=settings.max_issues,
-                timeline_limit=settings.max_timeline_events,
-                graphql_runner=default_graphql_runner,
-            )
-        except Exception:  # noqa: BLE001
-            LOGGER.exception(
-                "github_assignment_poll_failed repository=%s assignee=%s",
-                repository,
-                settings.assignee_login,
-            )
-            continue
-        scanned_event_count += len(repository_events)
-        events.extend(repository_events)
-
-    new_events = select_events_after_checkpoint(events, checkpoint=checkpoint)
-    published_count = publish_assignment_events(
-        events=new_events,
-        store=store,
-        broker=broker,
-        reply_channel_type=settings.reply_channel_type,
-        reply_channel_target=settings.reply_channel_target,
-        context_refs=settings.context_refs,
-        policy_profile=settings.policy_profile,
-    )
-    checkpoint_id = checkpoint.event_id if checkpoint else "none"
-    if new_events:
-        latest = new_events[-1]
-        checkpoint_store.set_checkpoint(
-            scope_key,
-            checkpoint=AssignmentCheckpoint(
-                event_created_at=latest.event_created_at,
-                event_id=latest.event_id,
-            ),
-        )
-        checkpoint_id = latest.event_id
-
-    return scanned_event_count, len(new_events), published_count, checkpoint_id
 
 
 def _build_policy_decision_for_message(egress_message: EgressQueueMessage) -> PolicyDecision:
@@ -1157,28 +1140,18 @@ def main() -> int:
         setting_name="metrics_port",
     )
     allowed_egress_channels = _resolve_allowed_egress_channels(args, config)
-    github_ingress_settings: GitHubIngressSettings | None = None
-    disabled_ingress_components: list[DisabledIngressComponent] = []
-    try:
-        github_ingress_settings = _resolve_github_ingress_settings(args, config)
-    except Exception as error:  # noqa: BLE001
-        LOGGER.exception("ingress_connector_startup_failed connector=github")
-        disabled_ingress_components.append(
-            DisabledIngressComponent(
-                component="github",
-                error=str(error),
-            )
-        )
 
     store = SQLiteStateStore(db_path)
     ledger = TaskLedgerStore(db_path)
     broker = BBMBQueueAdapter(address=bbmb_address)
     broker.ensure_queue(TASK_QUEUE_NAME)
     broker.ensure_queue(EGRESS_QUEUE_NAME)
-    github_checkpoint_store = GitHubAssignmentCheckpointStore(db_path) if github_ingress_settings else None
 
-    connectors, connector_failures = _build_live_connectors_fail_open(args, config)
-    disabled_ingress_components.extend(connector_failures)
+    connectors, disabled_ingress_components = _build_live_connectors_fail_open(
+        args,
+        config,
+        db_path=db_path,
+    )
     applier = IntegratedApplier(
         base_dir=".",
         email_sender=_build_email_sender(args, config),
@@ -1206,6 +1179,10 @@ def main() -> int:
                 )
 
             ingress_published = 0
+            github_scanned_events = 0
+            github_new_events = 0
+            github_published = 0
+            github_checkpoint = "disabled"
             for connector in connectors:
                 connector_name = type(connector).__name__
                 try:
@@ -1217,6 +1194,10 @@ def main() -> int:
                         loop_count,
                     )
                     continue
+                if isinstance(connector, GitHubIssueAssignmentConnector):
+                    github_scanned_events = connector.last_poll_scanned_events
+                    github_new_events = connector.last_poll_new_events
+                    github_checkpoint = connector.last_poll_checkpoint_id
                 for envelope in envelopes:
                     if store.seen(envelope.source, envelope.dedupe_key):
                         continue
@@ -1234,27 +1215,8 @@ def main() -> int:
                     ledger.record_task(task_message)
                     store.mark_seen(envelope.source, envelope.dedupe_key)
                     ingress_published += 1
-
-            github_scanned_events = 0
-            github_new_events = 0
-            github_published = 0
-            github_checkpoint = "disabled"
-            if github_ingress_settings is not None and github_checkpoint_store is not None:
-                try:
-                    (
-                        github_scanned_events,
-                        github_new_events,
-                        github_published,
-                        github_checkpoint,
-                    ) = _poll_github_assignment_ingress(
-                        settings=github_ingress_settings,
-                        checkpoint_store=github_checkpoint_store,
-                        store=store,
-                        broker=broker,
-                    )
-                except Exception:  # noqa: BLE001
-                    github_checkpoint = "error"
-                    LOGGER.exception("ingress_connector_poll_failed connector=github loop=%s", loop_count)
+                    if isinstance(connector, GitHubIssueAssignmentConnector):
+                        github_published += 1
 
             egress_picked = broker.pickup_json(
                 EGRESS_QUEUE_NAME,
@@ -1268,10 +1230,10 @@ def main() -> int:
                     ledger=ledger,
                     store=store,
                     allowed_egress_channels=allowed_egress_channels,
-                    applier=applier,
-                    ack_callback=lambda guid: broker.ack(EGRESS_QUEUE_NAME, guid),
-                    telemetry=telemetry,
-                )
+                applier=applier,
+                ack_callback=lambda guid: broker.ack(EGRESS_QUEUE_NAME, guid),
+                telemetry=telemetry,
+            )
 
             telemetry_snapshot = telemetry.snapshot()
             metrics.record_loop(

--- a/docs/connectors/github-issue-assignments.md
+++ b/docs/connectors/github-issue-assignments.md
@@ -2,15 +2,17 @@
 
 `chatting` can ingest GitHub issue assignments without exposing any webhook endpoint.
 
-GitHub polling now runs inside the existing message-handler loop:
+GitHub assignment polling is implemented as a first-class connector inside the existing
+message-handler loop:
 
 ```bash
 python3 -m app.main_message_handler --config /path/to/message-handler-runtime.json
 ```
 
-When `github_repositories` is configured, message-handler polls `gh api graphql` for `AssignedEvent`
-timeline items, filters by assignee login, and publishes normalized `TaskQueueMessage` payloads to
-`chatting.tasks.v1`.
+When `github_repositories` is configured, the GitHub connector polls `gh api graphql` for
+`AssignedEvent` timeline items, filters by assignee login, and emits normalized `TaskEnvelope`
+objects. Message-handler then handles publication to `chatting.tasks.v1` the same way it does for
+other connectors.
 
 ## Required config
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,9 +1,11 @@
 import unittest
 from datetime import datetime, timezone
 from email.message import EmailMessage as ParsedEmailMessage
+from tempfile import TemporaryDirectory
 
 from app.connectors.fake_cron_connector import CronTrigger, FakeCronConnector
 from app.connectors.fake_email_connector import EmailMessage, FakeEmailConnector
+from app.connectors.github_issue_assignment_connector import GitHubIssueAssignmentConnector
 from app.connectors.imap_email_connector import ImapEmailConnector
 from app.connectors.interval_schedule_connector import (
     IntervalScheduleConnector,
@@ -15,6 +17,7 @@ from app.connectors.telegram_connector import (
 )
 from app.connectors.slack_connector import SlackConnector
 from app.connectors.webhook_connector import WebhookConnector, WebhookEvent
+from app.github_ingress_runtime import GitHubAssignmentCheckpointStore
 
 
 class FakeCronConnectorTests(unittest.TestCase):
@@ -169,6 +172,180 @@ class IntervalScheduleConnectorTests(unittest.TestCase):
         self.assertEqual(len(envelopes), 1)
         self.assertEqual(envelopes[0].reply_channel.type, "telegram")
         self.assertEqual(envelopes[0].reply_channel.target, "8605042448")
+
+
+class GitHubIssueAssignmentConnectorTests(unittest.TestCase):
+    def test_poll_normalizes_new_assignment_events_to_envelopes(self) -> None:
+        responses = [
+            {
+                "data": {
+                    "repository": {
+                        "id": "R_1",
+                        "nameWithOwner": "brokensbone/chatting",
+                        "issues": {
+                            "nodes": [
+                                {
+                                    "id": "I_1",
+                                    "number": 12,
+                                    "title": "Plan milestone 5",
+                                    "body": "Body text",
+                                    "url": "https://github.com/brokensbone/chatting/issues/12",
+                                    "labels": {"nodes": [{"name": "enhancement"}]},
+                                    "timelineItems": {
+                                        "nodes": [
+                                            {
+                                                "id": "AE_1",
+                                                "createdAt": "2026-03-07T10:47:35Z",
+                                                "actor": {"login": "edward"},
+                                                "assignee": {
+                                                    "__typename": "User",
+                                                    "login": "BillyAcachofa",
+                                                },
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            },
+            {
+                "data": {
+                    "repository": {
+                        "id": "R_1",
+                        "nameWithOwner": "brokensbone/chatting",
+                        "issues": {
+                            "nodes": [
+                                {
+                                    "id": "I_1",
+                                    "number": 12,
+                                    "title": "Plan milestone 5",
+                                    "body": "Body text",
+                                    "url": "https://github.com/brokensbone/chatting/issues/12",
+                                    "labels": {"nodes": [{"name": "enhancement"}]},
+                                    "timelineItems": {
+                                        "nodes": [
+                                            {
+                                                "id": "AE_1",
+                                                "createdAt": "2026-03-07T10:47:35Z",
+                                                "actor": {"login": "edward"},
+                                                "assignee": {
+                                                    "__typename": "User",
+                                                    "login": "BillyAcachofa",
+                                                },
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            },
+        ]
+
+        def _graphql_runner(query: str, variables: dict[str, object]) -> dict[str, object]:
+            del query
+            self.assertEqual(variables["repoOwner"], "brokensbone")
+            self.assertEqual(variables["repoName"], "chatting")
+            return responses.pop(0)
+
+        with TemporaryDirectory() as tmpdir:
+            connector = GitHubIssueAssignmentConnector(
+                repository_patterns=["brokensbone/chatting"],
+                assignee_login="BillyAcachofa",
+                reply_channel_type="telegram",
+                reply_channel_target="8605042448",
+                context_refs=["repo:/home/edward/chatting"],
+                checkpoint_store=GitHubAssignmentCheckpointStore(f"{tmpdir}/state.db"),
+                graphql_runner=_graphql_runner,
+            )
+
+            first_poll = connector.poll()
+            second_poll = connector.poll()
+
+        self.assertEqual(len(first_poll), 1)
+        envelope = first_poll[0]
+        self.assertEqual(envelope.id, "github-assignment:brokensbone/chatting:12:AE_1")
+        self.assertEqual(envelope.reply_channel.type, "telegram")
+        self.assertEqual(envelope.reply_channel.target, "8605042448")
+        self.assertEqual(envelope.context_refs, ["repo:/home/edward/chatting"])
+        self.assertEqual(envelope.dedupe_key, "github:R_1:I_1:AE_1")
+        self.assertEqual(second_poll, [])
+        self.assertEqual(connector.last_poll_scanned_events, 1)
+        self.assertEqual(connector.last_poll_new_events, 0)
+        self.assertEqual(connector.last_poll_checkpoint_id, "AE_1")
+
+    def test_poll_continues_when_one_repository_fetch_fails(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def _graphql_runner(query: str, variables: dict[str, object]) -> dict[str, object]:
+            del query
+            calls.append((str(variables["repoOwner"]), str(variables["repoName"])))
+            if variables["repoName"] == "chatting":
+                raise RuntimeError("boom")
+            return {
+                "data": {
+                    "repository": {
+                        "id": "R_2",
+                        "nameWithOwner": "brokensbone/bbmb",
+                        "issues": {
+                            "nodes": [
+                                {
+                                    "id": "I_2",
+                                    "number": 34,
+                                    "title": "Build something",
+                                    "body": "",
+                                    "url": "https://github.com/brokensbone/bbmb/issues/34",
+                                    "labels": {"nodes": []},
+                                    "timelineItems": {
+                                        "nodes": [
+                                            {
+                                                "id": "AE_2",
+                                                "createdAt": "2026-03-07T11:00:00Z",
+                                                "actor": {"login": "edward"},
+                                                "assignee": {
+                                                    "__typename": "User",
+                                                    "login": "BillyAcachofa",
+                                                },
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+
+        with TemporaryDirectory() as tmpdir:
+            connector = GitHubIssueAssignmentConnector(
+                repository_patterns=["brokensbone/chatting", "brokensbone/bbmb"],
+                assignee_login="BillyAcachofa",
+                reply_channel_type="log",
+                reply_channel_target="ops",
+                context_refs=[],
+                checkpoint_store=GitHubAssignmentCheckpointStore(f"{tmpdir}/state.db"),
+                graphql_runner=_graphql_runner,
+            )
+
+            with self.assertLogs(
+                "app.connectors.github_issue_assignment_connector",
+                level="ERROR",
+            ) as logs:
+                envelopes = connector.poll()
+
+        self.assertEqual([call[1] for call in calls], ["chatting", "bbmb"])
+        self.assertEqual(len(envelopes), 1)
+        self.assertEqual(envelopes[0].id, "github-assignment:brokensbone/bbmb:34:AE_2")
+        self.assertTrue(
+            any(
+                "github_assignment_poll_failed repository=brokensbone/chatting assignee=BillyAcachofa"
+                in line
+                for line in logs.output
+            )
+        )
 
 
 class ImapEmailConnectorTests(unittest.TestCase):

--- a/tests/test_interface_contracts.py
+++ b/tests/test_interface_contracts.py
@@ -10,11 +10,13 @@ from app.connectors import (
     EmailMessage,
     FakeCronConnector,
     FakeEmailConnector,
+    GitHubIssueAssignmentConnector,
     SlackConnector,
     TelegramConnector,
     WebhookConnector,
     WebhookEvent,
 )
+from app.github_ingress_runtime import GitHubAssignmentCheckpointStore
 from app.connectors.telegram_connector import TelegramGetUpdatesResponse
 from app.executor import CodexExecutor, Executor, StubExecutor
 from app.policy import AllowlistPolicyEngine, PolicyEngine
@@ -54,6 +56,19 @@ class InterfaceContractTests(unittest.TestCase):
             SlackConnector(fetch_messages=lambda: []),
             Connector,
         )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.assertIsInstance(
+                GitHubIssueAssignmentConnector(
+                    repository_patterns=["brokensbone/chatting"],
+                    assignee_login="BillyAcachofa",
+                    reply_channel_type="log",
+                    reply_channel_target="ops",
+                    context_refs=[],
+                    checkpoint_store=GitHubAssignmentCheckpointStore(f"{tmpdir}/state.db"),
+                    graphql_runner=lambda _query, _variables: {"data": {"repository": None}},
+                ),
+                Connector,
+            )
         self.assertIsInstance(
             TelegramConnector(
                 bot_token="token",

--- a/tests/test_main_github_ingress.py
+++ b/tests/test_main_github_ingress.py
@@ -76,11 +76,11 @@ class MainGitHubIngressTests(unittest.TestCase):
                     return_value=_FakeMetricsServer(),
                 ),
                 patch(
-                    "app.main_message_handler.fetch_assignment_events_for_repository",
+                    "app.connectors.github_issue_assignment_connector.fetch_assignment_events_for_repository",
                     side_effect=[[event], [event]],
                 ),
                 patch(
-                    "app.main_message_handler.expand_repository_patterns",
+                    "app.connectors.github_issue_assignment_connector.expand_repository_patterns",
                     return_value=["brokensbone/chatting"],
                 ),
                 patch("app.main_message_handler._build_live_connectors", return_value=[]),
@@ -158,11 +158,11 @@ class MainGitHubIngressTests(unittest.TestCase):
                     return_value="BillyAcachofa",
                 ),
                 patch(
-                    "app.main_message_handler.expand_repository_patterns",
+                    "app.connectors.github_issue_assignment_connector.expand_repository_patterns",
                     return_value=["brokensbone/chatting"],
                 ),
                 patch(
-                    "app.main_message_handler.fetch_assignment_events_for_repository",
+                    "app.connectors.github_issue_assignment_connector.fetch_assignment_events_for_repository",
                     return_value=[event],
                 ),
                 patch("app.main_message_handler._build_live_connectors", return_value=[]),


### PR DESCRIPTION
## Summary
- add a first-class GitHub issue assignment connector with checkpoint-backed polling
- route GitHub ingress through the same connector publication path as the other message-handler inputs
- update tests and connector docs to reflect the new architecture

## Testing
- python3 -m unittest tests.test_message_handler_runtime tests.test_connectors tests.test_interface_contracts tests.test_main_github_ingress tests.test_github_ingress_runtime

Closes #30