### PR TITLE
Refresh split-mode docs and remove legacy runtime references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,21 +2,21 @@
 
 ## Getting started
 
-- [Quick Start](/home/edward/chatting/docs/quick-start.md)
-- [Run Split Mode (BBMB)](/home/edward/chatting/docs/run-split-bbmb.md)
-- [BBMB Message Flow](/home/edward/chatting/docs/bbmb-message-flow.md)
-- [Debug And Test Guide](/home/edward/chatting/docs/debug-and-test.md)
+- [Quick Start](quick-start.md)
+- [Run Split Mode (BBMB)](run-split-bbmb.md)
+- [BBMB Message Flow](bbmb-message-flow.md)
+- [Debug And Test Guide](debug-and-test.md)
 
 ## CI
 
-- [GitHub Actions CI Workflow](/home/edward/chatting/.github/workflows/ci.yml)
+- [GitHub Actions CI Workflow](../.github/workflows/ci.yml)
 
 ## Connectors
 
-- [Connector Docs Index](/home/edward/chatting/docs/connectors/README.md)
+- [Connector Docs Index](connectors/README.md)
 
 ## Architecture
 
-- [0001 Python Architecture For Private Single-User Automation](/home/edward/chatting/docs/architecture/0001-python-prototype-architecture.md)
-- [0002 Interface Contracts And Data Schemas](/home/edward/chatting/docs/architecture/0002-interface-contracts.md)
-- [0003 Current Implementation Overview (Single-User)](/home/edward/chatting/docs/architecture/0003-implementation-overview.md)
+- [0001 Split-Mode Architecture For Private Single-User Automation](architecture/0001-python-prototype-architecture.md)
+- [0002 Interface Contracts And BBMB Payload Schemas](architecture/0002-interface-contracts.md)
+- [0003 Current Implementation Overview (Split Mode)](architecture/0003-implementation-overview.md)

--- a/docs/architecture/0001-python-prototype-architecture.md
+++ b/docs/architecture/0001-python-prototype-architecture.md
@@ -1,4 +1,4 @@
-# 0001: Python Architecture For Private Single-User Automation
+# 0001: Split-Mode Architecture For Private Single-User Automation
 
 ## Status
 Accepted
@@ -12,42 +12,42 @@ We need a reliable local automation assistant that:
 - persists full run/audit history for local traceability
 - supports safe config proposal/approval/rollback
 
-This system is intentionally scoped for private, single-user operation on one machine.
+This system is intentionally scoped for private, single-user operation with a split runtime.
+The integration-facing host and execution-facing host may be the same machine or separate machines.
 
 ## Decision
 
-Use a modular, contract-driven single-process architecture:
+Use a modular, contract-driven split architecture:
 
-1. `connectors` produce canonical `TaskEnvelope` entries.
-2. `router` maps envelope -> `RoutedTask`.
-3. `executor` produces strict `ExecutionResult` payloads.
-4. `policy` gates actions/messages/config updates.
-5. `applier` executes approved operations and dispatches responses.
-6. `state` persists operational history and control-plane records.
+1. `message-handler` produces canonical `TaskEnvelope` entries from connectors and publishes
+   `TaskQueueMessage` payloads to BBMB.
+2. `worker` maps each task envelope to a routed task, executes it, evaluates policy, and emits
+   `EgressQueueMessage` payloads.
+3. `message-handler` validates egress against the ingress ledger and performs external dispatch.
+4. SQLite persists operational history, the ingress ledger, egress replay state, and control-plane records.
 
 ## Implementation modules
 
 ### `app/connectors/`
-- source adapters for cron/email/IM/webhook-style inputs
-- every connector emits canonical envelopes
+- source adapters for schedule, email, IM, heartbeat, and GitHub assignment ingress
+- every runtime connector emits canonical envelopes
 
-### `app/router/`
-- deterministic routing rules and execution constraints
+### `app/broker/`
+- BBMB transport adapter plus `chatting.task.v1` and `chatting.egress.v2` payload contracts
+- hardcoded transport queues: `chatting.tasks.v1` and `chatting.egress.v1`
 
-### `app/executor/`
-- `StubExecutor` for deterministic smoke/testing
-- `CodexExecutor` for subprocess-based real execution
-- strict structured-output parser contract
+### `app/main_message_handler.py`
+- owns connector polling, ingress dedupe, task ledger persistence, strict egress validation, and outbound dispatch
+- keeps integration secrets and allowlisted external effects on the integration-facing side
 
-### `app/policy/`
-- deny-by-default action policy
-- sensitive config updates become pending approvals
+### `app/main_worker.py`
+- owns task consumption, routing, executor calls, policy evaluation, retries, dead-lettering, and egress publication
+- keeps Codex execution isolated from integration credentials
 
-### `app/applier/`
-- action execution (`write_file`) with path safety
-- outbound dispatch support (log/email/telegram)
+### `app/router/`, `app/executor/`, `app/policy/`
+- deterministic routing, strict executor output parsing, and deny-by-default action policy
 
-### `app/state/`
+### `app/state/` and `app/message_handler_runtime.py`
 SQLite-backed persistence for:
 - idempotency keys
 - run records
@@ -55,19 +55,17 @@ SQLite-backed persistence for:
 - dead-letter queue
 - pending approvals
 - config versions + rollback
-
-### `app/queue/`
-- in-memory queue abstraction used in live loop
-- scoped to local process usage
+- worker egress outbox replay state
+- ingress task ledger, staged egress, and task-completion markers
 
 ## Runtime topology
 
-- one process
-- local SQLite database
-- local queue abstraction
-- worker loop tuned for private single-user reliability
+- `message-handler`
+- `worker`
+- `bbmb-server`
+- one SQLite database per runtime role by default
 
-No distributed or multi-tenant scaling is planned.
+No multi-tenant scaling is planned.
 
 ## Safety controls
 
@@ -81,10 +79,10 @@ No distributed or multi-tenant scaling is planned.
 ## Consequences
 
 Pros:
-- clear boundaries between modules
-- strong local observability and recoverability
-- safe-by-default automation behavior
+- clear security boundary between integration dispatch and Codex execution
+- strong observability and recoverability through SQLite state and egress replay
+- safe-by-default automation behavior with strict egress validation
 
 Tradeoffs:
-- optimized for one user, one machine
-- not designed for distributed workload scaling
+- optimized for one user and a small number of cooperating runtime processes
+- more moving parts than the retired single-process bootstrap prototype

--- a/docs/architecture/0002-interface-contracts.md
+++ b/docs/architecture/0002-interface-contracts.md
@@ -1,11 +1,12 @@
-# 0002: Interface Contracts And Data Schemas
+# 0002: Interface Contracts And BBMB Payload Schemas
 
 ## Status
 Accepted
 
 ## Purpose
 
-Define stable contracts across connectors/router/executor/policy/applier/state so behavior remains consistent as modules evolve.
+Define stable contracts across message-handler, worker, BBMB payloads, and persistence layers so
+behavior remains consistent as modules evolve.
 
 ## Core Python protocol contracts
 
@@ -24,14 +25,6 @@ class Executor(Protocol):
 class PolicyEngine(Protocol):
     def evaluate(self, result: "ExecutionResult") -> "PolicyDecision": ...
 
-class Applier(Protocol):
-    def apply(self, decision: "PolicyDecision") -> "ApplyResult": ...
-
-class QueueBackend(Protocol):
-    def enqueue(self, envelope: "TaskEnvelope") -> None: ...
-    def dequeue(self) -> "TaskEnvelope | None": ...
-    def size(self) -> int: ...
-
 class StateStore(Protocol):
     def seen(self, source: str, dedupe_key: str) -> bool: ...
     def mark_seen(self, source: str, dedupe_key: str) -> None: ...
@@ -42,10 +35,11 @@ class StateStore(Protocol):
 ## Canonical top-level schema objects
 
 - `TaskEnvelope`
+- `TaskQueueMessage`
+- `EgressQueueMessage`
 - `RoutedTask`
 - `ExecutionResult`
 - `PolicyDecision`
-- `ApplyResult`
 - `RunRecord`
 - `AuditEvent`
 
@@ -53,8 +47,13 @@ Operational extensions:
 - `DeadLetterRecord`
 - `PendingApprovalRecord`
 - `ConfigVersionRecord`
+- task-ledger and staged-egress records in `app.message_handler_runtime`
 
-All top-level objects include `schema_version` and enforce strict required fields.
+The BBMB payload contracts are:
+- `chatting.task.v1` on `chatting.tasks.v1`
+- `chatting.egress.v2` on `chatting.egress.v1`
+
+All top-level payload objects include `schema_version` and enforce strict required fields.
 
 ## Observability contract
 
@@ -74,8 +73,9 @@ Each run emits:
 - action execution deny-by-default
 - sensitive config updates require explicit approval workflow
 - all decisions/audit outcomes persisted in SQLite
+- `message-handler` is the only process allowed to dispatch to external systems
 
 ## Deployment scope
 
-Contracts are implemented for a private single-user system.
-No distributed orchestration contract is required.
+Contracts are implemented for a private single-user system with a split runtime.
+The transport contract is BBMB-backed; there is no multi-tenant orchestration layer.

--- a/docs/architecture/0003-implementation-overview.md
+++ b/docs/architecture/0003-implementation-overview.md
@@ -1,4 +1,4 @@
-# 0003: Current Implementation Overview (Single-User)
+# 0003: Current Implementation Overview (Split Mode)
 
 ## Status
 Accepted
@@ -6,21 +6,21 @@ Accepted
 ## Scope
 
 This document describes the current implementation as of 2026-03-01.
-The deployment model is private, single-user, single-machine.
+The deployment model is private, single-user, split mode.
 
 ## Runtime flow
 
-1. Connectors emit canonical `TaskEnvelope` objects.
-2. `RuleBasedRouter` maps each envelope to `RoutedTask`.
-3. Executor (`StubExecutor` or `CodexExecutor`) returns `ExecutionResult`.
-4. `AllowlistPolicyEngine` gates actions/config updates/messages.
-5. Applier executes approved actions/messages.
-6. `SQLiteStateStore` persists idempotency, run history, audit, dead letters, approvals, and config versions.
+1. `app.main_message_handler` polls connectors and emits canonical `TaskEnvelope` objects.
+2. Message-handler publishes `TaskQueueMessage` payloads to `chatting.tasks.v1` and records them in the ingress ledger.
+3. `app.main_worker` consumes tasks, routes them, runs the executor, evaluates policy, and emits `EgressQueueMessage` payloads.
+4. Message-handler validates egress against the ingress ledger, dispatches allowed messages, and marks tasks complete on terminal final events.
+5. `SQLiteStateStore` persists idempotency, run history, audit, dead letters, approvals, config versions, and worker egress outbox state.
 
 ## Entrypoints
 
 - `app.main_message_handler`: ingress + egress dispatch in split mode
 - `app.main_worker`: task execution in split mode
+- `app.main_reply`: publish immediate worker-side incremental egress
 - `app.main`: read/query + admin commands only (`--list-*`, replay dead letters, approvals, rollback, metrics)
 
 ## Persistence tables (SQLite)
@@ -44,8 +44,8 @@ The deployment model is private, single-user, single-machine.
 
 ## Non-goals
 
-- distributed deployment
 - multi-tenant operation
-- external queue systems
+- replacing BBMB with multiple transport layers
 
-The implementation remains intentionally private and single-user; distributed scaling is not a project goal.
+The implementation remains intentionally private and single-user; the split deployment can run on one
+host or a small number of cooperating hosts.

--- a/docs/bbmb-message-flow.md
+++ b/docs/bbmb-message-flow.md
@@ -24,7 +24,7 @@ There are currently two BBMB queues:
 | Queue | Producer | Consumer | Purpose |
 | --- | --- | --- | --- |
 | `chatting.tasks.v1` | `message-handler` | `worker` | Carries normalized ingress tasks as `chatting.task.v1` payloads |
-| `chatting.egress.v1` | `worker` | `message-handler` | Carries `chatting.egress.v2` payloads for ordered dispatch |
+| `chatting.egress.v1` | `worker` | `message-handler` | Carries `chatting.egress.v2` payloads for ordered dispatch and immediate ad-hoc incrementals |
 
 Important details:
 - Queue names are hardcoded today.
@@ -66,6 +66,8 @@ Current worker behavior:
 - normal replies are emitted as `chatting.egress.v2`
 - incremental replies use `event_kind="incremental"` and increasing `sequence`
 - final replies use `event_kind="final"`
+- worker-side `app.main_reply` can also publish unsequenced `event_kind="incremental"` messages for
+  immediate operator-visible updates
 - if execution/policy yields no final reply content, the worker emits a terminal
   `channel="drop", target="task"` final message as a completion marker
 - heartbeat tasks skip the normal executor path and emit a single log pong
@@ -85,7 +87,8 @@ outbox/BBMB path.
 - drops egress for tasks that are already completed
 - drops disallowed egress channels, except for the internal heartbeat log pong and terminal
   `drop/task` completion markers
-- stages the message by `event_id` and `sequence`
+- dispatches unsequenced incrementals immediately
+- stages sequenced events by `event_id` and `sequence`
 - dispatches staged events in order
 - records dispatched event ids so duplicate egress is ignored safely
 - marks the task complete after dispatching a final event, then rejects future egress for that task
@@ -114,7 +117,7 @@ An IMAP message from `alice@example.com` turns into a `chatting.task.v1` payload
     "actor": "alice@example.com",
     "content": "Subject: Please summarize\n\nSummarize the overnight logs.",
     "attachments": [],
-    "context_refs": ["repo:/home/edward/chatting"],
+    "context_refs": ["repo:/opt/chatting"],
     "policy_profile": "default",
     "reply_channel": {
       "type": "email",

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -2,11 +2,11 @@
 
 Implemented connector docs:
 
-- [Fake Cron](/home/edward/chatting/docs/connectors/fake-cron.md)
-- [Fake Email](/home/edward/chatting/docs/connectors/fake-email.md)
-- [Interval Schedule](/home/edward/chatting/docs/connectors/interval-schedule.md)
-- [IMAP Email](/home/edward/chatting/docs/connectors/imap-email.md)
-- [Telegram](/home/edward/chatting/docs/connectors/telegram.md)
-- [Slack](/home/edward/chatting/docs/connectors/slack.md)
-- [Webhook](/home/edward/chatting/docs/connectors/webhook.md)
-- [GitHub Issue Assignments](/home/edward/chatting/docs/connectors/github-issue-assignments.md)
+- [Fake Cron](fake-cron.md)
+- [Fake Email](fake-email.md)
+- [Interval Schedule](interval-schedule.md)
+- [IMAP Email](imap-email.md)
+- [Telegram](telegram.md)
+- [Slack](slack.md)
+- [Webhook](webhook.md)
+- [GitHub Issue Assignments](github-issue-assignments.md)

--- a/docs/connectors/fake-cron.md
+++ b/docs/connectors/fake-cron.md
@@ -4,7 +4,7 @@ Module: `app.connectors.fake_cron_connector`
 
 ## Purpose
 
-In-memory cron connector used by bootstrap flow and tests.
+In-memory cron connector used in tests and fixture-style local runs.
 
 ## Input model
 

--- a/docs/connectors/fake-email.md
+++ b/docs/connectors/fake-email.md
@@ -4,7 +4,7 @@ Module: `app.connectors.fake_email_connector`
 
 ## Purpose
 
-In-memory email connector used by bootstrap flow and tests.
+In-memory email connector used in tests and fixture-style local runs.
 
 ## Input model
 

--- a/docs/connectors/interval-schedule.md
+++ b/docs/connectors/interval-schedule.md
@@ -8,7 +8,7 @@ Live cron-style connector that emits events on fixed intervals.
 
 ## Runtime config keys
 
-Configured via `schedule_file` JSON loaded by `app.main`.
+Configured via `schedule_file` JSON loaded by `app.main_message_handler`.
 Each job supports:
 - `job_name` (required)
 - `content` (required)

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -9,7 +9,7 @@ Normalize Slack-style message payloads into canonical IM envelopes.
 ## Current integration state
 
 - Connector module is implemented and unit-tested.
-- It is not wired into `app.main` CLI/config yet.
+- It is not wired into the split-mode runtime CLI/config yet.
 - Intended for in-process/private integrations that provide `fetch_messages`.
 
 ## Constructor inputs

--- a/docs/connectors/webhook.md
+++ b/docs/connectors/webhook.md
@@ -9,7 +9,7 @@ Drain queued webhook events into canonical webhook envelopes.
 ## Current integration state
 
 - Connector module is implemented and unit-tested.
-- It is not wired into `app.main` CLI/config yet.
+- It is not wired into the split-mode runtime CLI/config yet.
 - Intended for private local integrations where events are pushed in-process.
 
 ## Input model

--- a/docs/debug-and-test.md
+++ b/docs/debug-and-test.md
@@ -26,9 +26,30 @@ python3 -m unittest tests.test_executor.ParseExecutionResultTests
 ```bash
 python3 -m unittest tests.test_sqlite_store tests.test_state_contract
 ```
+- Split-mode runtime coverage:
+```bash
+python3 -m unittest tests.test_worker_runtime tests.test_message_handler_runtime tests.test_main_reply
+```
+- Split-mode smoke e2e:
+```bash
+python3 -m unittest tests.test_split_mode_e2e -v
+```
+This skips locally unless `CHATTING_BBMB_SERVER_BIN` points to a built `bbmb-server`.
 
 ## Useful runtime inspection commands
 
+- Message-handler runtime help:
+```bash
+python3 -m app.main_message_handler --help
+```
+- Worker runtime help:
+```bash
+python3 -m app.main_worker --help
+```
+- Immediate reply CLI help:
+```bash
+python3 -m app.main_reply --help
+```
 - List runs:
 ```bash
 python3 -m app.main --db-path /tmp/chatting-state.db --list-runs --limit 50
@@ -77,7 +98,7 @@ python3 -m app.main --db-path /tmp/chatting-state.db --serve-metrics --metrics-p
 - `context_ref/context_refs entries must not be empty`:
   remove blank strings from context refs.
 - `schedule job ... unknown keys` or type errors:
-  validate schedule JSON against strict schema in `app.main`.
+  validate schedule JSON against strict message-handler schedule-file parsing.
 
 ## Logging behavior
 
@@ -101,3 +122,4 @@ Use these with DB queries to correlate outcomes.
 - Workflow file: `.github/workflows/ci.yml`
 - Triggers: push to `main`, and pull requests targeting `main`
 - Python version: `3.13`
+- CI also builds `bbmb-server` and sets `CHATTING_BBMB_SERVER_BIN` before running the test suite.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,7 +33,15 @@ cp configs/worker-runtime.example.json /tmp/worker.json
 # edit bbmb_address and connector/executor settings as needed
 ```
 
-## 4) Start services
+## 4) Start BBMB
+
+```bash
+bbmb-server
+```
+
+By default `chatting` expects BBMB on `127.0.0.1:9876`.
+
+## 5) Start chatting services
 
 ```bash
 python3 -m app.main_message_handler --config /tmp/message-handler.json
@@ -44,7 +52,7 @@ Or use the provided systemd unit templates in `deploy/systemd/`.
 
 The message handler also exposes Prometheus-style metrics at `http://127.0.0.1:9464/metrics` by default. You can override the bind host and port with `metrics_host` and `metrics_port` in the message-handler config or the matching CLI flags.
 
-## 5) Query state and metrics
+## 6) Query state and metrics
 
 `app.main` is now query/admin only:
 
@@ -57,6 +65,8 @@ python3 -m app.main --db-path /tmp/chatting-message-handler.db --list-metrics
 ## Notes
 
 - For the queue-by-queue runtime conversation, payload examples, and config levers, see
-  [BBMB Message Flow](/home/edward/chatting/docs/bbmb-message-flow.md).
-- For full split-mode setup and operational details, see [Run Split Mode (BBMB)](/home/edward/chatting/docs/run-split-bbmb.md).
+  [BBMB Message Flow](bbmb-message-flow.md).
+- For full split-mode setup and operational details, see [Run Split Mode (BBMB)](run-split-bbmb.md).
 - `app.main` no longer runs bootstrap/live runtime execution.
+- `app.main` reads one SQLite database at a time. In split mode, point it at either the
+  message-handler DB or the worker DB depending on what you want to inspect.

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -1,8 +1,8 @@
 # Running Split Mode With BBMB
 
 This mode runs `chatting` as a 3-part application:
-- `message-handler` on `UserOne` (connectors + outbound dispatch)
-- `worker` on `UserTwo` (routing + executor + policy)
+- `message-handler` on the integration host (connectors + outbound dispatch)
+- `worker` on the execution host (routing + executor + policy)
 - `bbmb-server` in the middle (message bus)
 
 GitHub assignment polling is part of `message-handler` when configured.
@@ -19,17 +19,25 @@ Egress payload contract is v2-only:
 - `message-handler` rejects legacy `chatting.egress.v1` payload types.
 
 For a worked message example and the full message-handler <-> worker conversation, see
-[BBMB Message Flow](/home/edward/chatting/docs/bbmb-message-flow.md).
+[BBMB Message Flow](bbmb-message-flow.md).
 
 ## Topology
 
-- Host A (`UserOne`): `python3 -m app.main_message_handler`
-- Host B (`UserTwo`): `python3 -m app.main_worker`
+- Host A (integration host): `python3 -m app.main_message_handler`
+- Host B (execution host): `python3 -m app.main_worker`
 - Host C (or A/B): `bbmb-server` on `:9876`
 
 All hosts must have network reachability to the BBMB TCP endpoint.
 
-## 1) Configure message-handler (`UserOne`)
+## 1) Start BBMB
+
+```bash
+bbmb-server
+```
+
+If BBMB is listening somewhere else, set `bbmb_address` in both runtime configs.
+
+## 2) Configure message-handler
 
 ```bash
 cp configs/message-handler-runtime.example.json /tmp/message-handler.json
@@ -44,7 +52,7 @@ export CHATTING_MESSAGE_HANDLER_CONFIG_PATH=/tmp/message-handler.json
 python3 -m app.main_message_handler
 ```
 
-## 2) Configure worker (`UserTwo`)
+## 3) Configure worker
 
 ```bash
 cp configs/worker-runtime.example.json /tmp/worker.json
@@ -63,7 +71,7 @@ export CHATTING_WORKER_CONFIG_PATH=/tmp/worker.json
 python3 -m app.main_worker
 ```
 
-## 3) Security boundary expectations
+## 4) Security boundary expectations
 
 - `message-handler` owns integration secrets (`IMAP`, `SMTP`, `Telegram`).
 - `worker` does not read integration secrets and does not dispatch directly.
@@ -72,7 +80,7 @@ python3 -m app.main_worker
   `drop/task` completion marker so `message-handler` can close the task and reject future egress.
 - Egress channel dispatch is allowlist-gated by `allowed_egress_channels`.
 
-## 4) Configure GitHub assignment polling (in message-handler)
+## 5) Configure GitHub assignment polling (in message-handler)
 
 ```bash
 # edit message-handler config: github_repositories (owner/repo or owner/*)
@@ -83,7 +91,7 @@ python3 -m app.main_message_handler --config /tmp/message-handler.json
 
 `gh` CLI must already be authenticated on the message-handler host.
 
-## 5) Run as `systemd` services
+## 6) Run as `systemd` services
 
 Use:
 - `deploy/systemd/chatting-message-handler.service`
@@ -103,7 +111,7 @@ sudo systemctl enable --now chatting-message-handler.service
 sudo systemctl enable --now chatting-worker.service
 ```
 
-## 6) Publish an immediate incremental reply from worker side
+## 7) Publish an immediate incremental reply from worker side
 
 Use the worker-side CLI to push an egress event directly to BBMB without waiting for worker loop completion:
 


### PR DESCRIPTION
## Summary
- refresh the main operator docs around the current split-mode runtime and BBMB startup flow
- remove stale single-process and hardcoded workstation-path references from docs
- rewrite the architecture docs so they describe the current message-handler/worker/BBMB design

## Testing
- python3 -m unittest discover -s tests