### PR TITLE
Accept Codex metadata in execution results

### DIFF
--- a/app/worker/executor/codex.py
+++ b/app/worker/executor/codex.py
@@ -19,6 +19,8 @@ _ALLOWED_TOP_LEVEL_KEYS = {
     "schema_version",
     "actions",
     "errors",
+    "type",
+    "usage",
 }
 _REQUIRED_TOP_LEVEL_KEYS = {
     "schema_version",

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -73,6 +73,24 @@ class ParseExecutionResultTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unknown_top_level_keys"):
             parse_execution_result(payload)
 
+    def test_parse_execution_result_accepts_codex_metadata_fields(self) -> None:
+        payload = json.dumps(
+            {
+                "type": "result",
+                "schema_version": "1.0",
+                "actions": [],
+                "errors": [],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                },
+            }
+        )
+
+        result = parse_execution_result(payload)
+
+        self.assertEqual(result.to_dict()["errors"], [])
+
     def test_parse_execution_result_rejects_legacy_messages_field(self) -> None:
         payload = json.dumps(
             {


### PR DESCRIPTION
## Summary
- allow Codex executor results to include top-level `type` and `usage` metadata without failing parsing
- add a regression test covering the metadata-bearing result payload

## Testing
- python3 -m unittest tests/test_executor.py