### PR TITLE
Normalize doubly escaped Telegram output

### DIFF
--- a/app/handler/applier/integrated.py
+++ b/app/handler/applier/integrated.py
@@ -8,6 +8,7 @@ import mimetypes
 import smtplib
 import subprocess
 import html
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -724,6 +725,7 @@ def _is_telegram_parse_mode_error(response: dict[str, object]) -> bool:
 
 
 def _normalize_telegram_text_for_parse_mode(text: str, parse_mode: str | None) -> str:
+    text = _normalize_telegram_escaped_sequences(text)
     if parse_mode is None:
         return text
     if parse_mode == "HTML":
@@ -733,6 +735,21 @@ def _normalize_telegram_text_for_parse_mode(text: str, parse_mode: str | None) -
     if parse_mode == "Markdown":
         return _escape_telegram_markdown(text)
     return text
+
+
+def _normalize_telegram_escaped_sequences(text: str) -> str:
+    text = re.sub(r"\\+([nrt])", lambda match: _decode_backslash_escape(match.group(1)), text)
+    return re.sub(r"\\+([_*`\[\]()~>#\+\-=|{}.!])", r"\1", text)
+
+
+def _decode_backslash_escape(character: str) -> str:
+    if character == "n":
+        return "\n"
+    if character == "r":
+        return "\r"
+    if character == "t":
+        return "\t"
+    return character
 
 
 def _escape_telegram_markdown(text: str) -> str:

--- a/tests/test_applier.py
+++ b/tests/test_applier.py
@@ -656,6 +656,76 @@ class TelegramMessageSenderTests(unittest.TestCase):
             },
         )
 
+    def test_send_normalizes_double_escaped_newlines_and_markdown_punctuation(self) -> None:
+        seen_calls: list[tuple[str, dict[str, object], float]] = []
+
+        def fake_http_post_json(
+            url: str,
+            payload: dict[str, object],
+            timeout: float,
+        ) -> dict[str, object]:
+            seen_calls.append((url, payload, timeout))
+            return {"ok": True, "result": {"message_id": 6}}
+
+        sender = TelegramMessageSender(
+            bot_token="token",
+            http_post_json=fake_http_post_json,
+        )
+
+        sender.send(
+            "12345",
+            OutboundMessage(
+                channel="telegram",
+                target="12345",
+                body=r"Your three 1960s albums are:\\n\\n- Gal Costa \\(second edition\\)",
+            ),
+        )
+
+        self.assertEqual(len(seen_calls), 1)
+        self.assertEqual(
+            seen_calls[0][1],
+            {
+                "chat_id": "12345",
+                "text": "Your three 1960s albums are:\n\n- Gal Costa \\(second edition\\)",
+                "parse_mode": "Markdown",
+            },
+        )
+
+    def test_send_normalizes_repeated_backslashes_before_newline_escape(self) -> None:
+        seen_calls: list[tuple[str, dict[str, object], float]] = []
+
+        def fake_http_post_json(
+            url: str,
+            payload: dict[str, object],
+            timeout: float,
+        ) -> dict[str, object]:
+            seen_calls.append((url, payload, timeout))
+            return {"ok": True, "result": {"message_id": 7}}
+
+        sender = TelegramMessageSender(
+            bot_token="token",
+            http_post_json=fake_http_post_json,
+        )
+
+        sender.send(
+            "12345",
+            OutboundMessage(
+                channel="telegram",
+                target="12345",
+                body=r"Line one\\\\nLine two",
+            ),
+        )
+
+        self.assertEqual(len(seen_calls), 1)
+        self.assertEqual(
+            seen_calls[0][1],
+            {
+                "chat_id": "12345",
+                "text": "Line one\nLine two",
+                "parse_mode": "Markdown",
+            },
+        )
+
     def test_send_photo_attachment_posts_multipart_with_caption(self) -> None:
         seen_calls: list[tuple[str, dict[str, object], str, Path, float]] = []
 


### PR DESCRIPTION
## Summary
- normalize double-escaped newline sequences before Telegram parse-mode escaping
- collapse repeated backslashes before Telegram Markdown punctuation so already-escaped model output does not leak stray backslashes
- add regression tests for the reported multiline album reply shape and repeated backslash-newline input

## Testing
- `uv run ruff check app/handler/applier/integrated.py tests/test_applier.py`
- `uv run python -m unittest tests.test_applier`
