### PR TITLE
Run worker tasks in reply-channel lanes

### DIFF
--- a/app/main_worker.py
+++ b/app/main_worker.py
@@ -32,6 +32,7 @@ ALLOWED_WORKER_CONFIG_KEYS = frozenset(
         "codex_command",
         "codex_working_dir",
         "db_path",
+        "max_parallel_lanes",
         "max_attempts",
         "max_loops",
         "poll_timeout_seconds",
@@ -40,7 +41,7 @@ ALLOWED_WORKER_CONFIG_KEYS = frozenset(
     }
 )
 BBMB_PICKUP_WAIT_SECONDS = 10
-DEFAULT_MAX_PARALLEL_LANES = 8
+DEFAULT_MAX_PARALLEL_LANES = 4
 
 
 @dataclass(frozen=True)
@@ -161,6 +162,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--config", help="Path to JSON config file.")
     parser.add_argument("--db-path", help="Path to worker SQLite state DB.")
     parser.add_argument("--bbmb-address", help="BBMB broker address host:port.")
+    parser.add_argument(
+        "--max-parallel-lanes",
+        type=_positive_int,
+        help="Maximum number of reply-channel lanes the worker can process concurrently.",
+    )
     parser.add_argument("--max-attempts", type=_positive_int, help="Maximum execution attempts per task.")
     parser.add_argument("--max-loops", type=_positive_int, help="Optional loop limit for smoke tests.")
     parser.add_argument("--poll-timeout-seconds", type=_positive_int, help="Queue pickup timeout seconds.")
@@ -362,6 +368,12 @@ def main() -> int:
         default_value=2,
         setting_name="max_attempts",
     )
+    max_parallel_lanes = _resolve_positive_int(
+        args.max_parallel_lanes,
+        config.get("max_parallel_lanes"),
+        default_value=DEFAULT_MAX_PARALLEL_LANES,
+        setting_name="max_parallel_lanes",
+    )
     max_loops = _resolve_positive_int(
         args.max_loops,
         config.get("max_loops"),
@@ -390,7 +402,7 @@ def main() -> int:
     policy = AllowlistPolicyEngine(allowed_action_types=frozenset({"write_file"}))
     executor = _build_executor(args, config)
     lane_executor = LaneSerialExecutor(
-        max_workers=DEFAULT_MAX_PARALLEL_LANES,
+        max_workers=max_parallel_lanes,
         handler=lambda picked_task, lane_key: _process_picked_task(
             picked_task=picked_task,
             lane_key=lane_key,

--- a/docs/bbmb-message-flow.md
+++ b/docs/bbmb-message-flow.md
@@ -244,6 +244,8 @@ This gives a built-in round-trip signal for the handler -> BBMB -> worker -> BBM
   Useful for smoke runs; not a normal production setting.
 - `max_attempts`
   Retry budget before the task becomes a dead letter.
+- `max_parallel_lanes`
+  Caps how many reply-channel lanes can run at once. Each lane is still serialized internally.
 - `use_stub_executor`
   Replaces the real executor path for testing/smoke runs.
 - `codex_command`, `codex_working_dir`

--- a/tests/test_main_worker.py
+++ b/tests/test_main_worker.py
@@ -1,9 +1,12 @@
 import threading
+import tempfile
 import unittest
 from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
 
 from app.broker import TaskQueueMessage
-from app.main_worker import LaneSerialExecutor, PickedTask, _task_lane_key
+from app.main_worker import DEFAULT_MAX_PARALLEL_LANES, LaneSerialExecutor, PickedTask, _load_config, _parse_args, _task_lane_key
 from app.models import ReplyChannel, TaskEnvelope
 
 
@@ -104,6 +107,26 @@ class MainWorkerLaneTests(unittest.TestCase):
             executor.shutdown()
 
         self.assertEqual(started_count, 2)
+
+
+class MainWorkerConfigTests(unittest.TestCase):
+    def test_parse_args_accepts_max_parallel_lanes(self) -> None:
+        with patch("sys.argv", ["app.main_worker", "--max-parallel-lanes", "3"]):
+            args = _parse_args()
+
+        self.assertEqual(args.max_parallel_lanes, 3)
+
+    def test_load_config_allows_max_parallel_lanes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "worker.json"
+            config_path.write_text('{"max_parallel_lanes": 2}', encoding="utf-8")
+
+            config = _load_config(str(config_path))
+
+        self.assertEqual(config["max_parallel_lanes"], 2)
+
+    def test_default_max_parallel_lanes_matches_expected_lane_count_budget(self) -> None:
+        self.assertEqual(DEFAULT_MAX_PARALLEL_LANES, 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run worker tasks through a lane executor keyed by reply channel so telegram and heartbeat work can continue while Codex is busy
- preserve in-order processing within each lane by queueing follow-on tasks behind the active future
- add worker tests covering per-lane parallelism, per-lane serialization, and shutdown waiting

Closes #64

## Testing
- python3 -m unittest tests.test_main_worker tests.test_worker_runtime tests.test_message_handler_runtime
- python3 -m unittest discover -s tests