### PR TITLE
Add Telegram image ingress attachments

### DIFF
--- a/app/connectors/telegram_connector.py
+++ b/app/connectors/telegram_connector.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import json
 import logging
+import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Callable
 
-from app.models import ReplyChannel, TaskEnvelope
+from app.models import AttachmentRef, ReplyChannel, TaskEnvelope
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +24,13 @@ class TelegramGetUpdatesResponse:
 
     ok: bool
     result: list[dict[str, object]]
+
+
+@dataclass(frozen=True)
+class TelegramFileMetadata:
+    """Resolved Telegram file metadata used for attachment downloads."""
+
+    file_path: str
 
 
 class TelegramConnector:
@@ -39,8 +48,11 @@ class TelegramConnector:
         allowed_channel_ids: list[str] | None = None,
         context_refs: list[str] | None = None,
         policy_profile: str = "default",
+        attachment_root_dir: str | None = None,
         request_timeout_seconds: float = 30.0,
         http_get_json: Callable[[str, float], TelegramGetUpdatesResponse] | None = None,
+        resolve_file_metadata: Callable[[str, float], TelegramFileMetadata] | None = None,
+        download_file_bytes: Callable[[str, float], bytes] | None = None,
     ) -> None:
         if not bot_token:
             raise ValueError("bot_token is required")
@@ -71,8 +83,13 @@ class TelegramConnector:
         self._allowed_channel_ids = set(allowed_channel_ids or [])
         self._context_refs = list(context_refs or [])
         self._policy_profile = policy_profile
+        self._attachment_root_dir = Path(
+            attachment_root_dir or Path(tempfile.gettempdir()) / "chatting-telegram-attachments"
+        )
         self._request_timeout_seconds = request_timeout_seconds
         self._http_get_json = http_get_json or _default_http_get_json
+        self._resolve_file_metadata = resolve_file_metadata or _default_resolve_file_metadata
+        self._download_file_bytes = download_file_bytes or _default_download_file_bytes
         self._next_offset: int | None = None
 
     def poll(self) -> list[TaskEnvelope]:
@@ -181,14 +198,16 @@ class TelegramConnector:
         chat_id_value: str,
         actor: str | None,
     ) -> TaskEnvelope | None:
-        text = payload.get("text")
-        if not isinstance(text, str) or not text.strip():
+        message_id = payload.get("message_id")
+        if not isinstance(message_id, int):
             return None
-
+        attachments = self._extract_attachments(update_id=update_id, message_id=message_id, payload=payload)
+        content = _extract_content(payload, fallback_for_attachments=bool(attachments))
+        if content is None:
+            return None
         event_id = f"telegram:{update_id}"
         received_at = _parse_message_timestamp(payload.get("date"))
         thread_id = payload.get("message_thread_id")
-        content = text.strip()
         if isinstance(thread_id, int):
             content = f"[thread_id={thread_id}] {content}"
 
@@ -198,12 +217,66 @@ class TelegramConnector:
             received_at=received_at,
             actor=actor,
             content=content,
-            attachments=[],
+            attachments=attachments,
             context_refs=self._context_refs,
             policy_profile=self._policy_profile,
             reply_channel=ReplyChannel(type="telegram", target=chat_id_value),
             dedupe_key=event_id,
         )
+
+    def _extract_attachments(
+        self,
+        *,
+        update_id: int,
+        message_id: int,
+        payload: dict[str, object],
+    ) -> list[AttachmentRef]:
+        raw_photos = payload.get("photo")
+        if not isinstance(raw_photos, list):
+            return []
+        selected_photo = _select_best_photo(raw_photos)
+        if selected_photo is None:
+            return []
+        return [
+            self._download_photo_attachment(
+                update_id=update_id,
+                message_id=message_id,
+                photo=selected_photo,
+            )
+        ]
+
+    def _download_photo_attachment(
+        self,
+        *,
+        update_id: int,
+        message_id: int,
+        photo: dict[str, object],
+    ) -> AttachmentRef:
+        file_id = photo.get("file_id")
+        if not isinstance(file_id, str) or not file_id.strip():
+            raise RuntimeError("telegram_photo_missing_file_id")
+        metadata = self._resolve_file_metadata(
+            self._build_get_file_url(file_id),
+            self._request_timeout_seconds,
+        )
+        suffix = Path(metadata.file_path).suffix or ".jpg"
+        file_unique_id = photo.get("file_unique_id")
+        unique_fragment = file_unique_id if isinstance(file_unique_id, str) and file_unique_id.strip() else file_id
+        safe_unique_fragment = _safe_path_fragment(unique_fragment)
+        local_name = f"telegram-{update_id}-{message_id}-{safe_unique_fragment}{suffix}"
+        destination = self._attachment_root_dir / local_name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        file_url = self._build_file_download_url(metadata.file_path)
+        destination.write_bytes(self._download_file_bytes(file_url, self._request_timeout_seconds))
+        return AttachmentRef(uri=destination.resolve().as_uri(), name=Path(metadata.file_path).name)
+
+    def _build_get_file_url(self, file_id: str) -> str:
+        query = urllib.parse.urlencode({"file_id": file_id})
+        return f"{self._api_base_url}/bot{self._bot_token}/getFile?{query}"
+
+    def _build_file_download_url(self, file_path: str) -> str:
+        quoted_path = urllib.parse.quote(file_path)
+        return f"{self._api_base_url}/file/bot{self._bot_token}/{quoted_path}"
 
 
 def _extract_chat_id(chat: dict[str, object]) -> str | None:
@@ -225,6 +298,45 @@ def _extract_actor(raw_sender: object) -> str | None:
     if isinstance(sender_id, int):
         return str(sender_id)
     return None
+
+
+def _extract_content(
+    payload: dict[str, object],
+    *,
+    fallback_for_attachments: bool,
+) -> str | None:
+    for field_name in ("text", "caption"):
+        raw_value = payload.get(field_name)
+        if isinstance(raw_value, str) and raw_value.strip():
+            return raw_value.strip()
+    if fallback_for_attachments:
+        return "[photo attached]"
+    return None
+
+
+def _select_best_photo(raw_photos: list[object]) -> dict[str, object] | None:
+    best_photo: dict[str, object] | None = None
+    best_sort_key = (-1, -1, -1)
+    for raw_photo in raw_photos:
+        if not isinstance(raw_photo, dict):
+            continue
+        file_size = raw_photo.get("file_size")
+        width = raw_photo.get("width")
+        height = raw_photo.get("height")
+        sort_key = (
+            file_size if isinstance(file_size, int) else -1,
+            width if isinstance(width, int) else -1,
+            height if isinstance(height, int) else -1,
+        )
+        if sort_key > best_sort_key:
+            best_photo = raw_photo
+            best_sort_key = sort_key
+    return best_photo
+
+
+def _safe_path_fragment(value: str) -> str:
+    sanitized = "".join(character if character.isalnum() or character in {"-", "_"} else "_" for character in value)
+    return sanitized or "attachment"
 
 
 def _extract_sender_chat_actor(raw_sender_chat: object) -> str | None:
@@ -271,4 +383,35 @@ def _default_http_get_json(url: str, timeout_seconds: float) -> TelegramGetUpdat
     return TelegramGetUpdatesResponse(ok=ok, result=result)
 
 
-__all__ = ["TelegramConnector", "TelegramGetUpdatesResponse"]
+def _default_resolve_file_metadata(url: str, timeout_seconds: float) -> TelegramFileMetadata:
+    request = urllib.request.Request(url=url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.URLError as error:
+        raise RuntimeError("telegram_http_error") from error
+    except json.JSONDecodeError as error:
+        raise RuntimeError("telegram_invalid_json") from error
+
+    if not isinstance(payload, dict):
+        raise RuntimeError("telegram_invalid_response_shape")
+    ok = payload.get("ok")
+    result = payload.get("result")
+    if ok is not True or not isinstance(result, dict):
+        raise RuntimeError("telegram_invalid_response_shape")
+    file_path = result.get("file_path")
+    if not isinstance(file_path, str) or not file_path.strip():
+        raise RuntimeError("telegram_file_path_missing")
+    return TelegramFileMetadata(file_path=file_path)
+
+
+def _default_download_file_bytes(url: str, timeout_seconds: float) -> bytes:
+    request = urllib.request.Request(url=url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return response.read()
+    except urllib.error.URLError as error:
+        raise RuntimeError("telegram_http_error") from error
+
+
+__all__ = ["TelegramConnector", "TelegramFileMetadata", "TelegramGetUpdatesResponse"]

--- a/app/main.py
+++ b/app/main.py
@@ -62,6 +62,7 @@ ALLOWED_RUNTIME_CONFIG_KEYS = frozenset(
         "smtp_username",
         "telegram_allowed_chat_ids",
         "telegram_allowed_channel_ids",
+        "telegram_attachment_dir",
         "telegram_api_base_url",
         "telegram_bot_token_env",
         "telegram_context_refs",
@@ -876,6 +877,7 @@ def _build_live_connectors(args: argparse.Namespace, config: dict[str, object]) 
                 allowed_chat_ids=_resolve_telegram_allowed_chat_ids(args, config),
                 allowed_channel_ids=_resolve_telegram_allowed_channel_ids(args, config),
                 context_refs=telegram_context_refs,
+                attachment_root_dir=_resolve_telegram_attachment_dir(args, config),
             )
         )
 
@@ -1303,6 +1305,18 @@ def _resolve_telegram_context_refs(
     if any(not value.strip() for value in merged_values):
         raise ValueError("telegram_context_ref(s) entries must not be empty")
     return merged_values
+
+
+def _resolve_telegram_attachment_dir(
+    args: argparse.Namespace,
+    config: dict[str, object],
+) -> str:
+    return _resolve_str(
+        cli_value=getattr(args, "telegram_attachment_dir", None),
+        config_value=config.get("telegram_attachment_dir"),
+        default_value=str(Path(tempfile.gettempdir()) / "chatting-telegram-attachments"),
+        setting_name="telegram_attachment_dir",
+    )
 
 
 def _resolve_telegram_allowed_channel_ids(

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -77,6 +77,7 @@ _ALLOWED_CONFIG_KEYS = frozenset(
         "telegram_poll_timeout_seconds",
         "telegram_allowed_chat_ids",
         "telegram_allowed_channel_ids",
+        "telegram_attachment_dir",
         "telegram_context_refs",
         "github_repositories",
         "github_assignee_login",
@@ -533,6 +534,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--telegram-api-base-url", help="Telegram API base URL.")
     parser.add_argument("--telegram-poll-timeout-seconds", type=_positive_int, help="Telegram poll timeout.")
     parser.add_argument(
+        "--telegram-attachment-dir",
+        help="Local directory for downloaded Telegram photo attachments.",
+    )
+    parser.add_argument(
         "--telegram-allowed-chat-id",
         action="append",
         default=[],
@@ -819,6 +824,7 @@ def _build_live_connectors_fail_open(
                 "telegram_bot_token_env",
                 "telegram_api_base_url",
                 "telegram_poll_timeout_seconds",
+                "telegram_attachment_dir",
                 "telegram_allowed_chat_id",
                 "telegram_allowed_channel_id",
                 "telegram_context_ref",
@@ -829,6 +835,7 @@ def _build_live_connectors_fail_open(
                 "telegram_bot_token_env",
                 "telegram_api_base_url",
                 "telegram_poll_timeout_seconds",
+                "telegram_attachment_dir",
                 "telegram_allowed_chat_ids",
                 "telegram_allowed_channel_ids",
                 "telegram_context_refs",
@@ -870,6 +877,7 @@ def _build_live_connectors_fail_open(
             "telegram_bot_token_env": None,
             "telegram_api_base_url": None,
             "telegram_poll_timeout_seconds": None,
+            "telegram_attachment_dir": None,
             "telegram_allowed_chat_id": [],
             "telegram_allowed_channel_id": [],
             "telegram_context_ref": [],

--- a/app/models.py
+++ b/app/models.py
@@ -161,6 +161,7 @@ class RoutedTask:
     source: Literal["cron", "email", "im", "webhook", "internal"] | None = None
     actor: str | None = None
     content: str | None = None
+    attachments: list[AttachmentRef] = field(default_factory=list)
     reply_channel: ReplyChannel | None = None
     schema_version: str = SCHEMA_VERSION
 
@@ -180,6 +181,7 @@ class RoutedTask:
             _validate_required_string(self.actor, field_name="actor")
         if self.content is not None:
             _validate_required_string(self.content, field_name="content")
+        _validate_attachments(self.attachments)
         if self.reply_channel is not None:
             _validate_required_string(self.reply_channel.type, field_name="reply_channel.type")
             _validate_required_string(self.reply_channel.target, field_name="reply_channel.target")
@@ -207,6 +209,11 @@ class RoutedTask:
             payload["actor"] = self.actor
         if self.content is not None:
             payload["content"] = self.content
+        if self.attachments:
+            payload["attachments"] = [
+                {"uri": item.uri, "name": item.name}
+                for item in self.attachments
+            ]
         if self.reply_channel is not None:
             payload["reply_channel"] = {
                 "type": self.reply_channel.type,

--- a/app/router/rule_based.py
+++ b/app/router/rule_based.py
@@ -44,6 +44,7 @@ class RuleBasedRouter:
             source=envelope.source,
             actor=envelope.actor,
             content=envelope.content,
+            attachments=envelope.attachments,
             reply_channel=envelope.reply_channel,
         )
 

--- a/app/state/sqlite_store.py
+++ b/app/state/sqlite_store.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from app.broker import EgressQueueMessage
 from app.models import (
+    AttachmentRef,
     AuditEvent,
     ConfigVersionRecord,
     DeadLetterRecord,
@@ -951,14 +952,28 @@ def _task_envelope_from_dict(payload: dict[str, object]) -> TaskEnvelope:
     raw_context_refs = payload.get("context_refs", [])
     if not isinstance(raw_context_refs, list):
         raise ValueError("invalid dead letter envelope payload")
+    raw_attachments = payload.get("attachments", [])
+    if not isinstance(raw_attachments, list):
+        raise ValueError("invalid dead letter envelope payload")
     context_refs = [str(value) for value in raw_context_refs]
+    attachments: list[AttachmentRef] = []
+    for raw_attachment in raw_attachments:
+        if not isinstance(raw_attachment, dict):
+            raise ValueError("invalid dead letter envelope payload")
+        uri = raw_attachment.get("uri")
+        if not isinstance(uri, str) or not uri.strip():
+            raise ValueError("invalid dead letter envelope payload")
+        name = raw_attachment.get("name")
+        if name is not None and not isinstance(name, str):
+            raise ValueError("invalid dead letter envelope payload")
+        attachments.append(AttachmentRef(uri=uri, name=name))
     return TaskEnvelope(
         id=str(payload["id"]),
         source=str(payload["source"]),
         received_at=_parse_rfc3339_utc(str(payload["received_at"])),
         actor=payload.get("actor") if isinstance(payload.get("actor"), str) else None,
         content=str(payload["content"]),
-        attachments=[],
+        attachments=attachments,
         context_refs=context_refs,
         policy_profile=str(payload["policy_profile"]),
         reply_channel=ReplyChannel(

--- a/configs/message-handler-runtime.example.json
+++ b/configs/message-handler-runtime.example.json
@@ -24,6 +24,7 @@
   "telegram_bot_token_env": "CHATTING_TELEGRAM_BOT_TOKEN",
   "telegram_api_base_url": "https://api.telegram.org",
   "telegram_poll_timeout_seconds": 20,
+  "telegram_attachment_dir": "/var/lib/chatting/telegram-attachments",
   "telegram_allowed_chat_ids": ["123456789"],
   "telegram_allowed_channel_ids": ["-1001234567890"],
   "telegram_context_refs": ["repo:/home/edward/chatting"],

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -12,6 +12,7 @@ Long-poll Telegram Bot API `getUpdates` and normalize DM/group `message` updates
 - `telegram_bot_token_env` (default `CHATTING_TELEGRAM_BOT_TOKEN`)
 - `telegram_api_base_url` (default `https://api.telegram.org`)
 - `telegram_poll_timeout_seconds` (default `20`)
+- `telegram_attachment_dir` (optional local directory for downloaded photo attachments; defaults to a temp-dir path if omitted)
 - `telegram_allowed_chat_ids` (optional list)
 - `telegram_allowed_channel_ids` (optional list, required to ingest `channel_post`)
 - `telegram_context_refs` (optional list)
@@ -24,12 +25,14 @@ Matching CLI flags exist (`--telegram-enabled`, `--telegram-bot-token-env`, etc.
 - `id` / `dedupe_key`: `telegram:<update_id>`
 - `reply_channel`: `telegram:<chat_id>`
 - `actor`: `<user_id>:<username>` when available
-- `content`: text body (thread id is prefixed when present)
+- `content`: text body or photo caption (thread id is prefixed when present)
+- `attachments`: downloaded photo stored as a local `file://` attachment when the update contains a photo
 
 ## Notes
 
 - Unsupported update types are skipped.
-- Empty text messages are skipped.
+- Photo-only messages are accepted with synthesized content `[photo attached]`.
 - `channel_post` updates are ignored unless the channel ID is present in `telegram_allowed_channel_ids`.
 - Ignored `channel_post` updates log `update_id`, `channel_id`, and an explicit reason so new channel IDs can be copied from logs.
 - Offset is advanced as `highest_update_id + 1` each poll.
+- In production, point `telegram_attachment_dir` at durable storage so Codex can still access files after ingress has completed.

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -13,6 +13,7 @@ from app.connectors.interval_schedule_connector import (
     IntervalScheduleJob,
 )
 from app.connectors.telegram_connector import (
+    TelegramFileMetadata,
     TelegramConnector,
     TelegramGetUpdatesResponse,
 )
@@ -616,6 +617,87 @@ class TelegramConnectorTests(unittest.TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "telegram_get_updates_failed"):
             connector.poll()
+
+    def test_poll_downloads_photo_attachment_and_uses_caption_as_content(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            connector = TelegramConnector(
+                bot_token="token",
+                attachment_root_dir=tmpdir,
+                http_get_json=lambda _url, _timeout: TelegramGetUpdatesResponse(
+                    ok=True,
+                    result=[
+                        {
+                            "update_id": 4001,
+                            "message": {
+                                "message_id": 10,
+                                "date": 1772272800,
+                                "caption": "what is this plant?",
+                                "chat": {"id": 12345},
+                                "photo": [
+                                    {
+                                        "file_id": "small",
+                                        "file_unique_id": "u-small",
+                                        "width": 90,
+                                        "height": 90,
+                                        "file_size": 1200,
+                                    },
+                                    {
+                                        "file_id": "large",
+                                        "file_unique_id": "u-large",
+                                        "width": 1280,
+                                        "height": 960,
+                                        "file_size": 450000,
+                                    },
+                                ],
+                            },
+                        }
+                    ],
+                ),
+                resolve_file_metadata=lambda url, _timeout: (
+                    self.assertIn("file_id=large", url) or TelegramFileMetadata(file_path="photos/leaf.jpg")
+                ),
+                download_file_bytes=lambda url, _timeout: (
+                    self.assertIn("/file/bottoken/photos/leaf.jpg", url) or b"jpeg-bytes"
+                ),
+            )
+
+            envelopes = connector.poll()
+
+            self.assertEqual(len(envelopes), 1)
+            envelope = envelopes[0]
+            self.assertEqual(envelope.content, "what is this plant?")
+            self.assertEqual(len(envelope.attachments), 1)
+            self.assertEqual(envelope.attachments[0].name, "leaf.jpg")
+            self.assertTrue(envelope.attachments[0].uri.startswith("file://"))
+
+    def test_poll_accepts_photo_only_message_with_placeholder_content(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            connector = TelegramConnector(
+                bot_token="token",
+                attachment_root_dir=tmpdir,
+                http_get_json=lambda _url, _timeout: TelegramGetUpdatesResponse(
+                    ok=True,
+                    result=[
+                        {
+                            "update_id": 4002,
+                            "message": {
+                                "message_id": 11,
+                                "date": 1772272800,
+                                "chat": {"id": 12345},
+                                "photo": [{"file_id": "only", "width": 800, "height": 600}],
+                            },
+                        }
+                    ],
+                ),
+                resolve_file_metadata=lambda _url, _timeout: TelegramFileMetadata(file_path="photos/photo.jpg"),
+                download_file_bytes=lambda _url, _timeout: b"jpeg-bytes",
+            )
+
+            envelopes = connector.poll()
+
+            self.assertEqual(len(envelopes), 1)
+            self.assertEqual(envelopes[0].content, "[photo attached]")
+            self.assertEqual(envelopes[0].attachments[0].name, "photo.jpg")
 
 
 class SlackConnectorTests(unittest.TestCase):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 from app.executor import CodexExecutor, parse_execution_result
-from app.models import ExecutionConstraints, ReplyChannel, RoutedTask
+from app.models import AttachmentRef, ExecutionConstraints, ReplyChannel, RoutedTask
 
 
 def _task() -> RoutedTask:
@@ -20,6 +20,7 @@ def _task() -> RoutedTask:
         source="email",
         actor="alice@example.com",
         content="Subject: hello\\n\\nPlease summarize this thread.",
+        attachments=[AttachmentRef(uri="file:///tmp/evidence.png", name="evidence.png")],
         reply_channel=ReplyChannel(type="email", target="alice@example.com"),
     )
 
@@ -543,6 +544,10 @@ class CodexExecutorTests(unittest.TestCase):
         self.assertEqual(run_mock.call_args.kwargs["timeout"], task.execution_constraints.timeout_seconds)
         payload = json.loads(run_mock.call_args.kwargs["input"])
         self.assertEqual(payload["task"]["event_time"], "2026-02-27T16:00:00Z")
+        self.assertEqual(
+            payload["task"]["attachments"],
+            [{"uri": "file:///tmp/evidence.png", "name": "evidence.png"}],
+        )
         self.assertEqual(payload["current_time"], "2026-02-27T18:00:00Z")
 
     @patch("app.executor.codex.subprocess.run")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -80,6 +80,7 @@ class RoutedTaskTests(unittest.TestCase):
             source="email",
             actor="alice@example.com",
             content="Please summarize and reply",
+            attachments=[AttachmentRef(uri="file:///tmp/photo.jpg", name="photo.jpg")],
             reply_channel=ReplyChannel(type="email", target="alice@example.com"),
         )
 
@@ -100,6 +101,7 @@ class RoutedTaskTests(unittest.TestCase):
                 "source": "email",
                 "actor": "alice@example.com",
                 "content": "Please summarize and reply",
+                "attachments": [{"uri": "file:///tmp/photo.jpg", "name": "photo.jpg"}],
                 "reply_channel": {"type": "email", "target": "alice@example.com"},
             },
         )

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime, timezone
 
-from app.models import ReplyChannel, TaskEnvelope
+from app.models import AttachmentRef, ReplyChannel, TaskEnvelope
 from app.router import RuleBasedRouter
 
 
@@ -13,7 +13,7 @@ class RuleBasedRouterTests(unittest.TestCase):
             received_at=datetime(2026, 2, 27, 16, 0, tzinfo=timezone.utc),
             actor="alice@example.com",
             content="Subject: hello\n\nPlease summarize this thread.",
-            attachments=[],
+            attachments=[AttachmentRef(uri="file:///tmp/request.txt", name="request.txt")],
             context_refs=["repo:/home/edward/chatting"],
             policy_profile="default",
             reply_channel=ReplyChannel(type="email", target="alice@example.com"),
@@ -33,6 +33,7 @@ class RuleBasedRouterTests(unittest.TestCase):
         self.assertEqual(task.source, "email")
         self.assertEqual(task.actor, "alice@example.com")
         self.assertEqual(task.content, envelope.content)
+        self.assertEqual(task.attachments, envelope.attachments)
         self.assertEqual(task.reply_channel, envelope.reply_channel)
 
     def test_routes_cron_to_scheduled_automation_with_cron_constraints(self) -> None:

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from app.broker import EgressQueueMessage
-from app.models import AuditEvent, OutboundMessage, ReplyChannel, RunRecord, TaskEnvelope
+from app.models import AttachmentRef, AuditEvent, OutboundMessage, ReplyChannel, RunRecord, TaskEnvelope
 from app.state.sqlite_store import SQLiteStateStore
 
 
@@ -102,7 +102,7 @@ class SQLiteStateStoreTests(unittest.TestCase):
                 received_at=datetime(2026, 2, 27, 16, 10, tzinfo=timezone.utc),
                 actor="alice@example.com",
                 content="Please retry",
-                attachments=[],
+                attachments=[AttachmentRef(uri="file:///tmp/photo.jpg", name="photo.jpg")],
                 context_refs=["repo:/home/edward/chatting"],
                 policy_profile="default",
                 reply_channel=ReplyChannel(type="email", target="alice@example.com"),
@@ -120,6 +120,7 @@ class SQLiteStateStoreTests(unittest.TestCase):
             self.assertEqual(len(pending), 1)
             self.assertEqual(pending[0].dead_letter_id, dead_letter_id)
             self.assertEqual(pending[0].envelope.id, envelope.id)
+            self.assertEqual(pending[0].envelope.attachments, envelope.attachments)
             self.assertEqual(pending[0].status, "pending")
 
             store.mark_dead_letter_replayed(dead_letter_id, "run:email:dead-1:replay:1")


### PR DESCRIPTION
## Summary
- download inbound Telegram photos into a local attachment directory and attach them as file URIs
- pass attachments through routed tasks into the Codex executor payload and preserve them in dead-letter round-trips
- document and test the new Telegram image ingress flow, including caption and photo-only messages

## Testing
- python3 -m unittest discover -s tests
