### PR TITLE
Use BBMB release binary in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.23'
-
-      - name: Checkout BBMB
-        uses: actions/checkout@v4
-        with:
-          repository: EdwardSalkeld/bbmb
-          path: bbmb
-
-      - name: Build bbmb-server
+      - name: Download bbmb-server release
         run: |
-          cd bbmb/server
-          go build -o ../bbmb-server .
+          curl -fsSL \
+            -o "${{ runner.temp }}/bbmb-server-linux-amd64" \
+            https://github.com/EdwardSalkeld/bbmb/releases/latest/download/bbmb-server-linux-amd64
+          curl -fsSL \
+            -o "${{ runner.temp }}/bbmb-server-linux-amd64.sha256" \
+            https://github.com/EdwardSalkeld/bbmb/releases/latest/download/bbmb-server-linux-amd64.sha256
+          (
+            cd "${{ runner.temp }}"
+            sha256sum -c bbmb-server-linux-amd64.sha256
+          )
+          chmod +x "${{ runner.temp }}/bbmb-server-linux-amd64"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -41,5 +39,5 @@ jobs:
 
       - name: Run unit tests
         env:
-          CHATTING_BBMB_SERVER_BIN: ${{ github.workspace }}/bbmb/bbmb-server
+          CHATTING_BBMB_SERVER_BIN: ${{ runner.temp }}/bbmb-server-linux-amd64
         run: python3 -m unittest discover -s tests

--- a/docs/debug-and-test.md
+++ b/docs/debug-and-test.md
@@ -112,4 +112,4 @@ Use these with DB queries to correlate outcomes.
 - Workflow file: `.github/workflows/ci.yml`
 - Triggers: push to `main`, and pull requests targeting `main`
 - Python version: `3.13`
-- CI also builds `bbmb-server` and sets `CHATTING_BBMB_SERVER_BIN` before running the test suite.
+- CI downloads the latest BBMB release binary, verifies its published SHA256, and sets `CHATTING_BBMB_SERVER_BIN` before running the test suite.


### PR DESCRIPTION
## Summary
- replace the BBMB checkout and local Go build in CI with a download of the latest BBMB release binary
- verify the published SHA256 before running tests
- update the debug/testing docs to match the new CI setup

## Verification
- downloaded `releases/latest` assets for `bbmb-server-linux-amd64` and `.sha256`
- `sha256sum -c` passed against the live release asset
