### PR TITLE
Fix cron UTC default for direct schedule jobs

### DIFF
--- a/app/connectors/interval_schedule_connector.py
+++ b/app/connectors/interval_schedule_connector.py
@@ -38,8 +38,6 @@ class IntervalScheduleJob:
             raise ValueError("cron must be non-empty when provided")
         if self.cron is None and self.timezone_name is not None:
             raise ValueError("timezone is only supported when cron is provided")
-        if self.cron is not None and self.timezone_name is None:
-            raise ValueError("timezone is required when cron is provided")
         if self.timezone_name is not None:
             if not self.timezone_name.strip():
                 raise ValueError("timezone must be non-empty when provided")

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -173,6 +173,16 @@ class IntervalScheduleConnectorTests(unittest.TestCase):
                 context_refs=[],
             )
 
+    def test_cron_job_defaults_timezone_to_utc(self) -> None:
+        job = IntervalScheduleJob(
+            job_name="utc-default",
+            content="Run",
+            cron="0 8 * * *",
+            context_refs=[],
+        )
+
+        self.assertIsNone(job.timezone_name)
+
     def test_poll_emits_cron_job_in_configured_timezone(self) -> None:
         clock = _MutableClock(datetime(2026, 2, 28, 8, 0, tzinfo=timezone.utc))
         connector = IntervalScheduleConnector(


### PR DESCRIPTION
## Summary
- allow direct `IntervalScheduleJob` cron definitions to omit `timezone_name`, matching the documented UTC default used by schedule-file loading
- add regression coverage for constructing cron jobs without an explicit timezone

## Testing
- python3 -m unittest tests.test_connectors tests.test_main tests.test_split_mode_e2e