### PR TITLE
Ensure terminal final egress and reject post-completion egress

### DIFF
--- a/app/applier/integrated.py
+++ b/app/applier/integrated.py
@@ -197,6 +197,10 @@ class IntegratedApplier:
                 LOGGER.info("log_dispatch target=%s body=%s", dispatch_target, message.body)
                 dispatched_messages.append(normalized_message)
                 continue
+            if dispatch_channel == "drop":
+                LOGGER.info("drop_marker target=%s body=%s", dispatch_target, message.body)
+                dispatched_messages.append(normalized_message)
+                continue
             if dispatch_channel == "email":
                 if self.email_sender is None:
                     LOGGER.warning(

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -119,6 +119,7 @@ class EgressTelemetryRollup:
     deduped_total: int = 0
     dropped_total: int = 0
     dropped_unknown_task_total: int = 0
+    dropped_completed_task_total: int = 0
     dropped_disallowed_channel_total: int = 0
     dropped_missing_event_id_total: int = 0
     dispatch_latency_ms_total: int = 0
@@ -137,6 +138,8 @@ class EgressTelemetryRollup:
         self.dropped_total += 1
         if reason == "unknown_task":
             self.dropped_unknown_task_total += 1
+        elif reason == "completed_task":
+            self.dropped_completed_task_total += 1
         elif reason == "disallowed_channel":
             self.dropped_disallowed_channel_total += 1
         elif reason == "missing_event_id":
@@ -169,6 +172,7 @@ class EgressTelemetryRollup:
             "dedupe_hit_rate_pct": dedupe_hit_rate_pct,
             "dropped_total": self.dropped_total,
             "dropped_unknown_task_total": self.dropped_unknown_task_total,
+            "dropped_completed_task_total": self.dropped_completed_task_total,
             "dropped_disallowed_channel_total": self.dropped_disallowed_channel_total,
             "dropped_missing_event_id_total": self.dropped_missing_event_id_total,
             "incremental_dispatched_total": self.incremental_dispatched_total,
@@ -376,6 +380,12 @@ def _render_prometheus_metrics(snapshot: Mapping[str, float | int]) -> str:
             "counter",
             "Egress messages dropped because the task ledger entry was missing.",
             "dropped_unknown_task_total",
+        ),
+        (
+            "chatting_message_handler_egress_dropped_completed_task_total",
+            "counter",
+            "Egress messages dropped because the task was already completed.",
+            "dropped_completed_task_total",
         ),
         (
             "chatting_message_handler_egress_dropped_disallowed_channel_total",
@@ -946,6 +956,14 @@ def _build_policy_decision_for_message(egress_message: EgressQueueMessage) -> Po
     )
 
 
+def _is_terminal_drop_message(egress_message: EgressQueueMessage) -> bool:
+    return (
+        egress_message.event_kind == "final"
+        and egress_message.message.channel == "drop"
+        and egress_message.message.target == "task"
+    )
+
+
 def _prepare_ingress_envelope(
     *,
     store: SQLiteStateStore,
@@ -996,6 +1014,21 @@ def _handle_egress_message(
         _ack_and_mark_outbox()
         return
 
+    if ledger.is_task_completed(
+        task_id=egress_message.task_id,
+        envelope_id=egress_message.envelope_id,
+    ):
+        if telemetry is not None:
+            telemetry.record_dropped(reason="completed_task")
+        LOGGER.error(
+            "egress_drop_completed_task task_id=%s envelope_id=%s guid=%s",
+            egress_message.task_id,
+            egress_message.envelope_id,
+            picked_guid,
+        )
+        _ack_and_mark_outbox(egress_message.event_id)
+        return
+
     ledger_record = ledger.get_task(egress_message.task_id)
     if ledger_record is None or ledger_record.envelope_id != egress_message.envelope_id:
         if telemetry is not None:
@@ -1015,7 +1048,12 @@ def _handle_egress_message(
         and egress_message.message.channel == "log"
         and egress_message.message.target == INTERNAL_HEARTBEAT_TARGET
     )
-    if egress_message.message.channel not in allowed_egress_channels and not heartbeat_log_message:
+    terminal_drop_message = _is_terminal_drop_message(egress_message)
+    if (
+        egress_message.message.channel not in allowed_egress_channels
+        and not heartbeat_log_message
+        and not terminal_drop_message
+    ):
         if telemetry is not None:
             telemetry.record_dropped(reason="disallowed_channel")
         LOGGER.error(
@@ -1152,6 +1190,13 @@ def _flush_task_egress_in_sequence(
             egress_message.event_kind,
             egress_message.message.channel,
         )
+        if egress_message.event_kind == "final":
+            ledger.mark_task_completed(
+                task_id=task_id,
+                envelope_id=egress_message.envelope_id,
+                trace_id=egress_message.trace_id,
+            )
+            return
 
 
 def main() -> int:

--- a/app/message_handler_runtime.py
+++ b/app/message_handler_runtime.py
@@ -30,6 +30,14 @@ class StagedEgressRecord:
     created_at: datetime
 
 
+@dataclass(frozen=True)
+class CompletedTaskRecord:
+    task_id: str
+    envelope_id: str
+    trace_id: str
+    completed_at: datetime
+
+
 class TaskLedgerStore:
     """Persist ingress task ledger for strict egress verification."""
 
@@ -76,12 +84,29 @@ class TaskLedgerStore:
                 )
                 """
             )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS completed_task_ledger (
+                    task_id TEXT PRIMARY KEY,
+                    envelope_id TEXT NOT NULL,
+                    trace_id TEXT NOT NULL,
+                    completed_at TEXT NOT NULL
+                )
+                """
+            )
             connection.commit()
 
     def record_task(self, task_message: TaskQueueMessage) -> None:
         payload = task_message.to_dict()
         created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                DELETE FROM completed_task_ledger
+                WHERE task_id = ?
+                """,
+                (task_message.task_id,),
+            )
             connection.execute(
                 """
                 INSERT OR REPLACE INTO task_ledger (
@@ -157,6 +182,71 @@ class TaskLedgerStore:
                 VALUES (?, 0)
                 """,
                 (egress_message.task_id,),
+            )
+            connection.commit()
+
+    def get_completed_task(self, task_id: str) -> CompletedTaskRecord | None:
+        with closing(self._connect()) as connection:
+            row = connection.execute(
+                """
+                SELECT task_id, envelope_id, trace_id, completed_at
+                FROM completed_task_ledger
+                WHERE task_id = ?
+                """,
+                (task_id,),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        return CompletedTaskRecord(
+            task_id=row["task_id"],
+            envelope_id=row["envelope_id"],
+            trace_id=row["trace_id"],
+            completed_at=_parse_rfc3339_utc(row["completed_at"]),
+        )
+
+    def is_task_completed(self, *, task_id: str, envelope_id: str) -> bool:
+        completed_record = self.get_completed_task(task_id)
+        if completed_record is None:
+            return False
+        return completed_record.envelope_id == envelope_id
+
+    def mark_task_completed(self, *, task_id: str, envelope_id: str, trace_id: str) -> None:
+        completed_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO completed_task_ledger (
+                    task_id,
+                    envelope_id,
+                    trace_id,
+                    completed_at
+                )
+                VALUES (?, ?, ?, ?)
+                """,
+                (task_id, envelope_id, trace_id, completed_at),
+            )
+            connection.execute(
+                """
+                DELETE FROM task_ledger
+                WHERE task_id = ?
+                """,
+                (task_id,),
+            )
+            connection.execute(
+                """
+                DELETE FROM egress_sequence_state
+                WHERE task_id = ?
+                """,
+                (task_id,),
+            )
+            connection.execute(
+                """
+                DELETE FROM staged_egress_events
+                WHERE task_id = ?
+                """,
+                (task_id,),
             )
             connection.commit()
 
@@ -236,6 +326,7 @@ def _parse_rfc3339_utc(raw_value: str) -> datetime:
 
 
 __all__ = [
+    "CompletedTaskRecord",
     "TaskLedgerRecord",
     "StagedEgressRecord",
     "TaskLedgerStore",

--- a/app/worker_runtime.py
+++ b/app/worker_runtime.py
@@ -167,6 +167,13 @@ def process_task_message(
                 decision=decision,
                 starting_sequence=next_sequence,
             )
+            if not final_egress_messages:
+                final_egress_messages = [
+                    _build_terminal_drop_egress(
+                        task_message=task_message,
+                        sequence=next_sequence,
+                    )
+                ]
             egress_messages = [*incremental_messages, *final_egress_messages]
             break
         except Exception as exc:  # noqa: BLE001
@@ -341,6 +348,31 @@ def _normalize_message_for_egress(*, message: OutboundMessage, task_message: Tas
         channel=task_message.envelope.reply_channel.type,
         target=task_message.envelope.reply_channel.target,
         body=message.body,
+    )
+
+
+def _build_terminal_drop_egress(*, task_message: TaskQueueMessage, sequence: int) -> EgressQueueMessage:
+    return EgressQueueMessage(
+        task_id=task_message.task_id,
+        envelope_id=task_message.envelope.id,
+        trace_id=task_message.trace_id,
+        event_index=sequence,
+        event_count=1,
+        message=OutboundMessage(
+            channel="drop",
+            target="task",
+            body="Worker completed without final reply; marking task complete.",
+        ),
+        emitted_at=datetime.now(timezone.utc),
+        event_id=_event_id_for_sequence(
+            task_id=task_message.task_id,
+            sequence=sequence,
+            event_kind="final",
+            dedupe_key="drop",
+        ),
+        sequence=sequence,
+        event_kind="final",
+        message_type="chatting.egress.v2",
     )
 
 

--- a/docs/bbmb-message-flow.md
+++ b/docs/bbmb-message-flow.md
@@ -59,12 +59,15 @@ Examples:
 ### 2. Worker consumes the task
 
 `worker` picks one payload from `chatting.tasks.v1`, parses `chatting.task.v1`, routes it, executes
-it, runs policy, persists run and audit records, and builds zero or more egress messages.
+it, runs policy, persists run and audit records, and always builds at least one terminal
+`event_kind="final"` egress message.
 
 Current worker behavior:
 - normal replies are emitted as `chatting.egress.v2`
 - incremental replies use `event_kind="incremental"` and increasing `sequence`
 - final replies use `event_kind="final"`
+- if execution/policy yields no final reply content, the worker emits a terminal
+  `channel="drop", target="task"` final message as a completion marker
 - heartbeat tasks skip the normal executor path and emit a single log pong
 
 Before publishing each egress message, the worker writes it to the SQLite egress outbox. That lets
@@ -79,10 +82,13 @@ outbox/BBMB path.
 - validates `message_type == "chatting.egress.v2"`
 - validates that the task exists in the ingress ledger
 - drops unknown-task egress
-- drops disallowed egress channels, except for the internal heartbeat log pong
+- drops egress for tasks that are already completed
+- drops disallowed egress channels, except for the internal heartbeat log pong and terminal
+  `drop/task` completion markers
 - stages the message by `event_id` and `sequence`
 - dispatches staged events in order
 - records dispatched event ids so duplicate egress is ignored safely
+- marks the task complete after dispatching a final event, then rejects future egress for that task
 
 This is the strict boundary in split mode: the worker can suggest output, but only the
 message-handler can dispatch it to external systems.

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -68,6 +68,8 @@ python3 -m app.main_worker
 - `message-handler` owns integration secrets (`IMAP`, `SMTP`, `Telegram`).
 - `worker` does not read integration secrets and does not dispatch directly.
 - Egress is strict: if a task is unknown to the ingress ledger, it is logged and dropped.
+- Worker always emits a terminal final egress event; when there is no user-visible reply it emits a
+  `drop/task` completion marker so `message-handler` can close the task and reject future egress.
 - Egress channel dispatch is allowlist-gated by `allowed_egress_channels`.
 
 ## 4) Configure GitHub assignment polling (in message-handler)

--- a/tests/test_message_handler_runtime.py
+++ b/tests/test_message_handler_runtime.py
@@ -111,6 +111,48 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             self.assertEqual(acked, ["guid-1"])
             self.assertEqual(applier.apply_calls, 0)
 
+    def test_handle_egress_message_drops_completed_task(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            store = SQLiteStateStore(db_path)
+            ledger = TaskLedgerStore(db_path)
+            task_message = self._build_task_message()
+            ledger.record_task(task_message)
+            ledger.mark_task_completed(
+                task_id=task_message.task_id,
+                envelope_id=task_message.envelope.id,
+                trace_id=task_message.trace_id,
+            )
+            applier = _RecordingApplier()
+            acked: list[str] = []
+
+            payload = EgressQueueMessage(
+                task_id=task_message.task_id,
+                envelope_id=task_message.envelope.id,
+                trace_id=task_message.trace_id,
+                event_index=0,
+                event_count=1,
+                message=OutboundMessage(channel="email", target="alice@example.com", body="reply"),
+                emitted_at=datetime(2026, 3, 6, 12, 1, tzinfo=timezone.utc),
+                event_id="evt:task:email:1:0",
+                sequence=0,
+                event_kind="final",
+                message_type="chatting.egress.v2",
+            ).to_dict()
+
+            _handle_egress_message(
+                picked_guid="guid-completed",
+                picked_payload=payload,
+                ledger=ledger,
+                store=store,
+                allowed_egress_channels={"email"},
+                applier=applier,
+                ack_callback=acked.append,
+            )
+
+            self.assertEqual(acked, ["guid-completed"])
+            self.assertEqual(applier.apply_calls, 0)
+
     def test_handle_egress_message_drops_disallowed_channel(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "handler.db")
@@ -189,6 +231,60 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
                 store.has_dispatched_event_id(
                     task_id=task_message.task_id,
                     event_id="evt:task:email:1:0",
+                )
+            )
+            self.assertIsNone(ledger.get_task(task_message.task_id))
+            self.assertTrue(
+                ledger.is_task_completed(
+                    task_id=task_message.task_id,
+                    envelope_id=task_message.envelope.id,
+                )
+            )
+
+    def test_handle_egress_message_accepts_terminal_drop_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            store = SQLiteStateStore(db_path)
+            ledger = TaskLedgerStore(db_path)
+            task_message = self._build_task_message()
+            ledger.record_task(task_message)
+            applier = _RecordingApplier()
+            acked: list[str] = []
+
+            payload = EgressQueueMessage(
+                task_id=task_message.task_id,
+                envelope_id=task_message.envelope.id,
+                trace_id=task_message.trace_id,
+                event_index=0,
+                event_count=1,
+                message=OutboundMessage(
+                    channel="drop",
+                    target="task",
+                    body="Worker completed without final reply; marking task complete.",
+                ),
+                emitted_at=datetime(2026, 3, 6, 12, 1, tzinfo=timezone.utc),
+                event_id="evt:task:email:1:0:final:drop",
+                sequence=0,
+                event_kind="final",
+                message_type="chatting.egress.v2",
+            ).to_dict()
+
+            _handle_egress_message(
+                picked_guid="guid-drop-terminal",
+                picked_payload=payload,
+                ledger=ledger,
+                store=store,
+                allowed_egress_channels={"email"},
+                applier=applier,
+                ack_callback=acked.append,
+            )
+
+            self.assertEqual(acked, ["guid-drop-terminal"])
+            self.assertEqual(applier.apply_calls, 1)
+            self.assertTrue(
+                ledger.is_task_completed(
+                    task_id=task_message.task_id,
+                    envelope_id=task_message.envelope.id,
                 )
             )
 
@@ -526,6 +622,7 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
         self.assertEqual(snapshot["dispatch_latency_ms_max"], 120)
         self.assertEqual(snapshot["dropped_total"], 2)
         self.assertEqual(snapshot["dropped_unknown_task_total"], 1)
+        self.assertEqual(snapshot["dropped_completed_task_total"], 0)
         self.assertEqual(snapshot["dropped_disallowed_channel_total"], 1)
         self.assertEqual(snapshot["dropped_missing_event_id_total"], 0)
 
@@ -546,6 +643,7 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             "dedupe_hit_rate_pct": 50.0,
             "dropped_total": 1,
             "dropped_unknown_task_total": 1,
+            "dropped_completed_task_total": 0,
             "dropped_disallowed_channel_total": 0,
             "dropped_missing_event_id_total": 0,
             "incremental_dispatched_total": 1,
@@ -593,6 +691,7 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
                 "dedupe_hit_rate_pct": 14.29,
                 "dropped_total": 2,
                 "dropped_unknown_task_total": 1,
+                "dropped_completed_task_total": 0,
                 "dropped_disallowed_channel_total": 1,
                 "dropped_missing_event_id_total": 0,
                 "incremental_dispatched_total": 4,

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -73,6 +73,19 @@ class IncrementalReplyExecutor:
         )
 
 
+@dataclass(frozen=True)
+class NoMessageExecutor:
+    def execute(self, task):
+        del task
+        return ExecutionResult(
+            messages=[],
+            actions=[],
+            config_updates=[],
+            requires_human_review=False,
+            errors=[],
+        )
+
+
 class WorkerRuntimeTests(unittest.TestCase):
     def _build_task_message(self) -> TaskQueueMessage:
         envelope = TaskEnvelope(
@@ -221,6 +234,26 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertEqual(audit_event.workflow, "internal_heartbeat")
             self.assertEqual(audit_event.detail["reason_codes"], ["internal_heartbeat"])
             self.assertEqual(audit_event.detail["heartbeat"]["kind"], "heartbeat_pong")
+
+    def test_process_task_message_emits_terminal_drop_when_no_final_messages(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            result = process_task_message(
+                store=store,
+                task_message=self._build_task_message(),
+                router=RuleBasedRouter(),
+                executor_impl=NoMessageExecutor(),
+                policy=AllowlistPolicyEngine(allowed_action_types=frozenset({"write_file"})),
+                max_attempts=2,
+            )
+
+            self.assertEqual(result.run_record.result_status, "success")
+            self.assertEqual(len(result.egress_messages), 1)
+            terminal = result.egress_messages[0]
+            self.assertEqual(terminal.event_kind, "final")
+            self.assertEqual(terminal.message.channel, "drop")
+            self.assertEqual(terminal.message.target, "task")
+            self.assertEqual(terminal.sequence, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure worker always emits a terminal `final` egress event by synthesizing `drop/task` when no final user-visible reply exists
- allow and dispatch terminal `drop/task` markers in the integrated applier and message-handler allowlist checks
- add completed-task ledger tracking so final dispatch marks completion and future egress for that task is dropped
- add telemetry for completed-task drops and update split-mode docs to reflect terminal-final semantics

## Testing
- python3 -m unittest discover -s tests

Closes #43