### PR TITLE
Add Telegram attachment cleanup policy

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -63,6 +63,8 @@ ALLOWED_RUNTIME_CONFIG_KEYS = frozenset(
         "telegram_allowed_chat_ids",
         "telegram_allowed_channel_ids",
         "telegram_attachment_dir",
+        "telegram_attachment_cleanup_grace_seconds",
+        "telegram_attachment_max_age_seconds",
         "telegram_api_base_url",
         "telegram_bot_token_env",
         "telegram_context_refs",

--- a/app/main_message_handler.py
+++ b/app/main_message_handler.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from threading import Event, Lock, Thread
@@ -42,9 +42,16 @@ from app.main import (
     _build_live_connectors,
     _build_telegram_sender,
     _enrich_telegram_envelope_with_memory,
+    _resolve_telegram_attachment_dir,
     _should_store_telegram_memory,
 )
-from app.message_handler_runtime import TaskLedgerRecord, TaskLedgerStore
+from app.message_handler_runtime import (
+    TaskLedgerRecord,
+    TaskLedgerStore,
+    TelegramAttachmentCleanupResult,
+    TelegramAttachmentStore,
+    cleanup_telegram_attachments,
+)
 from app.models import ConfigUpdateDecision, PolicyDecision, TaskEnvelope
 from app.state import SQLiteStateStore
 
@@ -82,6 +89,8 @@ _ALLOWED_CONFIG_KEYS = frozenset(
         "telegram_allowed_chat_ids",
         "telegram_allowed_channel_ids",
         "telegram_attachment_dir",
+        "telegram_attachment_cleanup_grace_seconds",
+        "telegram_attachment_max_age_seconds",
         "telegram_context_refs",
         "github_repositories",
         "github_assignee_login",
@@ -95,6 +104,8 @@ BBMB_EGRESS_PICKUP_WAIT_SECONDS = 5
 BBMB_EGRESS_DRAIN_WAIT_SECONDS = 0
 DEFAULT_METRICS_HOST = "127.0.0.1"
 DEFAULT_METRICS_PORT = 9464
+DEFAULT_TELEGRAM_ATTACHMENT_CLEANUP_GRACE_SECONDS = 7 * 24 * 60 * 60
+DEFAULT_TELEGRAM_ATTACHMENT_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -105,6 +116,13 @@ class GitHubIngressSettings:
     policy_profile: str
     max_issues: int
     max_timeline_events: int
+
+
+@dataclass(frozen=True)
+class TelegramAttachmentCleanupSettings:
+    attachment_root_dir: str
+    cleanup_grace_seconds: int
+    max_age_seconds: int
 
 
 @dataclass(frozen=True)
@@ -257,6 +275,10 @@ class MessageHandlerMetrics:
         self._github_scanned_events_total = 0
         self._github_new_events_total = 0
         self._github_published_total = 0
+        self._telegram_attachment_cleanup_deleted_total = 0
+        self._telegram_attachment_cleanup_missing_total = 0
+        self._telegram_attachment_cleanup_failed_total = 0
+        self._telegram_attachment_cleanup_reclaimed_bytes_total = 0
         self._egress_loops_total = 0
         self._last_loop_completed_at: datetime | None = None
         self._last_egress_loop_completed_at: datetime | None = None
@@ -269,6 +291,7 @@ class MessageHandlerMetrics:
         github_scanned_events: int,
         github_new_events: int,
         github_published: int,
+        telegram_attachment_cleanup: TelegramAttachmentCleanupResult | None,
         telemetry_snapshot: dict[str, float | int],
         completed_at: datetime | None = None,
     ) -> None:
@@ -279,6 +302,19 @@ class MessageHandlerMetrics:
             self._github_scanned_events_total += github_scanned_events
             self._github_new_events_total += github_new_events
             self._github_published_total += github_published
+            if telegram_attachment_cleanup is not None:
+                self._telegram_attachment_cleanup_deleted_total += (
+                    telegram_attachment_cleanup.deleted_count
+                )
+                self._telegram_attachment_cleanup_missing_total += (
+                    telegram_attachment_cleanup.missing_count
+                )
+                self._telegram_attachment_cleanup_failed_total += (
+                    telegram_attachment_cleanup.failed_count
+                )
+                self._telegram_attachment_cleanup_reclaimed_bytes_total += (
+                    telegram_attachment_cleanup.reclaimed_bytes
+                )
             self._last_loop_completed_at = loop_completed_at.astimezone(timezone.utc)
             self._egress_snapshot = dict(telemetry_snapshot)
 
@@ -315,6 +351,18 @@ class MessageHandlerMetrics:
                 "github_scanned_events_total": self._github_scanned_events_total,
                 "github_new_events_total": self._github_new_events_total,
                 "github_published_total": self._github_published_total,
+                "telegram_attachment_cleanup_deleted_total": (
+                    self._telegram_attachment_cleanup_deleted_total
+                ),
+                "telegram_attachment_cleanup_missing_total": (
+                    self._telegram_attachment_cleanup_missing_total
+                ),
+                "telegram_attachment_cleanup_failed_total": (
+                    self._telegram_attachment_cleanup_failed_total
+                ),
+                "telegram_attachment_cleanup_reclaimed_bytes_total": (
+                    self._telegram_attachment_cleanup_reclaimed_bytes_total
+                ),
                 "last_loop_completed_timestamp_seconds": round(last_ingress_loop_timestamp, 6),
                 "egress_loops_total": self._egress_loops_total,
                 "last_egress_loop_completed_timestamp_seconds": round(
@@ -375,6 +423,30 @@ def _render_prometheus_metrics(snapshot: Mapping[str, float | int]) -> str:
             "counter",
             "GitHub assignment events published as tasks.",
             "github_published_total",
+        ),
+        (
+            "chatting_message_handler_telegram_attachment_cleanup_deleted_total",
+            "counter",
+            "Telegram attachment files deleted by handler-managed cleanup.",
+            "telegram_attachment_cleanup_deleted_total",
+        ),
+        (
+            "chatting_message_handler_telegram_attachment_cleanup_missing_total",
+            "counter",
+            "Tracked Telegram attachment files already missing from disk during cleanup.",
+            "telegram_attachment_cleanup_missing_total",
+        ),
+        (
+            "chatting_message_handler_telegram_attachment_cleanup_failed_total",
+            "counter",
+            "Telegram attachment cleanup attempts that failed.",
+            "telegram_attachment_cleanup_failed_total",
+        ),
+        (
+            "chatting_message_handler_telegram_attachment_cleanup_reclaimed_bytes_total",
+            "counter",
+            "Bytes reclaimed by Telegram attachment cleanup.",
+            "telegram_attachment_cleanup_reclaimed_bytes_total",
         ),
         (
             "chatting_message_handler_last_loop_completed_timestamp_seconds",
@@ -592,6 +664,16 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--telegram-attachment-dir",
         help="Local directory for downloaded Telegram photo attachments.",
+    )
+    parser.add_argument(
+        "--telegram-attachment-cleanup-grace-seconds",
+        type=_positive_int,
+        help="Grace period after task completion before Telegram attachment cleanup.",
+    )
+    parser.add_argument(
+        "--telegram-attachment-max-age-seconds",
+        type=_positive_int,
+        help="Absolute max age before Telegram attachments are cleaned even without completion.",
     )
     parser.add_argument(
         "--telegram-allowed-chat-id",
@@ -829,6 +911,48 @@ def _resolve_github_ingress_settings(
     )
 
 
+def _resolve_telegram_attachment_cleanup_settings(
+    args: argparse.Namespace,
+    config: dict[str, object],
+) -> TelegramAttachmentCleanupSettings | None:
+    cleanup_keys = {
+        "telegram_attachment_dir",
+        "telegram_attachment_cleanup_grace_seconds",
+        "telegram_attachment_max_age_seconds",
+    }
+    explicit_cleanup_configured = (
+        args.telegram_attachment_dir is not None
+        or args.telegram_attachment_cleanup_grace_seconds is not None
+        or args.telegram_attachment_max_age_seconds is not None
+        or any(key in config for key in cleanup_keys)
+    )
+    if not _is_connector_configured(args, config, connector="telegram") and not explicit_cleanup_configured:
+        return None
+
+    cleanup_grace_seconds = _resolve_positive_int(
+        args.telegram_attachment_cleanup_grace_seconds,
+        config.get("telegram_attachment_cleanup_grace_seconds"),
+        default_value=DEFAULT_TELEGRAM_ATTACHMENT_CLEANUP_GRACE_SECONDS,
+        setting_name="telegram_attachment_cleanup_grace_seconds",
+    )
+    max_age_seconds = _resolve_positive_int(
+        args.telegram_attachment_max_age_seconds,
+        config.get("telegram_attachment_max_age_seconds"),
+        default_value=DEFAULT_TELEGRAM_ATTACHMENT_MAX_AGE_SECONDS,
+        setting_name="telegram_attachment_max_age_seconds",
+    )
+    if max_age_seconds < cleanup_grace_seconds:
+        raise ValueError(
+            "telegram_attachment_max_age_seconds must be greater than or equal to "
+            "telegram_attachment_cleanup_grace_seconds"
+        )
+    return TelegramAttachmentCleanupSettings(
+        attachment_root_dir=_resolve_telegram_attachment_dir(args, config),
+        cleanup_grace_seconds=cleanup_grace_seconds,
+        max_age_seconds=max_age_seconds,
+    )
+
+
 def _is_connector_configured(args: argparse.Namespace, config: dict[str, object], *, connector: str) -> bool:
     if connector == "schedule":
         return args.schedule_file is not None or config.get("schedule_file") is not None
@@ -1062,6 +1186,8 @@ def _handle_egress_message(
     allowed_egress_channels: set[str],
     applier: IntegratedApplier,
     ack_callback: Callable[[str], None],
+    attachment_store: TelegramAttachmentStore | None = None,
+    attachment_cleanup_settings: TelegramAttachmentCleanupSettings | None = None,
     heartbeat_telemetry: HeartbeatTelemetryRollup | None = None,
     telemetry: EgressTelemetryRollup | None = None,
 ) -> None:
@@ -1170,6 +1296,8 @@ def _handle_egress_message(
         task_id=egress_message.task_id,
         ledger=ledger,
         store=store,
+        attachment_store=attachment_store,
+        attachment_cleanup_settings=attachment_cleanup_settings,
         applier=applier,
         heartbeat_telemetry=heartbeat_telemetry,
         telemetry=telemetry,
@@ -1184,6 +1312,8 @@ def _drain_egress_queue(
     store: SQLiteStateStore,
     allowed_egress_channels: set[str],
     applier: IntegratedApplier,
+    attachment_store: TelegramAttachmentStore | None = None,
+    attachment_cleanup_settings: TelegramAttachmentCleanupSettings | None = None,
     heartbeat_telemetry: HeartbeatTelemetryRollup | None = None,
     telemetry: EgressTelemetryRollup | None = None,
 ) -> int:
@@ -1205,6 +1335,8 @@ def _drain_egress_queue(
             picked_payload=egress_picked.payload,
             ledger=ledger,
             store=store,
+            attachment_store=attachment_store,
+            attachment_cleanup_settings=attachment_cleanup_settings,
             allowed_egress_channels=allowed_egress_channels,
             applier=applier,
             ack_callback=lambda guid: broker.ack(EGRESS_QUEUE_NAME, guid),
@@ -1267,6 +1399,8 @@ def _apply_completion_event(
     egress_message: EgressQueueMessage,
     ledger: TaskLedgerStore,
     store: SQLiteStateStore,
+    attachment_store: TelegramAttachmentStore | None,
+    attachment_cleanup_settings: TelegramAttachmentCleanupSettings | None,
     telemetry: EgressTelemetryRollup | None,
 ) -> None:
     store.mark_dispatched_event_id(
@@ -1286,6 +1420,21 @@ def _apply_completion_event(
         envelope_id=egress_message.envelope_id,
         trace_id=egress_message.trace_id,
     )
+    if attachment_store is not None and attachment_cleanup_settings is not None:
+        eligible_after = datetime.now(timezone.utc) + timedelta(
+            seconds=attachment_cleanup_settings.cleanup_grace_seconds
+        )
+        tracked_count = attachment_store.mark_task_attachments_eligible(
+            task_id=egress_message.task_id,
+            eligible_after=eligible_after,
+        )
+        if tracked_count:
+            LOGGER.info(
+                "telegram_attachment_cleanup_eligible task_id=%s tracked_attachments=%s eligible_after=%s",
+                egress_message.task_id,
+                tracked_count,
+                _serialize_optional_datetime(eligible_after),
+            )
     LOGGER.info(
         "egress_completion_applied task_id=%s event_id=%s sequence=%s",
         egress_message.task_id,
@@ -1299,6 +1448,8 @@ def _flush_task_egress_in_sequence(
     task_id: str,
     ledger: TaskLedgerStore,
     store: SQLiteStateStore,
+    attachment_store: TelegramAttachmentStore | None,
+    attachment_cleanup_settings: TelegramAttachmentCleanupSettings | None,
     applier: IntegratedApplier,
     heartbeat_telemetry: HeartbeatTelemetryRollup | None = None,
     telemetry: EgressTelemetryRollup | None = None,
@@ -1334,6 +1485,8 @@ def _flush_task_egress_in_sequence(
                 egress_message=egress_message,
                 ledger=ledger,
                 store=store,
+                attachment_store=attachment_store,
+                attachment_cleanup_settings=attachment_cleanup_settings,
                 telemetry=telemetry,
             )
             return
@@ -1408,6 +1561,8 @@ def _run_ingress_loop(
     broker: BBMBQueueAdapter,
     connectors: list[object],
     disabled_ingress_components: list[DisabledIngressComponent],
+    attachment_store: TelegramAttachmentStore | None,
+    attachment_cleanup_settings: TelegramAttachmentCleanupSettings | None,
     heartbeat_telemetry: HeartbeatTelemetryRollup,
     metrics: MessageHandlerMetrics,
     poll_interval_seconds: float,
@@ -1430,6 +1585,7 @@ def _run_ingress_loop(
         github_new_events = 0
         github_published = 0
         github_checkpoint = "disabled"
+        attachment_cleanup_result: TelegramAttachmentCleanupResult | None = None
         for connector in connectors:
             connector_name = type(connector).__name__
             try:
@@ -1460,18 +1616,51 @@ def _run_ingress_loop(
                 )
                 broker.publish_json(TASK_QUEUE_NAME, task_message.to_dict())
                 ledger.record_task(task_message)
+                if attachment_store is not None and attachment_cleanup_settings is not None:
+                    tracked_attachments = attachment_store.record_task_attachments(
+                        task_message=task_message,
+                        attachment_root_dir=attachment_cleanup_settings.attachment_root_dir,
+                    )
+                    if tracked_attachments:
+                        LOGGER.info(
+                            "telegram_attachment_tracked task_id=%s tracked_attachments=%s",
+                            task_id,
+                            tracked_attachments,
+                        )
                 store.mark_seen(envelope.source, envelope.dedupe_key)
                 if is_internal_heartbeat_envelope(task_message.envelope):
                     heartbeat_telemetry.record_sent(sent_at=task_message.emitted_at)
                 ingress_published += 1
                 if isinstance(connector, (GitHubIssueAssignmentConnector, GitHubPullRequestReviewConnector)):
                     github_published += 1
+        if attachment_store is not None and attachment_cleanup_settings is not None:
+            attachment_cleanup_result = cleanup_telegram_attachments(
+                attachment_store=attachment_store,
+                attachment_root_dir=attachment_cleanup_settings.attachment_root_dir,
+                completion_grace_period=timedelta(
+                    seconds=attachment_cleanup_settings.cleanup_grace_seconds
+                ),
+                max_attachment_age=timedelta(seconds=attachment_cleanup_settings.max_age_seconds),
+            )
+            if (
+                attachment_cleanup_result.deleted_count
+                or attachment_cleanup_result.missing_count
+                or attachment_cleanup_result.failed_count
+            ):
+                LOGGER.info(
+                    "telegram_attachment_cleanup deleted=%s missing=%s failed=%s reclaimed_bytes=%s",
+                    attachment_cleanup_result.deleted_count,
+                    attachment_cleanup_result.missing_count,
+                    attachment_cleanup_result.failed_count,
+                    attachment_cleanup_result.reclaimed_bytes,
+                )
 
         metrics.record_loop(
             ingress_published=ingress_published,
             github_scanned_events=github_scanned_events,
             github_new_events=github_new_events,
             github_published=github_published,
+            telegram_attachment_cleanup=attachment_cleanup_result,
             telemetry_snapshot=metrics.snapshot(),
         )
         heartbeat_snapshot = heartbeat_telemetry.snapshot()
@@ -1480,6 +1669,8 @@ def _run_ingress_loop(
             (
                 "ingress_loop_completed loop=%s ingress_published=%s "
                 "github_scanned_events=%s github_new_events=%s github_published=%s github_checkpoint=%s "
+                "telegram_attachment_cleanup_deleted=%s telegram_attachment_cleanup_missing=%s "
+                "telegram_attachment_cleanup_failed=%s telegram_attachment_cleanup_reclaimed_bytes=%s "
                 "heartbeat_sent_total=%s heartbeat_received_total=%s "
                 "heartbeat_latest_sent_at=%s heartbeat_latest_received_at=%s heartbeat_latest_latency_ms=%s "
                 "egress_received_total=%s egress_dispatched_total=%s egress_deduped_total=%s "
@@ -1494,6 +1685,10 @@ def _run_ingress_loop(
             github_new_events,
             github_published,
             github_checkpoint,
+            attachment_cleanup_result.deleted_count if attachment_cleanup_result is not None else 0,
+            attachment_cleanup_result.missing_count if attachment_cleanup_result is not None else 0,
+            attachment_cleanup_result.failed_count if attachment_cleanup_result is not None else 0,
+            attachment_cleanup_result.reclaimed_bytes if attachment_cleanup_result is not None else 0,
             heartbeat_snapshot["sent_total"],
             heartbeat_snapshot["received_total"],
             heartbeat_snapshot["latest_sent_at"],
@@ -1523,6 +1718,8 @@ def _run_egress_loop(
     stop_event: Event,
     ledger: TaskLedgerStore,
     store: SQLiteStateStore,
+    attachment_store: TelegramAttachmentStore | None,
+    attachment_cleanup_settings: TelegramAttachmentCleanupSettings | None,
     broker: BBMBQueueAdapter,
     allowed_egress_channels: set[str],
     applier: IntegratedApplier,
@@ -1538,6 +1735,8 @@ def _run_egress_loop(
             poll_timeout_seconds=timeout_seconds,
             ledger=ledger,
             store=store,
+            attachment_store=attachment_store,
+            attachment_cleanup_settings=attachment_cleanup_settings,
             allowed_egress_channels=allowed_egress_channels,
             applier=applier,
             heartbeat_telemetry=heartbeat_telemetry,
@@ -1598,9 +1797,11 @@ def main() -> int:
         setting_name="metrics_port",
     )
     allowed_egress_channels = _resolve_allowed_egress_channels(args, config)
+    attachment_cleanup_settings = _resolve_telegram_attachment_cleanup_settings(args, config)
 
     store = SQLiteStateStore(db_path)
     ledger = TaskLedgerStore(db_path)
+    attachment_store = TelegramAttachmentStore(db_path) if attachment_cleanup_settings is not None else None
     broker = BBMBQueueAdapter(address=bbmb_address)
     broker.ensure_queue(TASK_QUEUE_NAME)
     broker.ensure_queue(EGRESS_QUEUE_NAME)
@@ -1647,6 +1848,8 @@ def main() -> int:
                     broker=broker,
                     connectors=connectors,
                     disabled_ingress_components=disabled_ingress_components,
+                    attachment_store=attachment_store,
+                    attachment_cleanup_settings=attachment_cleanup_settings,
                     heartbeat_telemetry=heartbeat_telemetry,
                     metrics=metrics,
                     poll_interval_seconds=poll_interval_seconds,
@@ -1662,6 +1865,8 @@ def main() -> int:
                     stop_event=stop_event,
                     ledger=ledger,
                     store=store,
+                    attachment_store=attachment_store,
+                    attachment_cleanup_settings=attachment_cleanup_settings,
                     broker=broker,
                     allowed_egress_channels=allowed_egress_channels,
                     applier=applier,

--- a/app/message_handler_runtime.py
+++ b/app/message_handler_runtime.py
@@ -1,15 +1,19 @@
-"""Message-handler runtime helpers for ingress task ledger and strict egress validation."""
+"""Message-handler runtime helpers for ingress task ledger and attachment cleanup."""
 
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from contextlib import closing
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 from app.broker import EgressQueueMessage, TaskQueueMessage
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -36,6 +40,27 @@ class CompletedTaskRecord:
     envelope_id: str
     trace_id: str
     completed_at: datetime
+
+
+@dataclass(frozen=True)
+class TelegramAttachmentRecord:
+    attachment_path: str
+    attachment_uri: str
+    task_id: str
+    envelope_id: str
+    created_at: datetime
+    eligible_after: datetime | None
+    deleted_at: datetime | None
+    cleanup_attempts: int
+    last_cleanup_error: str | None
+
+
+@dataclass(frozen=True)
+class TelegramAttachmentCleanupResult:
+    deleted_count: int = 0
+    missing_count: int = 0
+    failed_count: int = 0
+    reclaimed_bytes: int = 0
 
 
 class TaskLedgerStore:
@@ -98,7 +123,7 @@ class TaskLedgerStore:
 
     def record_task(self, task_message: TaskQueueMessage) -> None:
         payload = task_message.to_dict()
-        created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        created_at = _serialize_rfc3339_utc(datetime.now(timezone.utc))
         with closing(self._connect()) as connection:
             connection.execute(
                 """
@@ -155,7 +180,7 @@ class TaskLedgerStore:
             raise ValueError("egress_message.event_id is required")
         if egress_message.sequence is None:
             raise ValueError("egress_message.sequence is required")
-        created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        created_at = _serialize_rfc3339_utc(datetime.now(timezone.utc))
         with closing(self._connect()) as connection:
             connection.execute(
                 """
@@ -213,7 +238,7 @@ class TaskLedgerStore:
         return completed_record.envelope_id == envelope_id
 
     def mark_task_completed(self, *, task_id: str, envelope_id: str, trace_id: str) -> None:
-        completed_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        completed_at = _serialize_rfc3339_utc(datetime.now(timezone.utc))
         with closing(self._connect()) as connection:
             connection.execute(
                 """
@@ -321,13 +346,353 @@ class TaskLedgerStore:
             connection.commit()
 
 
+class TelegramAttachmentStore:
+    """Persist Telegram-downloaded local attachment lifecycle state."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._db_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _initialize(self) -> None:
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS telegram_attachment_ledger (
+                    attachment_path TEXT PRIMARY KEY,
+                    attachment_uri TEXT NOT NULL,
+                    task_id TEXT NOT NULL,
+                    envelope_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    eligible_after TEXT,
+                    deleted_at TEXT,
+                    cleanup_attempts INTEGER NOT NULL,
+                    last_cleanup_error TEXT
+                )
+                """
+            )
+            connection.commit()
+
+    def record_task_attachments(
+        self,
+        *,
+        task_message: TaskQueueMessage,
+        attachment_root_dir: str,
+    ) -> int:
+        envelope = task_message.envelope
+        if envelope.source != "im" or envelope.reply_channel.type != "telegram":
+            return 0
+        root_dir = Path(attachment_root_dir).resolve()
+        created_at = _serialize_rfc3339_utc(datetime.now(timezone.utc))
+        tracked_paths: list[tuple[Path, str]] = []
+        for attachment in envelope.attachments:
+            tracked_path = _tracked_attachment_path(
+                attachment_uri=attachment.uri,
+                attachment_root_dir=root_dir,
+            )
+            if tracked_path is None:
+                continue
+            tracked_paths.append((tracked_path, attachment.uri))
+        if not tracked_paths:
+            return 0
+        with closing(self._connect()) as connection:
+            for tracked_path, attachment_uri in tracked_paths:
+                connection.execute(
+                    """
+                    INSERT OR IGNORE INTO telegram_attachment_ledger (
+                        attachment_path,
+                        attachment_uri,
+                        task_id,
+                        envelope_id,
+                        created_at,
+                        eligible_after,
+                        deleted_at,
+                        cleanup_attempts,
+                        last_cleanup_error
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        str(tracked_path),
+                        attachment_uri,
+                        task_message.task_id,
+                        envelope.id,
+                        created_at,
+                        None,
+                        None,
+                        0,
+                        None,
+                    ),
+                )
+            connection.commit()
+        return len(tracked_paths)
+
+    def mark_task_attachments_eligible(
+        self,
+        *,
+        task_id: str,
+        eligible_after: datetime,
+    ) -> int:
+        if not task_id:
+            raise ValueError("task_id is required")
+        if eligible_after.tzinfo is None:
+            raise ValueError("eligible_after must be timezone-aware")
+        with closing(self._connect()) as connection:
+            cursor = connection.execute(
+                """
+                UPDATE telegram_attachment_ledger
+                SET eligible_after = ?, last_cleanup_error = NULL
+                WHERE task_id = ? AND deleted_at IS NULL
+                """,
+                (_serialize_rfc3339_utc(eligible_after), task_id),
+            )
+            connection.commit()
+        return int(cursor.rowcount)
+
+    def list_cleanup_candidates(
+        self,
+        *,
+        not_after: datetime,
+        max_age_cutoff: datetime,
+    ) -> list[TelegramAttachmentRecord]:
+        if not_after.tzinfo is None:
+            raise ValueError("not_after must be timezone-aware")
+        if max_age_cutoff.tzinfo is None:
+            raise ValueError("max_age_cutoff must be timezone-aware")
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT
+                    attachment_path,
+                    attachment_uri,
+                    task_id,
+                    envelope_id,
+                    created_at,
+                    eligible_after,
+                    deleted_at,
+                    cleanup_attempts,
+                    last_cleanup_error
+                FROM telegram_attachment_ledger
+                WHERE deleted_at IS NULL
+                  AND (
+                    (eligible_after IS NOT NULL AND eligible_after <= ?)
+                    OR created_at <= ?
+                  )
+                ORDER BY created_at ASC
+                """,
+                (
+                    _serialize_rfc3339_utc(not_after),
+                    _serialize_rfc3339_utc(max_age_cutoff),
+                ),
+            ).fetchall()
+        return [_attachment_record_from_row(row) for row in rows]
+
+    def mark_attachment_deleted(self, *, attachment_path: str) -> None:
+        if not attachment_path:
+            raise ValueError("attachment_path is required")
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                UPDATE telegram_attachment_ledger
+                SET deleted_at = ?, last_cleanup_error = NULL
+                WHERE attachment_path = ?
+                """,
+                (_serialize_rfc3339_utc(datetime.now(timezone.utc)), attachment_path),
+            )
+            connection.commit()
+
+    def mark_cleanup_failed(self, *, attachment_path: str, error: str) -> None:
+        if not attachment_path:
+            raise ValueError("attachment_path is required")
+        if not error:
+            raise ValueError("error is required")
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                UPDATE telegram_attachment_ledger
+                SET cleanup_attempts = cleanup_attempts + 1, last_cleanup_error = ?
+                WHERE attachment_path = ?
+                """,
+                (error, attachment_path),
+            )
+            connection.commit()
+
+    def list_records(self) -> list[TelegramAttachmentRecord]:
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT
+                    attachment_path,
+                    attachment_uri,
+                    task_id,
+                    envelope_id,
+                    created_at,
+                    eligible_after,
+                    deleted_at,
+                    cleanup_attempts,
+                    last_cleanup_error
+                FROM telegram_attachment_ledger
+                ORDER BY created_at ASC, attachment_path ASC
+                """
+            ).fetchall()
+        return [_attachment_record_from_row(row) for row in rows]
+
+
+def cleanup_telegram_attachments(
+    *,
+    attachment_store: TelegramAttachmentStore,
+    attachment_root_dir: str,
+    completion_grace_period: timedelta,
+    max_attachment_age: timedelta,
+    now: datetime | None = None,
+) -> TelegramAttachmentCleanupResult:
+    """Delete tracked Telegram attachments once they are safely eligible."""
+    if completion_grace_period.total_seconds() <= 0:
+        raise ValueError("completion_grace_period must be positive")
+    if max_attachment_age.total_seconds() <= 0:
+        raise ValueError("max_attachment_age must be positive")
+    cleanup_now = now or datetime.now(timezone.utc)
+    if cleanup_now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    candidates = attachment_store.list_cleanup_candidates(
+        not_after=cleanup_now,
+        max_age_cutoff=cleanup_now - max_attachment_age,
+    )
+    result = TelegramAttachmentCleanupResult()
+    root_dir = Path(attachment_root_dir).resolve()
+
+    for candidate in candidates:
+        attachment_path = Path(candidate.attachment_path)
+        cleanup_reason = (
+            "completed_grace_elapsed"
+            if candidate.eligible_after is not None and candidate.eligible_after <= cleanup_now
+            else "max_age_elapsed"
+        )
+        if not _is_relative_to(attachment_path, root_dir):
+            attachment_store.mark_cleanup_failed(
+                attachment_path=candidate.attachment_path,
+                error="attachment_path_outside_root",
+            )
+            LOGGER.error(
+                "telegram_attachment_cleanup_failed task_id=%s path=%s error=%s",
+                candidate.task_id,
+                candidate.attachment_path,
+                "attachment_path_outside_root",
+            )
+            result = TelegramAttachmentCleanupResult(
+                deleted_count=result.deleted_count,
+                missing_count=result.missing_count,
+                failed_count=result.failed_count + 1,
+                reclaimed_bytes=result.reclaimed_bytes,
+            )
+            continue
+        if not attachment_path.exists():
+            attachment_store.mark_attachment_deleted(attachment_path=candidate.attachment_path)
+            LOGGER.warning(
+                "telegram_attachment_cleanup_missing task_id=%s path=%s reason=%s",
+                candidate.task_id,
+                candidate.attachment_path,
+                cleanup_reason,
+            )
+            result = TelegramAttachmentCleanupResult(
+                deleted_count=result.deleted_count,
+                missing_count=result.missing_count + 1,
+                failed_count=result.failed_count,
+                reclaimed_bytes=result.reclaimed_bytes,
+            )
+            continue
+        try:
+            reclaimed_bytes = attachment_path.stat().st_size if attachment_path.is_file() else 0
+            attachment_path.unlink()
+            attachment_store.mark_attachment_deleted(attachment_path=candidate.attachment_path)
+            LOGGER.info(
+                "telegram_attachment_cleanup_deleted task_id=%s path=%s reason=%s bytes=%s",
+                candidate.task_id,
+                candidate.attachment_path,
+                cleanup_reason,
+                reclaimed_bytes,
+            )
+            result = TelegramAttachmentCleanupResult(
+                deleted_count=result.deleted_count + 1,
+                missing_count=result.missing_count,
+                failed_count=result.failed_count,
+                reclaimed_bytes=result.reclaimed_bytes + reclaimed_bytes,
+            )
+        except OSError as error:
+            attachment_store.mark_cleanup_failed(
+                attachment_path=candidate.attachment_path,
+                error=f"{type(error).__name__}: {error}",
+            )
+            LOGGER.error(
+                "telegram_attachment_cleanup_failed task_id=%s path=%s error=%s",
+                candidate.task_id,
+                candidate.attachment_path,
+                f"{type(error).__name__}: {error}",
+            )
+            result = TelegramAttachmentCleanupResult(
+                deleted_count=result.deleted_count,
+                missing_count=result.missing_count,
+                failed_count=result.failed_count + 1,
+                reclaimed_bytes=result.reclaimed_bytes,
+            )
+    return result
+
+
 def _parse_rfc3339_utc(raw_value: str) -> datetime:
     return datetime.fromisoformat(raw_value.replace("Z", "+00:00")).astimezone(timezone.utc)
 
 
+def _serialize_rfc3339_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _attachment_record_from_row(row: sqlite3.Row) -> TelegramAttachmentRecord:
+    eligible_after = row["eligible_after"]
+    deleted_at = row["deleted_at"]
+    return TelegramAttachmentRecord(
+        attachment_path=row["attachment_path"],
+        attachment_uri=row["attachment_uri"],
+        task_id=row["task_id"],
+        envelope_id=row["envelope_id"],
+        created_at=_parse_rfc3339_utc(row["created_at"]),
+        eligible_after=_parse_rfc3339_utc(eligible_after) if eligible_after is not None else None,
+        deleted_at=_parse_rfc3339_utc(deleted_at) if deleted_at is not None else None,
+        cleanup_attempts=int(row["cleanup_attempts"]),
+        last_cleanup_error=row["last_cleanup_error"],
+    )
+
+
+def _tracked_attachment_path(*, attachment_uri: str, attachment_root_dir: Path) -> Path | None:
+    parsed = urlparse(attachment_uri)
+    if parsed.scheme != "file":
+        return None
+    candidate_path = Path(unquote(parsed.path)).resolve()
+    if not _is_relative_to(candidate_path, attachment_root_dir):
+        return None
+    return candidate_path
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
 __all__ = [
     "CompletedTaskRecord",
-    "TaskLedgerRecord",
     "StagedEgressRecord",
+    "TaskLedgerRecord",
     "TaskLedgerStore",
+    "TelegramAttachmentCleanupResult",
+    "TelegramAttachmentRecord",
+    "TelegramAttachmentStore",
+    "cleanup_telegram_attachments",
 ]

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -13,6 +13,8 @@ Long-poll Telegram Bot API `getUpdates` and normalize DM/group `message` updates
 - `telegram_api_base_url` (default `https://api.telegram.org`)
 - `telegram_poll_timeout_seconds` (default `20`)
 - `telegram_attachment_dir` (optional local directory for downloaded photo attachments; defaults to a temp-dir path if omitted)
+- `telegram_attachment_cleanup_grace_seconds` (default `604800`, or 7 days)
+- `telegram_attachment_max_age_seconds` (default `2592000`, or 30 days)
 - `telegram_allowed_chat_ids` (optional list)
 - `telegram_allowed_channel_ids` (optional list, required to ingest `channel_post`)
 - `telegram_context_refs` (optional list)
@@ -36,4 +38,8 @@ Matching CLI flags exist (`--telegram-enabled`, `--telegram-bot-token-env`, etc.
 - `channel_post` updates are ignored unless the channel ID is present in `telegram_allowed_channel_ids`.
 - Ignored `channel_post` updates log `update_id`, `channel_id`, and an explicit reason so new channel IDs can be copied from logs.
 - Offset is advanced as `highest_update_id + 1` each poll.
-- In production, point `telegram_attachment_dir` at durable storage so Codex can still access files after ingress has completed.
+- The message handler tracks downloaded Telegram attachments in its SQLite DB and only makes them cleanup-eligible after the task reaches terminal completion.
+- Cleanup uses a hybrid policy:
+  terminal tasks wait for `telegram_attachment_cleanup_grace_seconds`, while orphaned/dead-lettered attachments are still reclaimed once they exceed `telegram_attachment_max_age_seconds`.
+- Cleanup runs in the message-handler loop and logs tracked, eligible, deleted, missing, and failed attachment cleanup events.
+- In production, point `telegram_attachment_dir` at durable storage when workers need access beyond ingress, but expect the handler to reclaim old files automatically unless you increase the retention settings.

--- a/tests/test_message_handler_runtime.py
+++ b/tests/test_message_handler_runtime.py
@@ -1,7 +1,7 @@
 import tempfile
 import unittest
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import json
 
@@ -9,14 +9,19 @@ from app.main_message_handler import (
     EgressTelemetryRollup,
     HeartbeatTelemetryRollup,
     MessageHandlerMetrics,
+    TelegramAttachmentCleanupSettings,
     _handle_egress_message,
     _prepare_ingress_envelope,
     _render_prometheus_metrics,
 )
 from app.broker import EgressQueueMessage, TaskQueueMessage
 from app.internal_heartbeat import build_internal_heartbeat_egress, build_internal_heartbeat_envelope
-from app.message_handler_runtime import TaskLedgerStore
-from app.models import ApplyResult, OutboundMessage, ReplyChannel, TaskEnvelope
+from app.message_handler_runtime import (
+    TaskLedgerStore,
+    TelegramAttachmentStore,
+    cleanup_telegram_attachments,
+)
+from app.models import ApplyResult, AttachmentRef, OutboundMessage, ReplyChannel, TaskEnvelope
 from app.state import SQLiteStateStore
 
 
@@ -61,6 +66,21 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             ),
             trace_id="trace:internal:heartbeat:1",
         )
+
+    def _build_telegram_attachment_task_message(self, attachment_uri: str) -> TaskQueueMessage:
+        envelope = TaskEnvelope(
+            id="telegram:photo-1",
+            source="im",
+            received_at=datetime(2026, 3, 6, 12, 0, tzinfo=timezone.utc),
+            actor="77:alice",
+            content="[photo attached]",
+            attachments=[AttachmentRef(uri=attachment_uri, name="telegram-photo.jpg")],
+            context_refs=[],
+            policy_profile="default",
+            reply_channel=ReplyChannel(type="telegram", target="12345"),
+            dedupe_key="telegram:photo-1",
+        )
+        return TaskQueueMessage.from_envelope(envelope, trace_id="trace:telegram:photo-1")
 
     def _build_telegram_envelope(self, *, envelope_id: str, content: str, target: str = "12345") -> TaskEnvelope:
         return TaskEnvelope(
@@ -240,6 +260,138 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
                     envelope_id=task_message.envelope.id,
                 )
             )
+
+    def test_handle_egress_message_marks_telegram_attachments_cleanup_eligible_on_completion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            attachment_dir = Path(tmpdir) / "attachments"
+            attachment_dir.mkdir()
+            attachment_path = attachment_dir / "telegram-photo.jpg"
+            attachment_path.write_bytes(b"photo-bytes")
+
+            store = SQLiteStateStore(db_path)
+            ledger = TaskLedgerStore(db_path)
+            attachment_store = TelegramAttachmentStore(db_path)
+            task_message = self._build_telegram_attachment_task_message(attachment_path.resolve().as_uri())
+            ledger.record_task(task_message)
+            tracked = attachment_store.record_task_attachments(
+                task_message=task_message,
+                attachment_root_dir=str(attachment_dir),
+            )
+            self.assertEqual(tracked, 1)
+            applier = _RecordingApplier()
+            acked: list[str] = []
+
+            payload = EgressQueueMessage(
+                task_id=task_message.task_id,
+                envelope_id=task_message.envelope.id,
+                trace_id=task_message.trace_id,
+                event_index=0,
+                event_count=1,
+                message=OutboundMessage(channel="log", target="ops", body="done"),
+                emitted_at=datetime(2026, 3, 6, 12, 1, tzinfo=timezone.utc),
+                event_id="evt:task:telegram:photo-1:0",
+                sequence=0,
+                event_kind="completion",
+                message_type="chatting.egress.v2",
+            ).to_dict()
+
+            _handle_egress_message(
+                picked_guid="guid-telegram-completion",
+                picked_payload=payload,
+                ledger=ledger,
+                store=store,
+                attachment_store=attachment_store,
+                attachment_cleanup_settings=TelegramAttachmentCleanupSettings(
+                    attachment_root_dir=str(attachment_dir),
+                    cleanup_grace_seconds=3600,
+                    max_age_seconds=86400,
+                ),
+                allowed_egress_channels={"log"},
+                applier=applier,
+                ack_callback=acked.append,
+            )
+
+            self.assertEqual(acked, ["guid-telegram-completion"])
+            records = attachment_store.list_records()
+            self.assertEqual(len(records), 1)
+            self.assertIsNotNone(records[0].eligible_after)
+            self.assertTrue(attachment_path.exists())
+
+    def test_cleanup_telegram_attachments_deletes_only_after_completion_grace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            attachment_dir = Path(tmpdir) / "attachments"
+            attachment_dir.mkdir()
+            attachment_path = attachment_dir / "telegram-photo.jpg"
+            attachment_path.write_bytes(b"photo-bytes")
+
+            attachment_store = TelegramAttachmentStore(db_path)
+            task_message = self._build_telegram_attachment_task_message(attachment_path.resolve().as_uri())
+            attachment_store.record_task_attachments(
+                task_message=task_message,
+                attachment_root_dir=str(attachment_dir),
+            )
+            attachment_store.mark_task_attachments_eligible(
+                task_id=task_message.task_id,
+                eligible_after=datetime(2026, 3, 6, 13, 0, tzinfo=timezone.utc),
+            )
+
+            before = cleanup_telegram_attachments(
+                attachment_store=attachment_store,
+                attachment_root_dir=str(attachment_dir),
+                completion_grace_period=timedelta(hours=1),
+                max_attachment_age=timedelta(days=30),
+                now=datetime(2026, 3, 6, 12, 59, tzinfo=timezone.utc),
+            )
+            self.assertEqual(before.deleted_count, 0)
+            self.assertTrue(attachment_path.exists())
+
+            after = cleanup_telegram_attachments(
+                attachment_store=attachment_store,
+                attachment_root_dir=str(attachment_dir),
+                completion_grace_period=timedelta(hours=1),
+                max_attachment_age=timedelta(days=30),
+                now=datetime(2026, 3, 6, 13, 1, tzinfo=timezone.utc),
+            )
+
+            self.assertEqual(after.deleted_count, 1)
+            self.assertFalse(attachment_path.exists())
+
+    def test_cleanup_telegram_attachments_deletes_orphaned_file_after_max_age(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "handler.db")
+            attachment_dir = Path(tmpdir) / "attachments"
+            attachment_dir.mkdir()
+            attachment_path = attachment_dir / "telegram-photo.jpg"
+            attachment_path.write_bytes(b"photo-bytes")
+
+            attachment_store = TelegramAttachmentStore(db_path)
+            task_message = self._build_telegram_attachment_task_message(attachment_path.resolve().as_uri())
+            attachment_store.record_task_attachments(
+                task_message=task_message,
+                attachment_root_dir=str(attachment_dir),
+            )
+
+            import sqlite3
+
+            with sqlite3.connect(db_path) as connection:
+                connection.execute(
+                    "UPDATE telegram_attachment_ledger SET created_at = ? WHERE task_id = ?",
+                    ("2026-02-01T00:00:00Z", task_message.task_id),
+                )
+                connection.commit()
+
+            result = cleanup_telegram_attachments(
+                attachment_store=attachment_store,
+                attachment_root_dir=str(attachment_dir),
+                completion_grace_period=timedelta(days=7),
+                max_attachment_age=timedelta(days=30),
+                now=datetime(2026, 3, 15, 12, 0, tzinfo=timezone.utc),
+            )
+
+            self.assertEqual(result.deleted_count, 1)
+            self.assertFalse(attachment_path.exists())
 
     def test_handle_egress_message_applies_completion_without_external_dispatch(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -718,6 +870,7 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
             github_scanned_events=5,
             github_new_events=2,
             github_published=1,
+            telegram_attachment_cleanup=None,
             telemetry_snapshot=telemetry_snapshot,
             completed_at=datetime(2026, 3, 6, 12, 1, tzinfo=timezone.utc),
         )
@@ -730,6 +883,10 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
         self.assertEqual(snapshot["github_scanned_events_total"], 5)
         self.assertEqual(snapshot["github_new_events_total"], 2)
         self.assertEqual(snapshot["github_published_total"], 1)
+        self.assertEqual(snapshot["telegram_attachment_cleanup_deleted_total"], 0)
+        self.assertEqual(snapshot["telegram_attachment_cleanup_missing_total"], 0)
+        self.assertEqual(snapshot["telegram_attachment_cleanup_failed_total"], 0)
+        self.assertEqual(snapshot["telegram_attachment_cleanup_reclaimed_bytes_total"], 0)
         self.assertEqual(snapshot["last_loop_completed_timestamp_seconds"], 1772798460.0)
         self.assertEqual(snapshot["egress_loops_total"], 0)
         self.assertEqual(snapshot["last_egress_loop_completed_timestamp_seconds"], 0.0)
@@ -746,6 +903,10 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
                 "github_scanned_events_total": 5,
                 "github_new_events_total": 3,
                 "github_published_total": 1,
+                "telegram_attachment_cleanup_deleted_total": 2,
+                "telegram_attachment_cleanup_missing_total": 1,
+                "telegram_attachment_cleanup_failed_total": 0,
+                "telegram_attachment_cleanup_reclaimed_bytes_total": 4096,
                 "last_loop_completed_timestamp_seconds": 1772798460.0,
                 "egress_loops_total": 5,
                 "last_egress_loop_completed_timestamp_seconds": 1772798461.0,
@@ -774,6 +935,11 @@ class MessageHandlerRuntimeTests(unittest.TestCase):
         )
         self.assertIn("chatting_message_handler_loops_total 2", rendered)
         self.assertIn("chatting_message_handler_github_published_total 1", rendered)
+        self.assertIn("chatting_message_handler_telegram_attachment_cleanup_deleted_total 2", rendered)
+        self.assertIn(
+            "chatting_message_handler_telegram_attachment_cleanup_reclaimed_bytes_total 4096",
+            rendered,
+        )
         self.assertIn("chatting_message_handler_egress_loops_total 5", rendered)
         self.assertIn("chatting_message_handler_egress_received_total 7", rendered)
         self.assertIn("chatting_message_handler_egress_message_dispatched_total 2", rendered)


### PR DESCRIPTION
## Summary
- add a message-handler attachment ledger for Telegram-downloaded local files
- mark Telegram attachments cleanup-eligible only after task completion, with a configurable grace period plus a max-age fallback for orphaned files
- expose cleanup metrics/logging and document the retention policy and settings

## Testing
- python3 -m unittest discover -s tests

Closes #59