### PR TITLE
Add internal heartbeat ping/pong

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -5,6 +5,7 @@ from app.connectors.fake_cron_connector import CronTrigger, FakeCronConnector
 from app.connectors.fake_email_connector import EmailMessage, FakeEmailConnector
 from app.connectors.github_issue_assignment_connector import GitHubIssueAssignmentConnector
 from app.connectors.imap_email_connector import ImapEmailConnector
+from app.connectors.internal_heartbeat_connector import InternalHeartbeatConnector
 from app.connectors.interval_schedule_connector import (
     IntervalScheduleConnector,
     IntervalScheduleJob,
@@ -21,6 +22,7 @@ __all__ = [
     "FakeEmailConnector",
     "GitHubIssueAssignmentConnector",
     "ImapEmailConnector",
+    "InternalHeartbeatConnector",
     "IntervalScheduleConnector",
     "IntervalScheduleJob",
     "SlackConnector",

--- a/app/connectors/internal_heartbeat_connector.py
+++ b/app/connectors/internal_heartbeat_connector.py
@@ -1,0 +1,33 @@
+"""Always-on internal heartbeat connector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable
+
+from app.internal_heartbeat import build_internal_heartbeat_envelope
+from app.models import TaskEnvelope
+
+
+@dataclass
+class InternalHeartbeatConnector:
+    """Emit one internal heartbeat envelope every poll cycle."""
+
+    now_provider: Callable[[], datetime] | None = None
+
+    def __post_init__(self) -> None:
+        self._now_provider = self.now_provider or (lambda: datetime.now(timezone.utc))
+        self._sequence = 0
+
+    def poll(self) -> list[TaskEnvelope]:
+        self._sequence += 1
+        return [
+            build_internal_heartbeat_envelope(
+                sequence=self._sequence,
+                now=self._now_provider(),
+            )
+        ]
+
+
+__all__ = ["InternalHeartbeatConnector"]

--- a/app/internal_heartbeat.py
+++ b/app/internal_heartbeat.py
@@ -1,0 +1,88 @@
+"""Shared helpers for internal message-handler/worker heartbeat traffic."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from app.broker import EgressQueueMessage, TaskQueueMessage
+from app.models import OutboundMessage, ReplyChannel, TaskEnvelope
+
+INTERNAL_SOURCE = "internal"
+INTERNAL_REPLY_CHANNEL_TYPE = "internal"
+INTERNAL_HEARTBEAT_TARGET = "heartbeat"
+INTERNAL_HEARTBEAT_POLICY_PROFILE = "default"
+
+
+def build_internal_heartbeat_envelope(*, sequence: int, now: datetime) -> TaskEnvelope:
+    current_time = _ensure_utc(now)
+    heartbeat_id = f"internal-heartbeat:{current_time.isoformat()}:{sequence}"
+    return TaskEnvelope(
+        id=heartbeat_id,
+        source=INTERNAL_SOURCE,
+        received_at=current_time,
+        actor="message-handler",
+        content="internal heartbeat ping",
+        attachments=[],
+        context_refs=[],
+        policy_profile=INTERNAL_HEARTBEAT_POLICY_PROFILE,
+        reply_channel=ReplyChannel(
+            type=INTERNAL_REPLY_CHANNEL_TYPE,
+            target=INTERNAL_HEARTBEAT_TARGET,
+        ),
+        dedupe_key=heartbeat_id,
+    )
+
+
+def is_internal_heartbeat_envelope(envelope: TaskEnvelope) -> bool:
+    return (
+        envelope.source == INTERNAL_SOURCE
+        and envelope.reply_channel.type == INTERNAL_REPLY_CHANNEL_TYPE
+        and envelope.reply_channel.target == INTERNAL_HEARTBEAT_TARGET
+    )
+
+
+def build_internal_heartbeat_egress(
+    *,
+    task_message: TaskQueueMessage,
+    worker_received_at: datetime,
+) -> EgressQueueMessage:
+    current_time = _ensure_utc(worker_received_at)
+    ping_emitted_at = task_message.emitted_at.astimezone(timezone.utc)
+    body = json.dumps(
+        {
+            "kind": "heartbeat_pong",
+            "ping_emitted_at": ping_emitted_at.isoformat().replace("+00:00", "Z"),
+            "worker_received_at": current_time.isoformat().replace("+00:00", "Z"),
+        },
+        sort_keys=True,
+    )
+    return EgressQueueMessage(
+        task_id=task_message.task_id,
+        envelope_id=task_message.envelope.id,
+        trace_id=task_message.trace_id,
+        event_index=0,
+        event_count=1,
+        message=OutboundMessage(channel="log", target=INTERNAL_HEARTBEAT_TARGET, body=body),
+        emitted_at=current_time,
+        event_id=f"evt:{task_message.task_id}:0:final:internal-heartbeat",
+        sequence=0,
+        event_kind="final",
+        message_type="chatting.egress.v2",
+    )
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError("datetime must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+__all__ = [
+    "INTERNAL_HEARTBEAT_TARGET",
+    "INTERNAL_REPLY_CHANNEL_TYPE",
+    "INTERNAL_SOURCE",
+    "build_internal_heartbeat_egress",
+    "build_internal_heartbeat_envelope",
+    "is_internal_heartbeat_envelope",
+]

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -24,12 +24,13 @@ from app.broker import (
     TASK_QUEUE_NAME,
     TaskQueueMessage,
 )
-from app.connectors import GitHubIssueAssignmentConnector
+from app.connectors import GitHubIssueAssignmentConnector, InternalHeartbeatConnector
 from app.github_ingress_runtime import (
     GitHubAssignmentCheckpointStore,
     default_graphql_runner,
     fetch_authenticated_viewer_login,
 )
+from app.internal_heartbeat import INTERNAL_HEARTBEAT_TARGET, is_internal_heartbeat_envelope
 from app.main import (
     TELEGRAM_MEMORY_TURN_LIMIT,
     _build_email_sender,
@@ -174,6 +175,39 @@ class EgressTelemetryRollup:
             "final_dispatched_total": self.final_dispatched_total,
             "dispatch_latency_ms_avg": avg_dispatch_latency_ms,
             "dispatch_latency_ms_max": self.dispatch_latency_ms_max,
+        }
+
+
+@dataclass
+class HeartbeatTelemetryRollup:
+    """In-memory telemetry for the message-handler/worker heartbeat."""
+
+    sent_total: int = 0
+    received_total: int = 0
+    latest_sent_at: datetime | None = None
+    latest_received_at: datetime | None = None
+    latest_latency_ms: int | None = None
+
+    def record_sent(self, *, sent_at: datetime) -> None:
+        self.sent_total += 1
+        self.latest_sent_at = sent_at.astimezone(timezone.utc)
+
+    def record_received(self, *, sent_at: datetime, received_at: datetime) -> None:
+        self.received_total += 1
+        self.latest_sent_at = sent_at.astimezone(timezone.utc)
+        self.latest_received_at = received_at.astimezone(timezone.utc)
+        self.latest_latency_ms = max(
+            int((self.latest_received_at - self.latest_sent_at).total_seconds() * 1000),
+            0,
+        )
+
+    def snapshot(self) -> dict[str, object]:
+        return {
+            "sent_total": self.sent_total,
+            "received_total": self.received_total,
+            "latest_sent_at": _serialize_optional_datetime(self.latest_sent_at),
+            "latest_received_at": _serialize_optional_datetime(self.latest_received_at),
+            "latest_latency_ms": self.latest_latency_ms,
         }
 
 
@@ -435,6 +469,12 @@ def _configure_logging() -> None:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%S%z",
     )
+
+
+def _serialize_optional_datetime(value: datetime | None) -> str:
+    if value is None:
+        return "none"
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _positive_int(value: str) -> int:
@@ -746,7 +786,7 @@ def _build_live_connectors_fail_open(
     *,
     db_path: str,
 ) -> tuple[list[object], list[DisabledIngressComponent]]:
-    connectors: list[object] = []
+    connectors: list[object] = [InternalHeartbeatConnector()]
     disabled_components: list[DisabledIngressComponent] = []
 
     connector_args: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
@@ -939,6 +979,7 @@ def _handle_egress_message(
     allowed_egress_channels: set[str],
     applier: IntegratedApplier,
     ack_callback: Callable[[str], None],
+    heartbeat_telemetry: HeartbeatTelemetryRollup | None = None,
     telemetry: EgressTelemetryRollup | None = None,
 ) -> None:
     def _ack_and_mark_outbox(event_id: str | None = None) -> None:
@@ -968,7 +1009,13 @@ def _handle_egress_message(
         _ack_and_mark_outbox(egress_message.event_id)
         return
 
-    if egress_message.message.channel not in allowed_egress_channels:
+    internal_heartbeat = is_internal_heartbeat_envelope(ledger_record.task_message.envelope)
+    heartbeat_log_message = (
+        internal_heartbeat
+        and egress_message.message.channel == "log"
+        and egress_message.message.target == INTERNAL_HEARTBEAT_TARGET
+    )
+    if egress_message.message.channel not in allowed_egress_channels and not heartbeat_log_message:
         if telemetry is not None:
             telemetry.record_dropped(reason="disallowed_channel")
         LOGGER.error(
@@ -1010,6 +1057,7 @@ def _handle_egress_message(
         ledger=ledger,
         store=store,
         applier=applier,
+        heartbeat_telemetry=heartbeat_telemetry,
         telemetry=telemetry,
     )
 
@@ -1020,6 +1068,7 @@ def _flush_task_egress_in_sequence(
     ledger: TaskLedgerStore,
     store: SQLiteStateStore,
     applier: IntegratedApplier,
+    heartbeat_telemetry: HeartbeatTelemetryRollup | None = None,
     telemetry: EgressTelemetryRollup | None = None,
 ) -> None:
     ledger_record = ledger.get_task(task_id)
@@ -1068,6 +1117,19 @@ def _flush_task_egress_in_sequence(
             telemetry.record_dispatched(
                 event_kind=egress_message.event_kind,
                 latency_ms=max(dispatch_latency_ms, 0),
+            )
+        if is_internal_heartbeat_envelope(ledger_record.task_message.envelope) and heartbeat_telemetry is not None:
+            heartbeat_received_at = datetime.now(timezone.utc)
+            heartbeat_telemetry.record_received(
+                sent_at=ledger_record.task_message.emitted_at,
+                received_at=heartbeat_received_at,
+            )
+            LOGGER.info(
+                "heartbeat_roundtrip task_id=%s sent_at=%s received_at=%s latency_ms=%s",
+                egress_message.task_id,
+                _serialize_optional_datetime(ledger_record.task_message.emitted_at),
+                _serialize_optional_datetime(heartbeat_received_at),
+                heartbeat_telemetry.latest_latency_ms,
             )
         if _should_store_telegram_memory(ledger_record.task_message.envelope):
             for message in apply_result.dispatched_messages:
@@ -1163,6 +1225,7 @@ def main() -> int:
         host=metrics_host,
         port=metrics_port,
     )
+    heartbeat_telemetry = HeartbeatTelemetryRollup()
 
     try:
         loop_count = 0
@@ -1214,6 +1277,8 @@ def main() -> int:
                     broker.publish_json(TASK_QUEUE_NAME, task_message.to_dict())
                     ledger.record_task(task_message)
                     store.mark_seen(envelope.source, envelope.dedupe_key)
+                    if is_internal_heartbeat_envelope(task_message.envelope):
+                        heartbeat_telemetry.record_sent(sent_at=task_message.emitted_at)
                     ingress_published += 1
                     if isinstance(connector, GitHubIssueAssignmentConnector):
                         github_published += 1
@@ -1230,12 +1295,14 @@ def main() -> int:
                     ledger=ledger,
                     store=store,
                     allowed_egress_channels=allowed_egress_channels,
-                applier=applier,
-                ack_callback=lambda guid: broker.ack(EGRESS_QUEUE_NAME, guid),
-                telemetry=telemetry,
-            )
+                    applier=applier,
+                    ack_callback=lambda guid: broker.ack(EGRESS_QUEUE_NAME, guid),
+                    heartbeat_telemetry=heartbeat_telemetry,
+                    telemetry=telemetry,
+                )
 
             telemetry_snapshot = telemetry.snapshot()
+            heartbeat_snapshot = heartbeat_telemetry.snapshot()
             metrics.record_loop(
                 ingress_published=ingress_published,
                 github_scanned_events=github_scanned_events,
@@ -1247,6 +1314,8 @@ def main() -> int:
                 (
                     "message_handler_loop_completed loop=%s ingress_published=%s "
                     "github_scanned_events=%s github_new_events=%s github_published=%s github_checkpoint=%s "
+                    "heartbeat_sent_total=%s heartbeat_received_total=%s "
+                    "heartbeat_latest_sent_at=%s heartbeat_latest_received_at=%s heartbeat_latest_latency_ms=%s "
                     "egress_received_total=%s egress_dispatched_total=%s egress_deduped_total=%s "
                     "egress_dedupe_hit_rate_pct=%s egress_dropped_total=%s "
                     "egress_dispatch_latency_ms_avg=%s egress_dispatch_latency_ms_max=%s "
@@ -1258,6 +1327,11 @@ def main() -> int:
                 github_new_events,
                 github_published,
                 github_checkpoint,
+                heartbeat_snapshot["sent_total"],
+                heartbeat_snapshot["received_total"],
+                heartbeat_snapshot["latest_sent_at"],
+                heartbeat_snapshot["latest_received_at"],
+                heartbeat_snapshot["latest_latency_ms"],
                 telemetry_snapshot["received_total"],
                 telemetry_snapshot["dispatched_total"],
                 telemetry_snapshot["deduped_total"],

--- a/app/models.py
+++ b/app/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-SOURCE_TYPES = ("cron", "email", "im", "webhook")
+SOURCE_TYPES = ("cron", "email", "im", "webhook", "internal")
 PRIORITY_TYPES = ("low", "normal", "high")
 SCHEMA_VERSION = "1.0"
 
@@ -101,7 +101,7 @@ class TaskEnvelope:
     """Normalized input event schema."""
 
     id: str
-    source: Literal["cron", "email", "im", "webhook"]
+    source: Literal["cron", "email", "im", "webhook", "internal"]
     received_at: datetime
     actor: str | None
     content: str
@@ -157,7 +157,7 @@ class RoutedTask:
     priority: Literal["low", "normal", "high"]
     execution_constraints: ExecutionConstraints
     policy_profile: str
-    source: Literal["cron", "email", "im", "webhook"] | None = None
+    source: Literal["cron", "email", "im", "webhook", "internal"] | None = None
     actor: str | None = None
     content: str | None = None
     reply_channel: ReplyChannel | None = None
@@ -435,7 +435,7 @@ class RunRecord:
 
     run_id: str
     envelope_id: str
-    source: Literal["cron", "email", "im", "webhook"]
+    source: Literal["cron", "email", "im", "webhook", "internal"]
     workflow: str
     policy_profile: str
     latency_ms: int
@@ -477,7 +477,7 @@ class AuditEvent:
 
     run_id: str
     envelope_id: str
-    source: Literal["cron", "email", "im", "webhook"]
+    source: Literal["cron", "email", "im", "webhook", "internal"]
     workflow: str
     policy_profile: str
     result_status: str

--- a/app/worker_runtime.py
+++ b/app/worker_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -9,6 +10,10 @@ from typing import Any, Callable
 
 from app.broker import EgressQueueMessage, TaskQueueMessage
 from app.executor import Executor
+from app.internal_heartbeat import (
+    build_internal_heartbeat_egress,
+    is_internal_heartbeat_envelope,
+)
 from app.models import AuditEvent, OutboundMessage, PolicyDecision, RunRecord
 from app.policy import AllowlistPolicyEngine
 from app.router import RuleBasedRouter
@@ -38,6 +43,12 @@ def process_task_message(
         raise ValueError("max_attempts must be positive")
 
     envelope = task_message.envelope
+    if is_internal_heartbeat_envelope(envelope):
+        return _process_internal_heartbeat(
+            store=store,
+            task_message=task_message,
+        )
+
     run_id = f"run:{task_message.task_id}:{time.time_ns()}"
     task = router.route(envelope)
     started = time.perf_counter()
@@ -218,6 +229,73 @@ def process_task_message(
         run_record=run_record,
         egress_messages=egress_messages,
         dead_lettered=dead_lettered,
+    )
+
+
+def _process_internal_heartbeat(
+    *,
+    store: StateStore,
+    task_message: TaskQueueMessage,
+) -> WorkerProcessResult:
+    worker_received_at = datetime.now(timezone.utc)
+    egress_message = build_internal_heartbeat_egress(
+        task_message=task_message,
+        worker_received_at=worker_received_at,
+    )
+    ping_emitted_at = task_message.emitted_at.astimezone(timezone.utc)
+    run_record = RunRecord(
+        run_id=f"run:{task_message.task_id}:{time.time_ns()}",
+        envelope_id=task_message.envelope.id,
+        source=task_message.envelope.source,
+        workflow="internal_heartbeat",
+        policy_profile=task_message.envelope.policy_profile,
+        latency_ms=max(int((worker_received_at - ping_emitted_at).total_seconds() * 1000), 0),
+        result_status="success",
+        created_at=worker_received_at,
+    )
+    store.append_run(run_record)
+    store.append_audit_event(
+        AuditEvent(
+            run_id=run_record.run_id,
+            envelope_id=run_record.envelope_id,
+            source=run_record.source,
+            workflow=run_record.workflow,
+            policy_profile=run_record.policy_profile,
+            result_status=run_record.result_status,
+            detail={
+                "trace_id": task_message.trace_id,
+                "task_id": task_message.task_id,
+                "reason_codes": ["internal_heartbeat"],
+                "attempt_count": 1,
+                "max_attempts": 1,
+                "last_error": None,
+                "last_error_stage": None,
+                "execution_result": {
+                    "messages": [egress_message.message.to_dict()],
+                    "actions": [],
+                    "config_updates": [],
+                    "requires_human_review": False,
+                    "errors": [],
+                },
+                "policy_decision": {
+                    "approved_actions": [],
+                    "blocked_actions": [],
+                    "approved_messages": [egress_message.message.to_dict()],
+                    "config_updates": {"approved": [], "pending_review": [], "rejected": []},
+                    "reason_codes": ["internal_heartbeat"],
+                },
+                "incremental_reply_send_requested_count": 0,
+                "incremental_reply_send_published_count": 0,
+                "egress_message_count": 1,
+                "heartbeat": json.loads(egress_message.message.body),
+            },
+            created_at=run_record.created_at,
+        )
+    )
+    return WorkerProcessResult(
+        run_record=run_record,
+        egress_messages=[egress_message],
+        dead_lettered=False,
     )
 
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -7,6 +7,7 @@ from app.connectors.fake_cron_connector import CronTrigger, FakeCronConnector
 from app.connectors.fake_email_connector import EmailMessage, FakeEmailConnector
 from app.connectors.github_issue_assignment_connector import GitHubIssueAssignmentConnector
 from app.connectors.imap_email_connector import ImapEmailConnector
+from app.connectors.internal_heartbeat_connector import InternalHeartbeatConnector
 from app.connectors.interval_schedule_connector import (
     IntervalScheduleConnector,
     IntervalScheduleJob,
@@ -346,6 +347,25 @@ class GitHubIssueAssignmentConnectorTests(unittest.TestCase):
                 for line in logs.output
             )
         )
+
+
+class InternalHeartbeatConnectorTests(unittest.TestCase):
+    def test_poll_emits_internal_heartbeat_with_unique_ids(self) -> None:
+        current = datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc)
+        connector = InternalHeartbeatConnector(now_provider=lambda: current)
+
+        first = connector.poll()
+        second = connector.poll()
+
+        self.assertEqual(len(first), 1)
+        self.assertEqual(len(second), 1)
+        self.assertEqual(first[0].source, "internal")
+        self.assertEqual(first[0].actor, "message-handler")
+        self.assertEqual(first[0].reply_channel.type, "internal")
+        self.assertEqual(first[0].reply_channel.target, "heartbeat")
+        self.assertNotEqual(first[0].id, second[0].id)
+        self.assertEqual(first[0].dedupe_key, first[0].id)
+        self.assertEqual(second[0].dedupe_key, second[0].id)
 
 
 class ImapEmailConnectorTests(unittest.TestCase):

--- a/tests/test_interface_contracts.py
+++ b/tests/test_interface_contracts.py
@@ -11,6 +11,7 @@ from app.connectors import (
     FakeCronConnector,
     FakeEmailConnector,
     GitHubIssueAssignmentConnector,
+    InternalHeartbeatConnector,
     SlackConnector,
     TelegramConnector,
     WebhookConnector,
@@ -52,6 +53,12 @@ class InterfaceContractTests(unittest.TestCase):
 
         self.assertIsInstance(cron, Connector)
         self.assertIsInstance(email, Connector)
+        self.assertIsInstance(
+            InternalHeartbeatConnector(
+                now_provider=lambda: datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc),
+            ),
+            Connector,
+        )
         self.assertIsInstance(
             SlackConnector(fetch_messages=lambda: []),
             Connector,

--- a/tests/test_main_github_ingress.py
+++ b/tests/test_main_github_ingress.py
@@ -39,6 +39,13 @@ class _FakeMetricsServer:
 
 
 class MainGitHubIngressTests(unittest.TestCase):
+    def _non_heartbeat_published(self, broker: _FakeBroker) -> list[tuple[str, dict[str, object]]]:
+        return [
+            item
+            for item in broker.published
+            if item[1].get("envelope", {}).get("source") != "internal"
+        ]
+
     def test_load_config_rejects_unknown_keys(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "message-handler.json"
@@ -109,16 +116,17 @@ class MainGitHubIngressTests(unittest.TestCase):
             ):
                 exit_code = main()
 
+            published = self._non_heartbeat_published(broker)
             self.assertEqual(exit_code, 0)
             self.assertEqual(broker.ensured, ["chatting.tasks.v1", "chatting.egress.v1"])
-            self.assertEqual(len(broker.published), 1)
-            self.assertEqual(broker.published[0][0], "chatting.tasks.v1")
+            self.assertEqual(len(published), 1)
+            self.assertEqual(published[0][0], "chatting.tasks.v1")
             self.assertEqual(
-                broker.published[0][1]["task_id"],
+                published[0][1]["task_id"],
                 "task:github-assignment:brokensbone/chatting:12:AE_1",
             )
             self.assertEqual(
-                broker.published[0][1]["envelope"]["reply_channel"],
+                published[0][1]["envelope"]["reply_channel"],
                 {
                     "type": "telegram",
                     "target": "8605042448",
@@ -189,10 +197,11 @@ class MainGitHubIngressTests(unittest.TestCase):
             ):
                 exit_code = main()
 
+            published = self._non_heartbeat_published(broker)
             self.assertEqual(exit_code, 0)
             self.assertEqual(broker.ensured, ["chatting.tasks.v1", "chatting.egress.v1"])
-            self.assertEqual(len(broker.published), 1)
-            self.assertEqual(broker.published[0][0], "chatting.tasks.v1")
+            self.assertEqual(len(published), 1)
+            self.assertEqual(published[0][0], "chatting.tasks.v1")
 
     def test_main_message_handler_disables_misconfigured_github_ingress_and_keeps_running(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -230,9 +239,11 @@ class MainGitHubIngressTests(unittest.TestCase):
             ):
                 exit_code = main()
 
+            published = self._non_heartbeat_published(broker)
             self.assertEqual(exit_code, 0)
             self.assertEqual(broker.ensured, ["chatting.tasks.v1", "chatting.egress.v1"])
-            self.assertEqual(len(broker.published), 0)
+            self.assertEqual(len(published), 0)
+            self.assertEqual(len(broker.published), 2)
             disabled_log_calls = [
                 call
                 for call in error_logger.call_args_list
@@ -294,10 +305,11 @@ class MainGitHubIngressTests(unittest.TestCase):
             ):
                 exit_code = main()
 
+            published = self._non_heartbeat_published(broker)
             self.assertEqual(exit_code, 0)
             self.assertEqual(broker.ensured, ["chatting.tasks.v1", "chatting.egress.v1"])
-            self.assertEqual(len(broker.published), 1)
-            self.assertEqual(broker.published[0][0], "chatting.tasks.v1")
+            self.assertEqual(len(published), 1)
+            self.assertEqual(published[0][0], "chatting.tasks.v1")
             disabled_log_calls = [
                 call
                 for call in error_logger.call_args_list
@@ -305,6 +317,46 @@ class MainGitHubIngressTests(unittest.TestCase):
             ]
             self.assertEqual(len(disabled_log_calls), 1)
             self.assertEqual(disabled_log_calls[0].args[1], "imap")
+
+    def test_main_message_handler_publishes_internal_heartbeat_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            broker = _FakeBroker()
+
+            with (
+                patch(
+                    "app.main_message_handler.BBMBQueueAdapter",
+                    return_value=broker,
+                ),
+                patch(
+                    "app.main_message_handler._start_metrics_server",
+                    return_value=_FakeMetricsServer(),
+                ),
+                patch(
+                    "sys.argv",
+                    [
+                        "main_message_handler.py",
+                        "--db-path",
+                        db_path,
+                        "--bbmb-address",
+                        "127.0.0.1:9876",
+                        "--max-loops",
+                        "1",
+                        "--poll-interval-seconds",
+                        "0.01",
+                    ],
+                ),
+            ):
+                exit_code = main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(len(broker.published), 1)
+            self.assertEqual(broker.published[0][0], "chatting.tasks.v1")
+            self.assertEqual(broker.published[0][1]["envelope"]["source"], "internal")
+            self.assertEqual(
+                broker.published[0][1]["envelope"]["reply_channel"],
+                {"type": "internal", "target": "heartbeat"},
+            )
 
     def test_main_message_handler_starts_and_stops_metrics_server_with_defaults(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_message_handler_runtime.py
+++ b/tests/test_message_handler_runtime.py
@@ -3,15 +3,18 @@ import unittest
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+import json
 
 from app.main_message_handler import (
     EgressTelemetryRollup,
+    HeartbeatTelemetryRollup,
     MessageHandlerMetrics,
     _handle_egress_message,
     _prepare_ingress_envelope,
     _render_prometheus_metrics,
 )
 from app.broker import EgressQueueMessage, TaskQueueMessage
+from app.internal_heartbeat import build_internal_heartbeat_egress, build_internal_heartbeat_envelope
 from app.message_handler_runtime import TaskLedgerStore
 from app.models import ApplyResult, OutboundMessage, ReplyChannel, TaskEnvelope
 from app.state import SQLiteStateStore
@@ -49,6 +52,15 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             dedupe_key="email:1",
         )
         return TaskQueueMessage.from_envelope(envelope, trace_id="trace:email:1")
+
+    def _build_internal_heartbeat_task_message(self) -> TaskQueueMessage:
+        return TaskQueueMessage.from_envelope(
+            build_internal_heartbeat_envelope(
+                sequence=1,
+                now=datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc),
+            ),
+            trace_id="trace:internal:heartbeat:1",
+        )
 
     def _build_telegram_envelope(self, *, envelope_id: str, content: str, target: str = "12345") -> TaskEnvelope:
         return TaskEnvelope(
@@ -253,6 +265,67 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             self.assertEqual(acked, ["guid-outbox-1"])
             self.assertEqual(applier.apply_calls, 1)
             self.assertEqual(store.list_replayable_egress_outbox_events(), [])
+
+    def test_handle_egress_message_allows_internal_heartbeat_log_channel_and_records_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            store = SQLiteStateStore(db_path)
+            ledger = TaskLedgerStore(db_path)
+            task_message = self._build_internal_heartbeat_task_message()
+            ledger.record_task(task_message)
+            heartbeat_telemetry = HeartbeatTelemetryRollup()
+            heartbeat_telemetry.record_sent(sent_at=task_message.emitted_at)
+            acked: list[str] = []
+            applied_messages: list[tuple[str, str, str]] = []
+
+            @dataclass
+            class _HeartbeatApplier:
+                apply_calls: int = 0
+
+                def apply(self, decision, envelope=None):
+                    del envelope
+                    self.apply_calls += 1
+                    applied_messages.extend(
+                        (message.channel, message.target, message.body)
+                        for message in decision.approved_messages
+                    )
+                    return ApplyResult(
+                        applied_actions=[],
+                        skipped_actions=[],
+                        dispatched_messages=decision.approved_messages,
+                        reason_codes=[],
+                    )
+
+            applier = _HeartbeatApplier()
+            queued = build_internal_heartbeat_egress(
+                task_message=task_message,
+                worker_received_at=task_message.emitted_at,
+            )
+
+            _handle_egress_message(
+                picked_guid="guid-heartbeat-1",
+                picked_payload=queued.to_dict(),
+                ledger=ledger,
+                store=store,
+                allowed_egress_channels={"email"},
+                applier=applier,
+                ack_callback=acked.append,
+                heartbeat_telemetry=heartbeat_telemetry,
+            )
+
+            self.assertEqual(acked, ["guid-heartbeat-1"])
+            self.assertEqual(applier.apply_calls, 1)
+            self.assertEqual(len(applied_messages), 1)
+            self.assertEqual(applied_messages[0][0], "log")
+            self.assertEqual(applied_messages[0][1], "heartbeat")
+            self.assertEqual(json.loads(applied_messages[0][2])["kind"], "heartbeat_pong")
+            snapshot = heartbeat_telemetry.snapshot()
+            self.assertEqual(snapshot["sent_total"], 1)
+            self.assertEqual(snapshot["received_total"], 1)
+            self.assertNotEqual(snapshot["latest_sent_at"], "none")
+            self.assertNotEqual(snapshot["latest_received_at"], "none")
+            self.assertIsInstance(snapshot["latest_latency_ms"], int)
+            self.assertGreaterEqual(snapshot["latest_latency_ms"], 0)
 
 
     def test_handle_egress_message_buffers_until_expected_sequence(self) -> None:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -3,8 +3,10 @@ import unittest
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+import json
 
 from app.broker import TaskQueueMessage
+from app.internal_heartbeat import build_internal_heartbeat_envelope
 from app.models import (
     ActionProposal,
     ExecutionResult,
@@ -86,6 +88,15 @@ class WorkerRuntimeTests(unittest.TestCase):
             dedupe_key="email:1",
         )
         return TaskQueueMessage.from_envelope(envelope, trace_id="trace:email:1")
+
+    def _build_internal_heartbeat_task_message(self) -> TaskQueueMessage:
+        return TaskQueueMessage.from_envelope(
+            build_internal_heartbeat_envelope(
+                sequence=1,
+                now=datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc),
+            ),
+            trace_id="trace:internal:heartbeat:1",
+        )
 
     def test_process_task_message_emits_multiple_egress_messages(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -185,6 +196,31 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertEqual(result.egress_messages[0].event_kind, "final")
             audit_event = store.list_audit_events()[0]
             self.assertIn("incremental_reply_send_not_allowed", audit_event.detail["reason_codes"])
+
+    def test_process_task_message_handles_internal_heartbeat_without_executor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            result = process_task_message(
+                store=store,
+                task_message=self._build_internal_heartbeat_task_message(),
+                router=RuleBasedRouter(),
+                executor_impl=AlwaysFailExecutor(),
+                policy=AllowlistPolicyEngine(allowed_action_types=frozenset({"write_file"})),
+                max_attempts=2,
+            )
+
+            self.assertEqual(result.run_record.result_status, "success")
+            self.assertEqual(result.run_record.workflow, "internal_heartbeat")
+            self.assertEqual(result.run_record.source, "internal")
+            self.assertEqual(len(result.egress_messages), 1)
+            egress_message = result.egress_messages[0]
+            self.assertEqual(egress_message.message.channel, "log")
+            self.assertEqual(egress_message.message.target, "heartbeat")
+            self.assertEqual(json.loads(egress_message.message.body)["kind"], "heartbeat_pong")
+            audit_event = store.list_audit_events()[0]
+            self.assertEqual(audit_event.workflow, "internal_heartbeat")
+            self.assertEqual(audit_event.detail["reason_codes"], ["internal_heartbeat"])
+            self.assertEqual(audit_event.detail["heartbeat"]["kind"], "heartbeat_pong")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an always-on internal heartbeat connector that emits a ping each message-handler loop
- short-circuit heartbeat tasks in the worker to emit a pong log event and record an internal run/audit entry
- allow the message handler to accept heartbeat log egress outside the normal channel allowlist and track round-trip telemetry

## Testing
- python3 -m unittest tests.test_worker_runtime tests.test_message_handler_runtime tests.test_connectors tests.test_interface_contracts tests.test_main_github_ingress
- python3 -m unittest discover -s tests

Closes #31