### PR TITLE
Add Telegram message reactions

### DIFF
--- a/app/applier/integrated.py
+++ b/app/applier/integrated.py
@@ -32,6 +32,9 @@ class TelegramSender(Protocol):
     def send(self, target: str, body: str) -> None:
         """Send one outbound Telegram message."""
 
+    def react(self, target: str, message_id: int, emoji: str) -> None:
+        """React to one existing Telegram message."""
+
 
 class GitHubSender(Protocol):
     """Dispatch outbound GitHub issue comments."""
@@ -156,6 +159,26 @@ class TelegramMessageSender:
 
         raise RuntimeError("telegram_send_failed")
 
+    def react(self, target: str, message_id: int, emoji: str) -> None:
+        if not target:
+            raise ValueError("target is required")
+        if message_id <= 0:
+            raise ValueError("message_id must be positive")
+        if not emoji.strip():
+            raise ValueError("emoji is required")
+
+        client = self.http_post_json or _default_http_post_json
+        url = f"{self.api_base_url.rstrip('/')}/bot{self.bot_token}/setMessageReaction"
+        payload: dict[str, object] = {
+            "chat_id": target,
+            "message_id": message_id,
+            "reaction": [{"type": "emoji", "emoji": emoji.strip()}],
+        }
+        response = client(url, payload, self.timeout_seconds)
+        if response.get("ok") is True:
+            return
+        raise RuntimeError("telegram_reaction_failed")
+
 
 @dataclass(frozen=True)
 class GitHubIssueCommentSender:
@@ -230,6 +253,7 @@ class IntegratedApplier:
                 channel=dispatch_channel,
                 target=dispatch_target,
                 body=message.body,
+                metadata=dict(message.metadata),
             )
 
             if dispatch_channel == "log":
@@ -311,6 +335,33 @@ class IntegratedApplier:
                     )
                     raise MessageDispatchError(
                         reason_code="github_dispatch_failed",
+                        dispatched_messages=list(dispatched_messages),
+                    ) from None
+                continue
+            if dispatch_channel == "telegram_reaction":
+                if self.telegram_sender is None:
+                    LOGGER.warning(
+                        "drop_dispatch reason=telegram_dispatch_not_configured channel=%s target=%s",
+                        dispatch_channel,
+                        dispatch_target,
+                    )
+                    reason_codes.append("telegram_dispatch_not_configured")
+                    continue
+                try:
+                    self.telegram_sender.react(
+                        dispatch_target,
+                        _resolve_telegram_reaction_message_id(message=message, envelope=envelope),
+                        message.body,
+                    )
+                    dispatched_messages.append(normalized_message)
+                except Exception:  # noqa: BLE001
+                    LOGGER.exception(
+                        "drop_dispatch reason=telegram_dispatch_failed channel=%s target=%s",
+                        dispatch_channel,
+                        dispatch_target,
+                    )
+                    raise MessageDispatchError(
+                        reason_code="telegram_dispatch_failed",
                         dispatched_messages=list(dispatched_messages),
                     ) from None
                 continue
@@ -417,6 +468,21 @@ def _resolve_dispatch_channel_and_target(
     if envelope is None:
         return message.channel, message.target
     return envelope.reply_channel.type, envelope.reply_channel.target
+
+
+def _resolve_telegram_reaction_message_id(
+    *,
+    message: OutboundMessage,
+    envelope: TaskEnvelope | None,
+) -> int:
+    message_id = message.metadata.get("message_id")
+    if isinstance(message_id, int) and message_id > 0:
+        return message_id
+    if envelope is not None:
+        reply_message_id = envelope.reply_channel.metadata.get("message_id")
+        if isinstance(reply_message_id, int) and reply_message_id > 0:
+            return reply_message_id
+    raise ValueError("telegram reaction message_id is required")
 
 
 def _default_http_post_json(

--- a/app/broker/messages.py
+++ b/app/broker/messages.py
@@ -46,6 +46,14 @@ def _parse_sequence(value: object) -> int:
         raise ValueError("sequence must be a non-negative integer")
     return value
 
+
+def _parse_optional_dict(value: object, *, field_name: str) -> dict[str, object]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+    return dict(value)
+
 @dataclass(frozen=True)
 class TaskQueueMessage:
     """Message published by ingress and consumed by worker."""
@@ -135,6 +143,10 @@ class TaskQueueMessage:
                 target=_require_non_empty_string(
                     reply_channel_payload.get("target"),
                     field_name="envelope.reply_channel.target",
+                ),
+                metadata=_parse_optional_dict(
+                    reply_channel_payload.get("metadata"),
+                    field_name="envelope.reply_channel.metadata",
                 ),
             ),
             dedupe_key=_require_non_empty_string(
@@ -252,6 +264,10 @@ class EgressQueueMessage:
                 channel=_require_non_empty_string(message_payload.get("channel"), field_name="message.channel"),
                 target=_require_non_empty_string(message_payload.get("target"), field_name="message.target"),
                 body=_require_non_empty_string(message_payload.get("body"), field_name="message.body"),
+                metadata=_parse_optional_dict(
+                    message_payload.get("metadata"),
+                    field_name="message.metadata",
+                ),
             ),
             emitted_at=_parse_utc_datetime(payload.get("emitted_at"), field_name="emitted_at"),
             event_id=event_id,

--- a/app/connectors/telegram_connector.py
+++ b/app/connectors/telegram_connector.py
@@ -186,6 +186,9 @@ class TelegramConnector:
             return None
 
         event_id = f"telegram:{update_id}"
+        message_id = payload.get("message_id")
+        if not isinstance(message_id, int):
+            return None
         received_at = _parse_message_timestamp(payload.get("date"))
         thread_id = payload.get("message_thread_id")
         content = text.strip()
@@ -201,7 +204,11 @@ class TelegramConnector:
             attachments=[],
             context_refs=self._context_refs,
             policy_profile=self._policy_profile,
-            reply_channel=ReplyChannel(type="telegram", target=chat_id_value),
+            reply_channel=ReplyChannel(
+                type="telegram",
+                target=chat_id_value,
+                metadata={"message_id": message_id},
+            ),
             dedupe_key=event_id,
         )
 

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -652,7 +652,7 @@ def _resolve_allowed_egress_channels(args: argparse.Namespace, config: dict[str,
 
     merged = [*config_values, *args.allowed_egress_channel]
     if not merged:
-        return {"email", "telegram", "log"}
+        return {"email", "telegram", "telegram_reaction", "log"}
     if any(not item.strip() for item in merged):
         raise ValueError("allowed_egress_channel entries must not be empty")
     return set(merged)

--- a/app/main_reply.py
+++ b/app/main_reply.py
@@ -10,6 +10,7 @@ import time
 from datetime import datetime, timezone
 
 from app.broker import BBMBQueueAdapter, EGRESS_QUEUE_NAME, EgressQueueMessage
+from app.message_handler_runtime import TaskLedgerStore
 from app.main_worker import WORKER_CONFIG_PATH_ENV_VAR, _load_config, _resolve_str
 from app.models import OutboundMessage
 
@@ -17,9 +18,11 @@ from app.models import OutboundMessage
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Publish one immediate incremental reply message.")
     parser.add_argument("task_id", help="Task identifier (for example: task:email:53).")
-    parser.add_argument("--message", required=True, help="Reply body text.")
+    parser.add_argument("--message", help="Reply body text.")
     parser.add_argument("--channel", required=True, help="Outbound channel (for example: email, telegram, github).")
     parser.add_argument("--target", required=True, help="Outbound channel target.")
+    parser.add_argument("--telegram-reaction", help="React to the Telegram source message instead of sending a text message.")
+    parser.add_argument("--telegram-message-id", type=int, help="Telegram message id to react to.")
     parser.add_argument("--event-id", help="Optional stable event id for idempotency.")
     parser.add_argument("--envelope-id", help="Envelope id (defaults to task_id without 'task:' prefix).")
     parser.add_argument("--trace-id", help="Trace id (defaults to trace:<envelope_id>).")
@@ -60,6 +63,64 @@ def _resolve_event_id(task_id: str, explicit_value: str | None) -> str:
     return f"evt:{task_id}:adhoc:{time.time_ns()}"
 
 
+def _resolve_telegram_message_id(
+    *,
+    task_id: str,
+    explicit_value: int | None,
+    config: dict[str, object],
+) -> int:
+    if explicit_value is not None:
+        if explicit_value <= 0:
+            raise ValueError("telegram_message_id must be positive")
+        return explicit_value
+
+    db_path = _resolve_str(
+        None,
+        config.get("db_path"),
+        default_value="",
+        setting_name="db_path",
+    ).strip()
+    if not db_path:
+        raise ValueError("telegram_message_id is required")
+
+    ledger_record = TaskLedgerStore(db_path).get_task(task_id)
+    if ledger_record is None:
+        raise ValueError("telegram_message_id is required")
+
+    message_id = ledger_record.task_message.envelope.reply_channel.metadata.get("message_id")
+    if isinstance(message_id, int) and message_id > 0:
+        return message_id
+
+    raise ValueError("telegram_message_id is required")
+
+
+def _resolve_reply_message(args: argparse.Namespace, config: dict[str, object]) -> OutboundMessage:
+    if args.telegram_reaction is not None:
+        if args.channel != "telegram":
+            raise ValueError("telegram reactions require --channel telegram")
+        emoji = args.telegram_reaction.strip()
+        if not emoji:
+            raise ValueError("telegram_reaction must not be empty")
+        message_id = _resolve_telegram_message_id(
+            task_id=args.task_id,
+            explicit_value=args.telegram_message_id,
+            config=config,
+        )
+        return OutboundMessage(
+            channel="telegram_reaction",
+            target=args.target,
+            body=emoji,
+            metadata={"message_id": message_id},
+        )
+
+    if args.message is None:
+        raise ValueError("message must not be empty")
+    body = args.message.strip()
+    if not body:
+        raise ValueError("message must not be empty")
+    return OutboundMessage(channel=args.channel, target=args.target, body=body)
+
+
 def main() -> int:
     args = _parse_args()
     config = _load_config(args.config, os.environ)
@@ -75,9 +136,7 @@ def main() -> int:
     trace_id = _resolve_trace_id(envelope_id, args.trace_id)
     event_id = _resolve_event_id(args.task_id, args.event_id)
 
-    body = args.message.strip()
-    if not body:
-        raise ValueError("message must not be empty")
+    outbound_message = _resolve_reply_message(args, config)
 
     egress_message = EgressQueueMessage(
         task_id=args.task_id,
@@ -85,7 +144,7 @@ def main() -> int:
         trace_id=trace_id,
         event_index=0,
         event_count=1,
-        message=OutboundMessage(channel=args.channel, target=args.target, body=body),
+        message=outbound_message,
         emitted_at=datetime.now(timezone.utc),
         event_id=event_id,
         sequence=None,

--- a/app/models.py
+++ b/app/models.py
@@ -49,6 +49,14 @@ def _validate_context_refs(values: list[str]) -> None:
             raise ValueError("context_refs items must be non-empty strings")
 
 
+def _validate_metadata_dict(values: dict[str, Any], *, field_name: str) -> None:
+    if not isinstance(values, dict):
+        raise ValueError(f"{field_name} must be a dict")
+    for key in values:
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+
+
 def _validate_attachments(values: list["AttachmentRef"]) -> None:
     if not isinstance(values, list):
         raise ValueError("attachments must be a list")
@@ -76,10 +84,12 @@ class ReplyChannel:
 
     type: str
     target: str
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         _validate_required_string(self.type, field_name="type")
         _validate_required_string(self.target, field_name="target")
+        _validate_metadata_dict(self.metadata, field_name="metadata")
 
 
 @dataclass(frozen=True)
@@ -126,7 +136,7 @@ class TaskEnvelope:
             raise ValueError("received_at must be timezone-aware")
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "schema_version": self.schema_version,
             "id": self.id,
             "source": self.source,
@@ -145,6 +155,9 @@ class TaskEnvelope:
             },
             "dedupe_key": self.dedupe_key,
         }
+        if self.reply_channel.metadata:
+            payload["reply_channel"]["metadata"] = self.reply_channel.metadata
+        return payload
 
 
 @dataclass(frozen=True)
@@ -212,6 +225,8 @@ class RoutedTask:
                 "type": self.reply_channel.type,
                 "target": self.reply_channel.target,
             }
+            if self.reply_channel.metadata:
+                payload["reply_channel"]["metadata"] = self.reply_channel.metadata
         return payload
 
 
@@ -222,18 +237,23 @@ class OutboundMessage:
     channel: str
     target: str
     body: str
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         _validate_required_string(self.channel, field_name="channel")
         _validate_required_string(self.target, field_name="target")
         _validate_required_string(self.body, field_name="body")
+        _validate_metadata_dict(self.metadata, field_name="metadata")
 
-    def to_dict(self) -> dict[str, str]:
-        return {
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
             "channel": self.channel,
             "target": self.target,
             "body": self.body,
         }
+        if self.metadata:
+            payload["metadata"] = self.metadata
+        return payload
 
 
 @dataclass(frozen=True)

--- a/app/state/sqlite_store.py
+++ b/app/state/sqlite_store.py
@@ -964,6 +964,9 @@ def _task_envelope_from_dict(payload: dict[str, object]) -> TaskEnvelope:
         reply_channel=ReplyChannel(
             type=str(reply_channel["type"]),
             target=str(reply_channel["target"]),
+            metadata=dict(reply_channel.get("metadata", {}))
+            if isinstance(reply_channel.get("metadata"), dict)
+            else {},
         ),
         dedupe_key=str(payload["dedupe_key"]),
         schema_version=str(payload.get("schema_version", "1.0")),

--- a/app/worker_runtime.py
+++ b/app/worker_runtime.py
@@ -348,6 +348,7 @@ def _normalize_message_for_egress(*, message: OutboundMessage, task_message: Tas
         channel=task_message.envelope.reply_channel.type,
         target=task_message.envelope.reply_channel.target,
         body=message.body,
+        metadata=dict(message.metadata),
     )
 
 

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -23,6 +23,7 @@ Matching CLI flags exist (`--telegram-enabled`, `--telegram-bot-token-env`, etc.
 - `source`: `im`
 - `id` / `dedupe_key`: `telegram:<update_id>`
 - `reply_channel`: `telegram:<chat_id>`
+- `reply_channel.metadata.message_id`: original Telegram `message_id` for native reactions
 - `actor`: `<user_id>:<username>` when available
 - `content`: text body (thread id is prefixed when present)
 

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -126,3 +126,14 @@ Notes:
 - `message_type` is `chatting.egress.v2` with `event_kind=incremental`.
 - These ad-hoc events are intentionally unsequenced and dispatch immediately at message-handler.
 - `--event-id` can be supplied for stable idempotency across retries.
+- Telegram reactions use the same CLI, but publish `telegram_reaction` egress under the hood:
+
+```bash
+python3 -m app.main_reply task:telegram:53 \
+  --channel telegram \
+  --target 8605042448 \
+  --telegram-reaction "👍" \
+  --config /tmp/worker.json
+```
+
+- If `--telegram-message-id` is omitted, `app.main_reply` looks up the inbound Telegram `message_id` from the task ledger in `db_path`.

--- a/tests/test_applier.py
+++ b/tests/test_applier.py
@@ -1,5 +1,5 @@
 import unittest
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from email.message import EmailMessage
 from pathlib import Path
@@ -196,6 +196,40 @@ class IntegratedApplierTests(unittest.TestCase):
             self.assertEqual(
                 [message.channel for message in result.dispatched_messages],
                 ["telegram"],
+            )
+            self.assertEqual(result.reason_codes, [])
+
+    def test_apply_dispatches_telegram_reaction_with_sender(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            sender = _RecordingTelegramSender(sent=[])
+            decision = PolicyDecision(
+                approved_actions=[],
+                blocked_actions=[],
+                approved_messages=[
+                    OutboundMessage(
+                        channel="telegram_reaction",
+                        target="12345",
+                        body="👍",
+                        metadata={"message_id": 321},
+                    )
+                ],
+                config_updates=ConfigUpdateDecision(),
+                reason_codes=[],
+            )
+
+            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+
+            self.assertEqual(sender.reactions, [("12345", 321, "👍")])
+            self.assertEqual(
+                result.dispatched_messages,
+                [
+                    OutboundMessage(
+                        channel="telegram_reaction",
+                        target="12345",
+                        body="👍",
+                        metadata={"message_id": 321},
+                    )
+                ],
             )
             self.assertEqual(result.reason_codes, [])
 
@@ -505,6 +539,39 @@ class TelegramMessageSenderTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "telegram_send_failed"):
             sender.send("12345", "hello")
 
+    def test_react_posts_set_message_reaction_request(self) -> None:
+        seen_calls: list[tuple[str, dict[str, object], float]] = []
+
+        def fake_http_post_json(
+            url: str,
+            payload: dict[str, object],
+            timeout: float,
+        ) -> dict[str, object]:
+            seen_calls.append((url, payload, timeout))
+            return {"ok": True, "result": True}
+
+        sender = TelegramMessageSender(
+            bot_token="token",
+            http_post_json=fake_http_post_json,
+        )
+
+        sender.react("12345", 99, "👍")
+
+        self.assertEqual(
+            seen_calls,
+            [
+                (
+                    "https://api.telegram.org/bottoken/setMessageReaction",
+                    {
+                        "chat_id": "12345",
+                        "message_id": 99,
+                        "reaction": [{"type": "emoji", "emoji": "👍"}],
+                    },
+                    10.0,
+                )
+            ],
+        )
+
 
 class GitHubIssueCommentSenderTests(unittest.TestCase):
     def test_send_uses_gh_cli_for_issue_url_target(self) -> None:
@@ -576,9 +643,13 @@ class _FakeSmtpClient:
 @dataclass
 class _RecordingTelegramSender:
     sent: list[tuple[str, str]]
+    reactions: list[tuple[str, int, str]] = field(default_factory=list)
 
     def send(self, target: str, body: str) -> None:
         self.sent.append((target, body))
+
+    def react(self, target: str, message_id: int, emoji: str) -> None:
+        self.reactions.append((target, message_id, emoji))
 
 
 class _FailingTelegramSender:

--- a/tests/test_broker_messages.py
+++ b/tests/test_broker_messages.py
@@ -16,7 +16,11 @@ class TaskQueueMessageTests(unittest.TestCase):
             attachments=[AttachmentRef(uri="file://inbox/msg1.txt", name="msg1.txt")],
             context_refs=["repo:/home/edward/develop/chatting"],
             policy_profile="default",
-            reply_channel=ReplyChannel(type="email", target="alice@example.com"),
+            reply_channel=ReplyChannel(
+                type="email",
+                target="alice@example.com",
+                metadata={"thread_id": "abc"},
+            ),
             dedupe_key="email:1",
         )
 
@@ -27,6 +31,7 @@ class TaskQueueMessageTests(unittest.TestCase):
         self.assertEqual(parsed.task_id, "task:email:1")
         self.assertEqual(parsed.envelope.id, envelope.id)
         self.assertEqual(parsed.envelope.attachments[0].uri, "file://inbox/msg1.txt")
+        self.assertEqual(parsed.envelope.reply_channel.metadata, {"thread_id": "abc"})
 
     def test_task_message_rejects_wrong_type(self) -> None:
         with self.assertRaises(ValueError):
@@ -41,7 +46,12 @@ class EgressQueueMessageTests(unittest.TestCase):
             trace_id="trace:email:1",
             event_index=0,
             event_count=2,
-            message=OutboundMessage(channel="email", target="alice@example.com", body="hello"),
+            message=OutboundMessage(
+                channel="email",
+                target="alice@example.com",
+                body="hello",
+                metadata={"thread_id": "abc"},
+            ),
             emitted_at=datetime(2026, 3, 6, 11, 1, tzinfo=timezone.utc),
             event_id="evt:task:email:1:0",
             sequence=0,
@@ -58,6 +68,7 @@ class EgressQueueMessageTests(unittest.TestCase):
         self.assertEqual(parsed.sequence, 0)
         self.assertEqual(parsed.event_kind, "final")
         self.assertEqual(parsed.message.target, "alice@example.com")
+        self.assertEqual(parsed.message.metadata, {"thread_id": "abc"})
 
     def test_egress_v2_message_round_trip(self) -> None:
         message = EgressQueueMessage(

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -473,6 +473,7 @@ class TelegramConnectorTests(unittest.TestCase):
         self.assertEqual(envelope.actor, "77:alice")
         self.assertEqual(envelope.reply_channel.type, "telegram")
         self.assertEqual(envelope.reply_channel.target, "12345")
+        self.assertEqual(envelope.reply_channel.metadata, {"message_id": 1})
         self.assertEqual(envelope.content, "hello from telegram")
         self.assertEqual(envelope.context_refs, ["repo:/home/edward/chatting"])
         self.assertEqual(second_poll, [])
@@ -570,6 +571,7 @@ class TelegramConnectorTests(unittest.TestCase):
         self.assertEqual(envelope.id, "telegram:3001")
         self.assertEqual(envelope.reply_channel.type, "telegram")
         self.assertEqual(envelope.reply_channel.target, "-100123")
+        self.assertEqual(envelope.reply_channel.metadata, {"message_id": 1})
         self.assertEqual(envelope.actor, "-100123:release-feed")
         self.assertEqual(envelope.content, "deploy completed")
 

--- a/tests/test_main_reply.py
+++ b/tests/test_main_reply.py
@@ -2,10 +2,14 @@ import io
 import json
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
+from app.broker import TaskQueueMessage
 from app.main_reply import main
+from app.message_handler_runtime import TaskLedgerStore
+from app.models import ReplyChannel, TaskEnvelope
 
 
 class _FakeBroker:
@@ -112,6 +116,83 @@ class MainReplyCliTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(ValueError, "envelope_id is required"):
                 main()
+
+    def test_main_reply_publishes_telegram_reaction_using_explicit_message_id(self) -> None:
+        broker = _FakeBroker("127.0.0.1:9876")
+        with (
+            patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+            patch(
+                "sys.argv",
+                [
+                    "main_reply.py",
+                    "task:telegram:53",
+                    "--channel",
+                    "telegram",
+                    "--target",
+                    "8605042448",
+                    "--telegram-reaction",
+                    "👍",
+                    "--telegram-message-id",
+                    "123",
+                ],
+            ),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        _, payload = broker.published[0]
+        self.assertEqual(payload["message"]["channel"], "telegram_reaction")
+        self.assertEqual(payload["message"]["body"], "👍")
+        self.assertEqual(payload["message"]["metadata"], {"message_id": 123})
+
+    def test_main_reply_publishes_telegram_reaction_using_task_ledger_message_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            config_path = Path(tmpdir) / "worker.json"
+            config_path.write_text(json.dumps({"db_path": str(db_path)}), encoding="utf-8")
+            ledger = TaskLedgerStore(str(db_path))
+            envelope = TaskEnvelope(
+                id="telegram:53",
+                source="im",
+                received_at=datetime(2026, 3, 10, 12, 0, tzinfo=timezone.utc),
+                actor="8605042448:edsalkeld",
+                content="hello",
+                attachments=[],
+                context_refs=[],
+                policy_profile="default",
+                reply_channel=ReplyChannel(
+                    type="telegram",
+                    target="8605042448",
+                    metadata={"message_id": 456},
+                ),
+                dedupe_key="telegram:53",
+            )
+            ledger.record_task(TaskQueueMessage.from_envelope(envelope, trace_id="trace:telegram:53"))
+
+            broker = _FakeBroker("127.0.0.1:9876")
+            with (
+                patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+                patch(
+                    "sys.argv",
+                    [
+                        "main_reply.py",
+                        "task:telegram:53",
+                        "--channel",
+                        "telegram",
+                        "--target",
+                        "8605042448",
+                        "--telegram-reaction",
+                        "👍",
+                        "--config",
+                        str(config_path),
+                    ],
+                ),
+            ):
+                exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        _, payload = broker.published[0]
+        self.assertEqual(payload["message"]["metadata"], {"message_id": 456})
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -142,6 +142,24 @@ class ExecutionResultTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "body is required"):
             OutboundMessage(channel="email", target="alice@example.com", body="")
 
+    def test_outbound_message_serializes_metadata_when_present(self) -> None:
+        message = OutboundMessage(
+            channel="telegram_reaction",
+            target="8605042448",
+            body="👍",
+            metadata={"message_id": 12},
+        )
+
+        self.assertEqual(
+            message.to_dict(),
+            {
+                "channel": "telegram_reaction",
+                "target": "8605042448",
+                "body": "👍",
+                "metadata": {"message_id": 12},
+            },
+        )
+
 
 class PolicyDecisionTests(unittest.TestCase):
     def test_policy_decision_serializes_expected_shape(self) -> None:


### PR DESCRIPTION
## Summary
- preserve inbound Telegram message ids in reply-channel metadata
- add `app.main_reply --telegram-reaction` and a dedicated Telegram reaction egress path
- document and test the reaction flow in split mode

## Testing
- python3 -m unittest discover -s tests