### PR TITLE
Allow longer timeout for cron jobs

### DIFF
--- a/app/router/rule_based.py
+++ b/app/router/rule_based.py
@@ -13,7 +13,7 @@ class RuleBasedRouter:
 
     default_timeout_seconds: int = 1800
     default_max_tokens: int = 12000
-    cron_timeout_seconds: int = 120
+    cron_timeout_seconds: int = 1800
     cron_max_tokens: int = 8000
 
     def route(self, envelope: TaskEnvelope) -> RoutedTask:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -52,7 +52,7 @@ class RuleBasedRouterTests(unittest.TestCase):
 
         self.assertEqual(task.workflow, "scheduled_automation")
         self.assertEqual(task.priority, "low")
-        self.assertEqual(task.execution_constraints.timeout_seconds, 120)
+        self.assertEqual(task.execution_constraints.timeout_seconds, 1800)
         self.assertEqual(task.execution_constraints.max_tokens, 8000)
 
     def test_urgent_email_is_prioritized_high(self) -> None:


### PR DESCRIPTION
## Summary
- increase `cron_timeout_seconds` from 120 to 1800 in `RuleBasedRouter`
- keep cron timeout as a separate router variable from default timeout
- update router test expectation for cron envelopes

Closes #22

## Testing
- python3 -m unittest tests.test_router
- python3 -m unittest discover -s tests