### PR TITLE
Add Ruff lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruff
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: 0.15.5
+
+      - name: Run Ruff
+        run: ruff check app tests
+

--- a/app/executor/stub.py
+++ b/app/executor/stub.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
 from app.models import ActionProposal, ExecutionResult, OutboundMessage, RoutedTask
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+target-version = "py313"
+


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for Ruff linting
- add a minimal Ruff config targeting Python 3.13
- fix the one existing Ruff violation in the stub executor

## Testing
- /tmp/ruff-download/ruff-x86_64-unknown-linux-musl/ruff check app tests
- python3 -m unittest discover -s tests