### PR TITLE
Add immediate worker reply CLI for egress updates

### DIFF
--- a/app/broker/messages.py
+++ b/app/broker/messages.py
@@ -197,26 +197,31 @@ class EgressQueueMessage:
             raise ValueError("emitted_at must be timezone-aware")
         _require_positive_int(self.event_count, field_name="event_count")
         _require_non_empty_string(self.event_id, field_name="event_id")
-        if self.sequence is None:
-            raise ValueError("sequence is required")
-        _parse_sequence(self.sequence)
         if self.event_kind not in {"final", "incremental"}:
             raise ValueError("event_kind must be final or incremental")
+        if self.sequence is None:
+            if self.event_kind != "incremental":
+                raise ValueError("sequence is required for final events")
+            object.__setattr__(self, "event_index", 0)
+            return
+        _parse_sequence(self.sequence)
         object.__setattr__(self, "event_index", self.sequence)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "schema_version": self.schema_version,
             "message_type": self.message_type,
             "task_id": self.task_id,
             "envelope_id": self.envelope_id,
             "trace_id": self.trace_id,
             "event_id": self.event_id,
-            "sequence": self.sequence,
             "event_kind": self.event_kind,
             "emitted_at": _serialize_utc_datetime(self.emitted_at),
             "message": self.message.to_dict(),
         }
+        if self.sequence is not None:
+            payload["sequence"] = self.sequence
+        return payload
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "EgressQueueMessage":
@@ -231,7 +236,10 @@ class EgressQueueMessage:
             raise ValueError("message must be an object")
 
         event_id = _require_non_empty_string(payload.get("event_id"), field_name="event_id")
-        sequence = _parse_sequence(payload.get("sequence"))
+        raw_sequence = payload.get("sequence")
+        sequence: int | None = None
+        if raw_sequence is not None:
+            sequence = _parse_sequence(raw_sequence)
         event_kind = _require_non_empty_string(payload.get("event_kind"), field_name="event_kind")
 
         return cls(

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -39,7 +39,7 @@ from app.main import (
     _enrich_telegram_envelope_with_memory,
     _should_store_telegram_memory,
 )
-from app.message_handler_runtime import TaskLedgerStore
+from app.message_handler_runtime import TaskLedgerRecord, TaskLedgerStore
 from app.models import ConfigUpdateDecision, PolicyDecision, TaskEnvelope
 from app.state import SQLiteStateStore
 
@@ -1088,6 +1088,17 @@ def _handle_egress_message(
         _ack_and_mark_outbox(egress_message.event_id)
         return
 
+    if egress_message.sequence is None:
+        _ack_and_mark_outbox(egress_message.event_id)
+        _dispatch_unsequenced_egress(
+            egress_message=egress_message,
+            ledger_record=ledger_record,
+            store=store,
+            applier=applier,
+            telemetry=telemetry,
+        )
+        return
+
     ledger.stage_egress_event(egress_message)
     _ack_and_mark_outbox(egress_message.event_id)
     _flush_task_egress_in_sequence(
@@ -1097,6 +1108,54 @@ def _handle_egress_message(
         applier=applier,
         heartbeat_telemetry=heartbeat_telemetry,
         telemetry=telemetry,
+    )
+
+
+def _dispatch_unsequenced_egress(
+    *,
+    egress_message: EgressQueueMessage,
+    ledger_record: TaskLedgerRecord,
+    store: SQLiteStateStore,
+    applier: IntegratedApplier,
+    telemetry: EgressTelemetryRollup | None,
+) -> None:
+    decision = _build_policy_decision_for_message(egress_message)
+    apply_result = applier.apply(
+        decision,
+        envelope=ledger_record.task_message.envelope,
+    )
+    store.mark_dispatched_event_id(
+        task_id=egress_message.task_id,
+        event_id=egress_message.event_id,
+    )
+    dispatch_latency_ms = int(
+        (datetime.now(timezone.utc) - egress_message.emitted_at.astimezone(timezone.utc)).total_seconds() * 1000
+    )
+    if telemetry is not None:
+        telemetry.record_dispatched(
+            event_kind=egress_message.event_kind,
+            latency_ms=max(dispatch_latency_ms, 0),
+        )
+    if _should_store_telegram_memory(ledger_record.task_message.envelope):
+        for message in apply_result.dispatched_messages:
+            if message.channel != "telegram":
+                continue
+            if message.target != ledger_record.task_message.envelope.reply_channel.target:
+                continue
+            store.append_conversation_turn(
+                channel="telegram",
+                target=message.target,
+                role="assistant",
+                content=message.body,
+                run_id=egress_message.task_id,
+            )
+    LOGGER.info(
+        "egress_dispatched task_id=%s event_id=%s sequence=%s event_kind=%s channel=%s",
+        egress_message.task_id,
+        egress_message.event_id,
+        egress_message.sequence,
+        egress_message.event_kind,
+        egress_message.message.channel,
     )
 
 

--- a/app/main_reply.py
+++ b/app/main_reply.py
@@ -1,0 +1,122 @@
+"""Worker-side CLI to publish immediate incremental egress messages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+from app.broker import BBMBQueueAdapter, EGRESS_QUEUE_NAME, EgressQueueMessage
+from app.main_worker import WORKER_CONFIG_PATH_ENV_VAR, _load_config, _resolve_str
+from app.models import OutboundMessage
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Publish one immediate incremental reply message.")
+    parser.add_argument("task_id", help="Task identifier (for example: task:email:53).")
+    parser.add_argument("--message", required=True, help="Reply body text.")
+    parser.add_argument("--channel", required=True, help="Outbound channel (for example: email, telegram, github).")
+    parser.add_argument("--target", required=True, help="Outbound channel target.")
+    parser.add_argument("--event-id", help="Optional stable event id for idempotency.")
+    parser.add_argument("--envelope-id", help="Envelope id (defaults to task_id without 'task:' prefix).")
+    parser.add_argument("--trace-id", help="Trace id (defaults to trace:<envelope_id>).")
+    parser.add_argument("--bbmb-address", help="BBMB broker address host:port.")
+    parser.add_argument(
+        "--config",
+        help=(
+            "Path to worker config JSON. If omitted, this command also checks "
+            f"{WORKER_CONFIG_PATH_ENV_VAR}."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _resolve_envelope_id(task_id: str, explicit_value: str | None) -> str:
+    if explicit_value is not None:
+        if not explicit_value.strip():
+            raise ValueError("envelope_id must not be empty")
+        return explicit_value
+    if not task_id.startswith("task:"):
+        raise ValueError("envelope_id is required when task_id does not start with 'task:'")
+    return task_id[len("task:") :]
+
+
+def _resolve_trace_id(envelope_id: str, explicit_value: str | None) -> str:
+    if explicit_value is not None:
+        if not explicit_value.strip():
+            raise ValueError("trace_id must not be empty")
+        return explicit_value
+    return f"trace:{envelope_id}"
+
+
+def _resolve_event_id(task_id: str, explicit_value: str | None) -> str:
+    if explicit_value is not None:
+        if not explicit_value.strip():
+            raise ValueError("event_id must not be empty")
+        return explicit_value
+    return f"evt:{task_id}:adhoc:{time.time_ns()}"
+
+
+def main() -> int:
+    args = _parse_args()
+    config = _load_config(args.config, os.environ)
+
+    bbmb_address = _resolve_str(
+        args.bbmb_address,
+        config.get("bbmb_address"),
+        default_value="127.0.0.1:9876",
+        setting_name="bbmb_address",
+    )
+
+    envelope_id = _resolve_envelope_id(args.task_id, args.envelope_id)
+    trace_id = _resolve_trace_id(envelope_id, args.trace_id)
+    event_id = _resolve_event_id(args.task_id, args.event_id)
+
+    body = args.message.strip()
+    if not body:
+        raise ValueError("message must not be empty")
+
+    egress_message = EgressQueueMessage(
+        task_id=args.task_id,
+        envelope_id=envelope_id,
+        trace_id=trace_id,
+        event_index=0,
+        event_count=1,
+        message=OutboundMessage(channel=args.channel, target=args.target, body=body),
+        emitted_at=datetime.now(timezone.utc),
+        event_id=event_id,
+        sequence=None,
+        event_kind="incremental",
+        message_type="chatting.egress.v2",
+    )
+
+    broker = BBMBQueueAdapter(address=bbmb_address)
+    broker.ensure_queue(EGRESS_QUEUE_NAME)
+    guid = broker.publish_json(EGRESS_QUEUE_NAME, egress_message.to_dict())
+
+    print(
+        json.dumps(
+            {
+                "status": "published",
+                "queue": EGRESS_QUEUE_NAME,
+                "guid": guid,
+                "task_id": egress_message.task_id,
+                "event_id": egress_message.event_id,
+                "event_kind": egress_message.event_kind,
+                "sequence": egress_message.sequence,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        raise SystemExit(2)

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -102,3 +102,20 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now chatting-message-handler.service
 sudo systemctl enable --now chatting-worker.service
 ```
+
+## 6) Publish an immediate incremental reply from worker side
+
+Use the worker-side CLI to push an egress event directly to BBMB without waiting for worker loop completion:
+
+```bash
+python3 -m app.main_reply task:email:53 \
+  --message "working on it" \
+  --channel email \
+  --target alice@example.com \
+  --config /tmp/worker.json
+```
+
+Notes:
+- `message_type` is `chatting.egress.v2` with `event_kind=incremental`.
+- These ad-hoc events are intentionally unsequenced and dispatch immediately at message-handler.
+- `--event-id` can be supplied for stable idempotency across retries.

--- a/tests/test_broker_messages.py
+++ b/tests/test_broker_messages.py
@@ -113,6 +113,43 @@ class EgressQueueMessageTests(unittest.TestCase):
                 message_type="chatting.egress.v2",
             )
 
+    def test_egress_v2_message_allows_missing_sequence(self) -> None:
+        message = EgressQueueMessage(
+            task_id="task:email:2",
+            envelope_id="email:2",
+            trace_id="trace:email:2",
+            event_index=0,
+            event_count=1,
+            message=OutboundMessage(channel="email", target="alice@example.com", body="hello"),
+            emitted_at=datetime(2026, 3, 6, 11, 1, tzinfo=timezone.utc),
+            event_id="evt:task:email:2:adhoc",
+            sequence=None,
+            event_kind="incremental",
+            message_type="chatting.egress.v2",
+        )
+
+        payload = message.to_dict()
+        self.assertNotIn("sequence", payload)
+        parsed = EgressQueueMessage.from_dict(payload)
+        self.assertIsNone(parsed.sequence)
+        self.assertEqual(parsed.event_kind, "incremental")
+
+    def test_egress_v2_final_message_requires_sequence(self) -> None:
+        with self.assertRaises(ValueError):
+            EgressQueueMessage(
+                task_id="task:email:2",
+                envelope_id="email:2",
+                trace_id="trace:email:2",
+                event_index=0,
+                event_count=1,
+                message=OutboundMessage(channel="email", target="alice@example.com", body="hello"),
+                emitted_at=datetime(2026, 3, 6, 11, 1, tzinfo=timezone.utc),
+                event_id="evt:task:email:2:final",
+                sequence=None,
+                event_kind="final",
+                message_type="chatting.egress.v2",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_main_reply.py
+++ b/tests/test_main_reply.py
@@ -1,0 +1,118 @@
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app.main_reply import main
+
+
+class _FakeBroker:
+    def __init__(self, address: str):
+        self.address = address
+        self.ensured: list[str] = []
+        self.published: list[tuple[str, dict[str, object]]] = []
+
+    def ensure_queue(self, queue_name: str) -> None:
+        self.ensured.append(queue_name)
+
+    def publish_json(self, queue_name: str, payload: dict[str, object]) -> str:
+        self.published.append((queue_name, payload))
+        return "guid-1"
+
+
+class MainReplyCliTests(unittest.TestCase):
+    def test_main_reply_publishes_unsequenced_incremental_v2_payload(self) -> None:
+        broker = _FakeBroker("127.0.0.1:9876")
+        stdout = io.StringIO()
+        with (
+            patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+            patch("sys.stdout", stdout),
+            patch(
+                "sys.argv",
+                [
+                    "main_reply.py",
+                    "task:email:53",
+                    "--message",
+                    "working on it",
+                    "--channel",
+                    "email",
+                    "--target",
+                    "alice@example.com",
+                    "--event-id",
+                    "evt:custom:1",
+                ],
+            ),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(broker.ensured, ["chatting.egress.v1"])
+        self.assertEqual(len(broker.published), 1)
+        queue_name, payload = broker.published[0]
+        self.assertEqual(queue_name, "chatting.egress.v1")
+        self.assertEqual(payload["task_id"], "task:email:53")
+        self.assertEqual(payload["envelope_id"], "email:53")
+        self.assertEqual(payload["trace_id"], "trace:email:53")
+        self.assertEqual(payload["event_id"], "evt:custom:1")
+        self.assertEqual(payload["event_kind"], "incremental")
+        self.assertEqual(payload["message_type"], "chatting.egress.v2")
+        self.assertNotIn("sequence", payload)
+
+        printed = json.loads(stdout.getvalue())
+        self.assertEqual(printed["status"], "published")
+        self.assertEqual(printed["guid"], "guid-1")
+        self.assertIsNone(printed["sequence"])
+
+    def test_main_reply_uses_bbmb_address_from_worker_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "worker.json"
+            config_path.write_text(json.dumps({"bbmb_address": "10.0.0.5:9999"}), encoding="utf-8")
+            broker = _FakeBroker("placeholder")
+            stdout = io.StringIO()
+            with (
+                patch("app.main_reply.BBMBQueueAdapter", return_value=broker) as broker_ctor,
+                patch("sys.stdout", stdout),
+                patch(
+                    "sys.argv",
+                    [
+                        "main_reply.py",
+                        "task:email:53",
+                        "--message",
+                        "working on it",
+                        "--channel",
+                        "email",
+                        "--target",
+                        "alice@example.com",
+                        "--config",
+                        str(config_path),
+                    ],
+                ),
+                ):
+                exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        broker_ctor.assert_called_once_with(address="10.0.0.5:9999")
+        self.assertEqual(broker.ensured, ["chatting.egress.v1"])
+
+    def test_main_reply_requires_envelope_id_for_non_prefixed_task_id(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "main_reply.py",
+                "email:53",
+                "--message",
+                "working on it",
+                "--channel",
+                "email",
+                "--target",
+                "alice@example.com",
+            ],
+        ):
+            with self.assertRaisesRegex(ValueError, "envelope_id is required"):
+                main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_message_handler_runtime.py
+++ b/tests/test_message_handler_runtime.py
@@ -334,6 +334,63 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             self.assertEqual(acked, ["guid-4", "guid-5"])
             self.assertEqual(applier.apply_calls, 1)
 
+    def test_handle_egress_message_dispatches_unsequenced_incremental_immediately(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            store = SQLiteStateStore(db_path)
+            ledger = TaskLedgerStore(db_path)
+            task_message = self._build_task_message()
+            ledger.record_task(task_message)
+            acked: list[str] = []
+            applied_bodies: list[str] = []
+
+            @dataclass
+            class _BodyRecordingApplier:
+                def apply(self, decision, envelope=None):
+                    del envelope
+                    applied_bodies.append(decision.approved_messages[0].body)
+                    return ApplyResult(
+                        applied_actions=[],
+                        skipped_actions=[],
+                        dispatched_messages=decision.approved_messages,
+                        reason_codes=[],
+                    )
+
+            applier = _BodyRecordingApplier()
+            payload = EgressQueueMessage(
+                task_id=task_message.task_id,
+                envelope_id=task_message.envelope.id,
+                trace_id=task_message.trace_id,
+                event_index=0,
+                event_count=1,
+                message=OutboundMessage(channel="email", target="alice@example.com", body="working on it"),
+                emitted_at=datetime(2026, 3, 6, 12, 1, tzinfo=timezone.utc),
+                event_id="evt:task:email:1:adhoc",
+                sequence=None,
+                event_kind="incremental",
+                message_type="chatting.egress.v2",
+            ).to_dict()
+
+            _handle_egress_message(
+                picked_guid="guid-adhoc-1",
+                picked_payload=payload,
+                ledger=ledger,
+                store=store,
+                allowed_egress_channels={"email"},
+                applier=applier,
+                ack_callback=acked.append,
+            )
+
+            self.assertEqual(acked, ["guid-adhoc-1"])
+            self.assertEqual(applied_bodies, ["working on it"])
+            self.assertTrue(
+                store.has_dispatched_event_id(
+                    task_id=task_message.task_id,
+                    event_id="evt:task:email:1:adhoc",
+                )
+            )
+            self.assertEqual(store.list_dispatched_event_indices(run_id=task_message.task_id), [])
+
     def test_handle_egress_message_marks_outbox_event_acked(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "handler.db")


### PR DESCRIPTION
## Summary
- add `app.main_reply` worker-side CLI that publishes immediate incremental `chatting.egress.v2` events to BBMB
- allow unsequenced incremental egress events in `EgressQueueMessage` while keeping sequence required for final events
- dispatch unsequenced incremental egress immediately in `message-handler` (no sequence staging wait)
- document the new CLI in split-mode runbook and add coverage tests

## Validation
- `python3 -m unittest discover -s tests`

Closes #45