### PR TITLE
docs: remove historical wording

### DIFF
--- a/docs/bbmb-message-flow.md
+++ b/docs/bbmb-message-flow.md
@@ -19,7 +19,7 @@ Use it as the source of truth for:
 
 ## Queues
 
-There are currently two BBMB queues:
+There are two BBMB queues:
 
 | Queue | Producer | Consumer | Purpose |
 | --- | --- | --- | --- |
@@ -27,11 +27,11 @@ There are currently two BBMB queues:
 | `chatting.egress.v1` | `worker` | `message-handler` | Carries `chatting.egress.v2` payloads for visible executor-published incrementals and internal completion |
 
 Important details:
-- Queue names are hardcoded today.
+- Queue names are hardcoded.
 - There is no separate BBMB retry queue, dead-letter queue, or approval queue.
 - Retries, dead letters, ingress dedupe state, the task ledger, and the worker egress outbox all
   live in SQLite, not in BBMB.
-- The current worker emits `chatting.egress.v2` payloads on `chatting.egress.v1`. The queue name is
+- The worker emits `chatting.egress.v2` payloads on `chatting.egress.v1`. The queue name is
   transport-level; the `message_type` inside the JSON is the payload contract version.
 - `message-handler` enforces this contract and rejects legacy `chatting.egress.v1` payload types.
 
@@ -62,7 +62,7 @@ Examples:
 it, runs policy, persists run and audit records, and always emits exactly one terminal
 `event_kind="completion"` egress message.
 
-Current worker behavior:
+Worker behavior:
 - the executor returns only completion metadata, actions, config updates, and errors
 - the executor must publish any visible reply itself with `app.main_reply`
 - terminal task closure uses `event_kind="completion"` and is internal-only

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -6,7 +6,7 @@ Module: `app.connectors.slack_connector`
 
 Normalize Slack-style message payloads into canonical IM envelopes.
 
-## Current integration state
+## Integration state
 
 - Connector module is implemented and unit-tested.
 - It is not wired into the split-mode runtime CLI/config yet.

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -40,9 +40,9 @@ Matching CLI flags exist (`--telegram-enabled`, `--telegram-bot-token-env`, etc.
 - Offset is advanced as `highest_update_id + 1` each poll.
 - The message handler tracks downloaded Telegram attachments in its SQLite DB and only makes them cleanup-eligible after the task reaches terminal completion.
 - Cleanup uses a hybrid policy:
-  terminal tasks wait for `telegram_attachment_cleanup_grace_seconds`, while orphaned/dead-lettered attachments are still reclaimed once they exceed `telegram_attachment_max_age_seconds`.
+  terminal tasks wait for `telegram_attachment_cleanup_grace_seconds`, while orphaned/dead-lettered attachments are reclaimed once they exceed `telegram_attachment_max_age_seconds`.
 - Cleanup runs in the message-handler loop and logs tracked, eligible, deleted, missing, and failed attachment cleanup events.
-- In production, point `telegram_attachment_dir` at durable storage when workers need access beyond ingress, but expect the handler to reclaim old files automatically unless you increase the retention settings.
+- In production, point `telegram_attachment_dir` at durable storage when workers need access beyond ingress; the handler reclaims old files automatically unless you increase the retention settings.
 
 ## Outbound egress
 
@@ -57,7 +57,7 @@ Matching CLI flags exist (`--telegram-enabled`, `--telegram-bot-token-env`, etc.
   - image MIME types go to `sendPhoto`
   - everything else goes to `sendDocument`
 - Attachment constraints:
-  - only local absolute `file://` paths are supported today
+  - only local absolute `file://` paths are supported
   - the referenced file must already exist on disk when dispatch runs
   - upload/API failures surface deterministic Telegram reason codes such as `telegram_attachment_missing` and `telegram_attachment_send_failed`
 - Outbound attachments under `telegram_attachment_dir` are tracked in the same cleanup ledger as inbound downloads and become cleanup-eligible after task completion.

--- a/docs/connectors/webhook.md
+++ b/docs/connectors/webhook.md
@@ -6,7 +6,7 @@ Module: `app.connectors.webhook_connector`
 
 Drain queued webhook events into canonical webhook envelopes.
 
-## Current integration state
+## Integration state
 
 - Connector module is implemented and unit-tested.
 - It is not wired into the split-mode runtime CLI/config yet.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-This system now runs in split mode only:
+`chatting` runs as three services:
 - `message-handler`
 - `worker`
 - `bbmb-server`
@@ -74,6 +74,6 @@ uv run python -m app.cli --db-path /tmp/chatting-message-handler.db --list-metri
 - For the queue-by-queue runtime conversation, payload examples, and config levers, see
   [BBMB Message Flow](bbmb-message-flow.md).
 - For full split-mode setup and operational details, see [Run Split Mode (BBMB)](run-split-bbmb.md).
-- `app.cli`/`app.main` no longer run bootstrap/live runtime execution.
+- `app.cli`/`app.main` are admin/query entrypoints only.
 - `app.cli` reads one SQLite database at a time. In split mode, point it at either the
   message-handler DB or the worker DB depending on what you want to inspect.

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -1,6 +1,6 @@
 # Running Split Mode With BBMB
 
-This mode runs `chatting` as a 3-part application:
+`chatting` runs as three services:
 - `message-handler` on the integration host (connectors + outbound dispatch)
 - `worker` on the execution host (routing + executor + policy)
 - `bbmb-server` in the middle (message bus)
@@ -128,7 +128,7 @@ uv run python -m app.main_reply task:email:53 \
 Notes:
 - `message_type` is `chatting.egress.v2` with `event_kind=incremental`.
 - These events are intentionally unsequenced and dispatch immediately at `message-handler`.
-- In the current contract, executor stdout is completion-only; visible replies belong here.
+- Executor stdout is completion-only; visible replies belong here.
 - `--event-id` can be supplied for stable idempotency across retries.
 - Telegram reactions use the same CLI, but publish `telegram_reaction` egress under the hood:
 


### PR DESCRIPTION
## Summary
- rewrite runtime docs so they describe the current system directly instead of referencing past states
- tighten connector doc headings and cleanup wording that implied transitional behaviour
- leave architecture ADR history alone and keep the docs changes scoped to active runtime docs

## Testing
- not run (docs-only change)

Closes #98