### PR TITLE
Fix bubblewrap warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GO_ARCHIVE=go${GO_VERSION}.linux-amd64.tar.gz
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends nodejs npm ca-certificates curl gh git gosu ripgrep \
+    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu ripgrep \
     && npm install -g @openai/codex @anthropic-ai/claude-code \
     && npm cache clean --force \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- install the Debian `bubblewrap` package in the runtime image
- ensure Codex finds `/usr/bin/bwrap` instead of warning and falling back to the vendored binary

## Testing
- `uv run ruff format --check` *(fails on current repo baseline: many unrelated files already need formatting)*
- Docker image build not run here because `docker` is not installed in the workspace
