### PR TITLE
Auto-append structured output args to executor commands

### DIFF
--- a/app/executor/__init__.py
+++ b/app/executor/__init__.py
@@ -1,6 +1,6 @@
 """Executor package."""
 
 from app.executor.base import Executor
-from app.executor.codex import CodexExecutor, parse_execution_result
+from app.executor.codex import EXECUTION_RESULT_JSON_SCHEMA, CodexExecutor, parse_execution_result
 
-__all__ = ["Executor", "CodexExecutor", "parse_execution_result"]
+__all__ = ["Executor", "CodexExecutor", "EXECUTION_RESULT_JSON_SCHEMA", "parse_execution_result"]

--- a/app/executor/codex.py
+++ b/app/executor/codex.py
@@ -33,6 +33,21 @@ _REQUIRED_TOP_LEVEL_KEYS = {
 _ALLOWED_ACTION_KEYS = {"type", "path", "content"}
 _ALLOWED_CONFIG_UPDATE_KEYS = {"path", "value"}
 
+EXECUTION_RESULT_JSON_SCHEMA = json.dumps(
+    {
+        "type": "object",
+        "properties": {
+            "schema_version": {"type": "string"},
+            "actions": {"type": "array"},
+            "config_updates": {"type": "array"},
+            "requires_human_review": {"type": "boolean"},
+            "errors": {"type": "array"},
+        },
+        "required": sorted(_REQUIRED_TOP_LEVEL_KEYS),
+    },
+    separators=(",", ":"),
+)
+
 
 @dataclass(frozen=True)
 class CodexExecutor:

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.connectors import (
     IntervalScheduleJob,
     TelegramConnector,
 )
-from app.executor import CodexExecutor, Executor
+from app.executor import EXECUTION_RESULT_JSON_SCHEMA, CodexExecutor, Executor
 from app.models import AuditEvent, DeadLetterRecord, OutboundMessage, PolicyDecision, RunRecord, TaskEnvelope
 from app.policy import AllowlistPolicyEngine
 from app.router import RuleBasedRouter
@@ -38,6 +38,7 @@ CONFIG_PATH_ENV_VAR = "CHATTING_CONFIG_PATH"
 ALLOWED_RUNTIME_CONFIG_KEYS = frozenset(
     {
         "base_dir",
+        "claude_command",
         "codex_command",
         "context_ref",
         "context_refs",
@@ -906,15 +907,28 @@ def _build_telegram_sender(
 
 
 def _build_codex_executor(args: argparse.Namespace, config: dict[str, object]) -> Executor:
-    codex_command = _resolve_str(
+    codex_raw = _resolve_optional_str(
         cli_value=args.codex_command,
         config_value=config.get("codex_command"),
-        default_value="codex exec --json",
         setting_name="codex_command",
     )
-    command = tuple(shlex.split(codex_command))
-    if not command:
-        raise ValueError("--codex-command must not be empty")
+    claude_raw = _resolve_optional_str(
+        cli_value=getattr(args, "claude_command", None),
+        config_value=config.get("claude_command"),
+        setting_name="claude_command",
+    )
+
+    if codex_raw:
+        command = tuple(shlex.split(codex_raw)) + ("--json",)
+    elif claude_raw:
+        command = tuple(shlex.split(claude_raw)) + (
+            "-p",
+            "--output-format", "json",
+            "--json-schema", EXECUTION_RESULT_JSON_SCHEMA,
+        )
+    else:
+        command = ("codex", "exec", "--json")
+
     return CodexExecutor(command=command)
 
 

--- a/app/main_worker.py
+++ b/app/main_worker.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Mapping
 
 from app.broker import BBMBQueueAdapter, EGRESS_QUEUE_NAME, EgressQueueMessage, TASK_QUEUE_NAME, TaskQueueMessage
-from app.executor import CodexExecutor, Executor
+from app.executor import EXECUTION_RESULT_JSON_SCHEMA, CodexExecutor, Executor
 from app.policy import AllowlistPolicyEngine
 from app.router import RuleBasedRouter
 from app.state import SQLiteStateStore, StateStore
@@ -29,6 +29,7 @@ LOGGER = logging.getLogger(__name__)
 ALLOWED_WORKER_CONFIG_KEYS = frozenset(
     {
         "bbmb_address",
+        "claude_command",
         "codex_command",
         "codex_working_dir",
         "db_path",
@@ -170,10 +171,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--max-loops", type=_positive_int, help="Optional loop limit for smoke tests.")
     parser.add_argument("--poll-timeout-seconds", type=_positive_int, help="Queue pickup timeout seconds.")
     parser.add_argument("--sleep-seconds", type=_positive_float, help="Sleep duration after empty pickup.")
-    parser.add_argument("--codex-command", help="Command used for Codex executor.")
+    parser.add_argument("--codex-command", help="Base Codex command (e.g. 'codex exec'). JSON args appended automatically.")
+    parser.add_argument("--claude-command", help="Base Claude command (e.g. 'claude'). Structured output args appended automatically.")
     parser.add_argument(
         "--codex-working-dir",
-        help="Working directory used only for launching Codex subprocesses.",
+        help="Working directory used only for launching executor subprocesses.",
     )
     return parser.parse_args()
 
@@ -262,21 +264,39 @@ def _resolve_bool(cli_value: bool, config_value: object, *, default_value: bool,
 
 
 def _build_executor(args: argparse.Namespace, config: dict[str, object]) -> Executor:
-    command = _resolve_str(
-        args.codex_command,
-        config.get("codex_command"),
-        default_value="codex exec --json",
-        setting_name="codex_command",
-    )
-    split_command = tuple(shlex.split(command))
-    if not split_command:
-        raise ValueError("codex_command must not be empty")
     codex_working_dir = _resolve_optional_str(
         args.codex_working_dir,
         config.get("codex_working_dir"),
         setting_name="codex_working_dir",
     )
-    return CodexExecutor(command=split_command, cwd=codex_working_dir)
+
+    # Prefer codex_command if set, fall back to claude_command
+    codex_raw = _resolve_optional_str(
+        args.codex_command,
+        config.get("codex_command"),
+        setting_name="codex_command",
+    )
+    claude_raw = _resolve_optional_str(
+        getattr(args, "claude_command", None),
+        config.get("claude_command"),
+        setting_name="claude_command",
+    )
+
+    if codex_raw:
+        command = tuple(shlex.split(codex_raw)) + ("--json",)
+    elif claude_raw:
+        command = tuple(shlex.split(claude_raw)) + (
+            "-p",
+            "--output-format", "json",
+            "--json-schema", EXECUTION_RESULT_JSON_SCHEMA,
+        )
+    else:
+        command = ("codex", "exec", "--json")
+
+    if not command:
+        raise ValueError("codex_command or claude_command must be configured")
+
+    return CodexExecutor(command=command, cwd=codex_working_dir)
 
 
 def _task_lane_key(task_message: TaskQueueMessage) -> str:

--- a/configs/worker-runtime.example.json
+++ b/configs/worker-runtime.example.json
@@ -5,6 +5,6 @@
   "poll_timeout_seconds": 20,
   "sleep_seconds": 1.0,
   "max_loops": 1,
-  "codex_command": "codex exec --json",
+  "codex_command": "codex exec",
   "codex_working_dir": "/opt/chatting"
 }

--- a/configs/worker.json.example
+++ b/configs/worker.json.example
@@ -4,6 +4,6 @@
   "max_attempts": 2,
   "poll_timeout_seconds": 20,
   "sleep_seconds": 1.0,
-  "codex_command": "codex exec --json",
+  "codex_command": "codex exec",
   "codex_working_dir": "/workspace"
 }


### PR DESCRIPTION
Config now just provides the base command ("codex exec" or "claude") and the worker appends the necessary structured output args automatically. Added a claude_command config key alongside codex_command - if both are set, codex wins.

Breaking change: existing configs that include --json in codex_command will get it doubled, so they need updating.

Closes #91