### PR TITLE
Remove non-cron schedule format

### DIFF
--- a/app/handler/connectors/interval_schedule_connector.py
+++ b/app/handler/connectors/interval_schedule_connector.py
@@ -1,9 +1,9 @@
-"""Interval and cron-based scheduled-event connector."""
+"""Cron-based scheduled-event connector."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Callable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -19,11 +19,9 @@ class IntervalScheduleJob:
     job_name: str
     content: str
     context_refs: list[str]
+    cron: str
     prompt_context: list[str] = field(default_factory=list)
-    interval_seconds: int | None = None
-    cron: str | None = None
     timezone_name: str | None = None
-    start_at: datetime | None = None
     reply_channel_type: str | None = None
     reply_channel_target: str | None = None
 
@@ -36,22 +34,13 @@ class IntervalScheduleJob:
             isinstance(item, str) and item.strip() for item in self.prompt_context
         ):
             raise ValueError("prompt_context must be a list of non-empty strings")
-        if self.interval_seconds is None and self.cron is None:
-            raise ValueError("interval_seconds or cron is required")
-        if self.interval_seconds is not None and self.interval_seconds <= 0:
-            raise ValueError("interval_seconds must be positive")
-        if self.cron is not None and not self.cron.strip():
+        if not self.cron.strip():
             raise ValueError("cron must be non-empty when provided")
-        if self.cron is None and self.timezone_name is not None:
-            raise ValueError("timezone is only supported when cron is provided")
         if self.timezone_name is not None:
             if not self.timezone_name.strip():
                 raise ValueError("timezone must be non-empty when provided")
             _load_timezone(self.timezone_name)
-        if self.cron is not None:
-            _validate_cron(self.cron)
-        if self.start_at is not None and self.start_at.tzinfo is None:
-            raise ValueError("start_at must be timezone-aware")
+        _validate_cron(self.cron)
         if self.reply_channel_type is not None and not self.reply_channel_type.strip():
             raise ValueError("reply_channel_type must be non-empty when provided")
         if self.reply_channel_target is not None and not self.reply_channel_target.strip():
@@ -63,7 +52,7 @@ class IntervalScheduleJob:
 
 
 class IntervalScheduleConnector:
-    """Emit cron-source envelopes when configured interval jobs are due."""
+    """Emit cron-source envelopes when configured jobs are due."""
 
     source = "cron"
 
@@ -125,26 +114,15 @@ class IntervalScheduleConnector:
 
 
 def _initial_next_run_at(*, job: IntervalScheduleJob, now: datetime) -> datetime:
-    if job.cron is not None:
-        return _find_next_cron_time(job=job, reference=now, inclusive=True)
-    baseline = job.start_at if job.start_at is not None else now
-    return _ensure_utc(baseline)
+    return _find_next_cron_time(job=job, reference=now, inclusive=True)
 
 
 def _next_due_time(*, job: IntervalScheduleJob, next_run_at: datetime, now: datetime) -> datetime:
-    if job.cron is not None:
-        return _find_next_cron_time(job=job, reference=now, inclusive=False)
-    if job.interval_seconds is None:
-        raise ValueError("interval_seconds must be configured for interval schedules")
-    next_due = next_run_at + timedelta(seconds=job.interval_seconds)
-    while next_due <= now:
-        next_due += timedelta(seconds=job.interval_seconds)
-    return next_due
+    del next_run_at
+    return _find_next_cron_time(job=job, reference=now, inclusive=False)
 
 
 def _find_next_cron_time(*, job: IntervalScheduleJob, reference: datetime, inclusive: bool) -> datetime:
-    if job.cron is None:
-        raise ValueError("cron must be configured for cron schedules")
     tz = _job_timezone(job)
     local_ref = _ensure_utc(reference).astimezone(tz)
     if inclusive:

--- a/app/handler/main.py
+++ b/app/handler/main.py
@@ -133,12 +133,10 @@ ALLOWED_SCHEDULE_JOB_KEYS = frozenset(
         "content",
         "cron",
         "context_refs",
-        "interval_seconds",
         "job_name",
         "prompt_context",
         "reply_channel_target",
         "reply_channel_type",
-        "start_at",
         "timezone",
     }
 )
@@ -1365,41 +1363,17 @@ def _load_schedule_jobs(schedule_file: str) -> list[IntervalScheduleJob]:
             )
 
         cron = raw_job.get("cron")
-        if cron is not None and (not isinstance(cron, str) or not cron.strip()):
+        if not isinstance(cron, str) or not cron.strip():
             raise ValueError(
                 f"schedule job at index {index} cron must be a non-empty string"
             )
 
-        raw_interval = raw_job.get("interval_seconds")
-        interval_seconds: int | None = None
-        if isinstance(raw_interval, int) and not isinstance(raw_interval, bool):
-            interval_seconds = raw_interval
-        if cron is None:
-            if interval_seconds is None or interval_seconds <= 0:
-                raise ValueError(
-                    f"schedule job at index {index} interval_seconds must be a positive integer"
-                )
-        elif interval_seconds is not None and interval_seconds <= 0:
-            raise ValueError(
-                f"schedule job at index {index} interval_seconds must be a positive integer"
-            )
-
         timezone_name = raw_job.get("timezone")
-        if cron is not None:
-            if timezone_name is None:
-                timezone_name = "UTC"
-            elif not isinstance(timezone_name, str) or not timezone_name.strip():
-                raise ValueError(
-                    f"schedule job at index {index} timezone must be a non-empty string"
-                )
-        elif timezone_name is not None:
+        if timezone_name is None:
+            timezone_name = "UTC"
+        elif not isinstance(timezone_name, str) or not timezone_name.strip():
             raise ValueError(
-                f"schedule job at index {index} timezone is only valid with cron"
-            )
-
-        if interval_seconds is None and cron is None:
-            raise ValueError(
-                f"schedule job at index {index} must define interval_seconds or cron"
+                f"schedule job at index {index} timezone must be a non-empty string"
             )
 
         raw_context_refs = raw_job.get("context_refs", [])
@@ -1417,20 +1391,6 @@ def _load_schedule_jobs(schedule_file: str) -> list[IntervalScheduleJob]:
             raise ValueError(
                 f"schedule job at index {index} prompt_context must be a list of non-empty strings"
             )
-
-        raw_start_at = raw_job.get("start_at")
-        if cron is None:
-            if raw_start_at is not None and not isinstance(raw_start_at, str):
-                raise ValueError(
-                    f"schedule job at index {index} start_at must be an RFC3339 string"
-                )
-            start_at = (
-                _parse_optional_rfc3339(raw_start_at)
-                if raw_start_at is not None
-                else None
-            )
-        else:
-            start_at = None
 
         reply_channel_type = raw_job.get("reply_channel_type")
         if reply_channel_type is not None and (
@@ -1459,14 +1419,10 @@ def _load_schedule_jobs(schedule_file: str) -> list[IntervalScheduleJob]:
                 content=content.strip(),
                 context_refs=list(raw_context_refs),
                 prompt_context=list(raw_prompt_context),
-                interval_seconds=interval_seconds
-                if isinstance(interval_seconds, int)
-                else None,
-                cron=cron.strip() if isinstance(cron, str) else None,
+                cron=cron.strip(),
                 timezone_name=timezone_name.strip()
                 if isinstance(timezone_name, str)
                 else None,
-                start_at=start_at,
                 reply_channel_type=reply_channel_type.strip()
                 if isinstance(reply_channel_type, str)
                 else None,
@@ -1476,15 +1432,6 @@ def _load_schedule_jobs(schedule_file: str) -> list[IntervalScheduleJob]:
             )
         )
     return jobs
-
-
-def _parse_optional_rfc3339(value: str) -> datetime:
-    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if parsed.tzinfo is None:
-        raise ValueError("schedule job start_at must be timezone-aware")
-    return parsed.astimezone(timezone.utc)
-
-
 def _build_live_connectors_fail_open(
     args: argparse.Namespace,
     config: dict[str, object],

--- a/configs/live-schedule.example.json
+++ b/configs/live-schedule.example.json
@@ -2,8 +2,7 @@
   {
     "job_name": "heartbeat",
     "content": "Run scheduled heartbeat",
-    "interval_seconds": 300,
-    "start_at": "2026-03-07T00:00:00Z"
+    "cron": "*/5 * * * *"
   },
   {
     "job_name": "london-morning",

--- a/docs/connectors/interval-schedule.md
+++ b/docs/connectors/interval-schedule.md
@@ -4,7 +4,7 @@ Module: `app.connectors.interval_schedule_connector`
 
 ## Purpose
 
-Live scheduled-job connector that emits `cron`-source events from either fixed intervals or cron expressions.
+Live scheduled-job connector that emits `cron`-source events from cron expressions.
 
 ## Runtime config keys
 
@@ -16,34 +16,16 @@ Global schedule prompt guidance comes from message-handler config:
 Each job supports:
 - `job_name` (required)
 - `content` (required)
-- `interval_seconds` (optional positive int)
-- `cron` (optional 5-field cron expression)
-- `timezone` (optional with `cron`, defaults to `UTC`; uses an IANA name such as `Europe/London`)
+- `cron` (required 5-field cron expression)
+- `timezone` (optional, defaults to `UTC`; uses an IANA name such as `Europe/London`)
 - `context_refs` (optional list of non-empty strings)
 - `prompt_context` (optional list of per-job prompt instructions)
-- `start_at` (optional RFC3339 datetime for interval schedules)
 - `reply_channel_type` (optional non-empty string, requires `reply_channel_target`)
 - `reply_channel_target` (optional non-empty string, requires `reply_channel_type`)
 
-Each job must define at least one schedule:
-- interval mode: `interval_seconds` with optional `start_at`
-- cron mode: `cron` with an optional `timezone`
-
-If both `cron` and `interval_seconds` are present, cron scheduling takes precedence.
+Each job must define a cron schedule.
 
 ## Examples
-
-Interval:
-
-```json
-{
-  "job_name": "heartbeat",
-  "content": "Run scheduled heartbeat",
-  "interval_seconds": 300,
-  "start_at": "2026-03-07T00:00:00Z",
-  "prompt_context": ["Mention overdue alerts first."]
-}
-```
 
 Cron:
 
@@ -53,19 +35,6 @@ Cron:
   "content": "Prepare the 8am London update",
   "cron": "0 8 * * *",
   "timezone": "Europe/London"
-}
-```
-
-Cron with an interval fallback left in place during migration. The cron schedule wins:
-
-```json
-{
-  "job_name": "daily-summary",
-  "content": "Publish the daily summary",
-  "cron": "0 8 * * *",
-  "timezone": "Europe/London",
-  "interval_seconds": 86400,
-  "start_at": "2026-03-01T08:00:00Z"
 }
 ```
 
@@ -79,7 +48,7 @@ Cron with an interval fallback left in place during migration. The cron schedule
 
 ## Notes
 
-- Startup validation is strict: unknown keys, missing keys, invalid types, blank fields, invalid cron expressions, invalid timezone names, and invalid `start_at` values are rejected.
+- Startup validation is strict: unknown keys, missing keys, invalid types, blank fields, invalid cron expressions, and invalid timezone names are rejected.
 - Prompt guidance is assembled in this order before task content:
   global `prompt_context`, then `cron_prompt_context`, then the job's own `prompt_context`.
 - `reply_channel_type` and `reply_channel_target` must be provided together.

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -125,15 +125,14 @@ class FakeEmailConnectorTests(unittest.TestCase):
 
 
 class IntervalScheduleConnectorTests(unittest.TestCase):
-    def test_poll_emits_due_job_and_respects_interval(self) -> None:
+    def test_poll_emits_due_job_and_respects_cron_schedule(self) -> None:
         clock = _MutableClock(datetime(2026, 2, 28, 10, 0, tzinfo=timezone.utc))
         connector = IntervalScheduleConnector(
             jobs=[
                 IntervalScheduleJob(
                     job_name="heartbeat",
                     content="Run scheduled heartbeat",
-                    interval_seconds=60,
-                    start_at=datetime(2026, 2, 28, 10, 0, tzinfo=timezone.utc),
+                    cron="* * * * *",
                     context_refs=["repo:/home/edward/chatting"],
                 )
             ],
@@ -164,8 +163,7 @@ class IntervalScheduleConnectorTests(unittest.TestCase):
                 IntervalScheduleJob(
                     job_name="heartbeat",
                     content="Run scheduled heartbeat",
-                    interval_seconds=60,
-                    start_at=datetime(2026, 2, 28, 10, 0, tzinfo=timezone.utc),
+                    cron="* * * * *",
                     context_refs=[],
                     prompt_context=["Include yesterday's failures first."],
                 )
@@ -186,13 +184,11 @@ class IntervalScheduleConnectorTests(unittest.TestCase):
             ],
         )
 
-    def test_job_rejects_naive_start_at(self) -> None:
-        with self.assertRaisesRegex(ValueError, "timezone-aware"):
+    def test_job_requires_cron_expression(self) -> None:
+        with self.assertRaisesRegex(TypeError, "required positional argument: 'cron'"):
             IntervalScheduleJob(
                 job_name="daily",
                 content="Run",
-                interval_seconds=30,
-                start_at=datetime(2026, 2, 28, 10, 0),
                 context_refs=[],
             )
 
@@ -256,41 +252,6 @@ class IntervalScheduleConnectorTests(unittest.TestCase):
         self.assertEqual(
             second_poll[0].dedupe_key,
             "cron:london-morning:2026-03-01T08:00:00+00:00",
-        )
-
-    def test_cron_schedule_takes_precedence_over_interval_fields(self) -> None:
-        clock = _MutableClock(datetime(2026, 2, 28, 8, 0, tzinfo=timezone.utc))
-        connector = IntervalScheduleConnector(
-            jobs=[
-                IntervalScheduleJob(
-                    job_name="cron-wins",
-                    content="Use the cron schedule",
-                    interval_seconds=60,
-                    start_at=datetime(2026, 2, 28, 7, 0, tzinfo=timezone.utc),
-                    cron="0 8 * * *",
-                    timezone_name="UTC",
-                    context_refs=[],
-                )
-            ],
-            now_provider=clock.now,
-        )
-
-        first_poll = connector.poll()
-        self.assertEqual(len(first_poll), 1)
-        self.assertEqual(
-            first_poll[0].dedupe_key,
-            "cron:cron-wins:2026-02-28T08:00:00+00:00",
-        )
-
-        clock.set(datetime(2026, 2, 28, 8, 1, tzinfo=timezone.utc))
-        self.assertEqual(connector.poll(), [])
-
-        clock.set(datetime(2026, 3, 1, 8, 0, tzinfo=timezone.utc))
-        second_poll = connector.poll()
-        self.assertEqual(len(second_poll), 1)
-        self.assertEqual(
-            second_poll[0].dedupe_key,
-            "cron:cron-wins:2026-03-01T08:00:00+00:00",
         )
 
     def test_cron_schedule_fires_near_nonexistent_dst_local_times(self) -> None:
@@ -358,8 +319,7 @@ class IntervalScheduleConnectorTests(unittest.TestCase):
                 IntervalScheduleJob(
                     job_name="morning-weather",
                     content="Check weather in Leeds",
-                    interval_seconds=60,
-                    start_at=datetime(2026, 2, 28, 10, 0, tzinfo=timezone.utc),
+                    cron="0 10 * * *",
                     context_refs=["repo:/home/edward/chatting"],
                     reply_channel_type="telegram",
                     reply_channel_target="8605042448",
@@ -405,28 +365,6 @@ class IntervalScheduleConnectorTests(unittest.TestCase):
             second_poll[0].dedupe_key,
             "cron:london-morning:2026-03-02T08:00:00+00:00",
         )
-
-    def test_poll_uses_cron_precedence_when_interval_is_also_present(self) -> None:
-        clock = _MutableClock(datetime(2026, 3, 1, 8, 0, tzinfo=timezone.utc))
-        connector = IntervalScheduleConnector(
-            jobs=[
-                IntervalScheduleJob(
-                    job_name="cron-wins",
-                    content="Run cron-scheduled task",
-                    interval_seconds=60,
-                    cron="0 8 * * *",
-                    timezone_name="Europe/London",
-                    context_refs=[],
-                )
-            ],
-            now_provider=clock.now,
-        )
-
-        first_poll = connector.poll()
-        self.assertEqual(len(first_poll), 1)
-
-        clock.set(datetime(2026, 3, 1, 8, 1, tzinfo=timezone.utc))
-        self.assertEqual(connector.poll(), [])
 
     def test_cron_job_rejects_invalid_timezone(self) -> None:
         with self.assertRaisesRegex(ValueError, "invalid timezone"):

--- a/tests/test_main_github_ingress.py
+++ b/tests/test_main_github_ingress.py
@@ -118,9 +118,7 @@ class MainGitHubIngressTests(unittest.TestCase):
         self.assertEqual(connectors[0]._reply_target, "generic-post")
         self.assertEqual(connectors[1]._reply_target, "new-service")
 
-    def test_load_schedule_jobs_accepts_cron_timezone_and_interval_fallback(
-        self,
-    ) -> None:
+    def test_load_schedule_jobs_accepts_cron_timezone(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             schedule_path = Path(tmpdir) / "schedule.json"
             schedule_path.write_text(
@@ -131,13 +129,11 @@ class MainGitHubIngressTests(unittest.TestCase):
                             "content": "Run cron job",
                             "cron": "0 8 * * *",
                             "timezone": "Europe/London",
-                            "interval_seconds": 86400,
                         },
                         {
-                            "job_name": "interval-job",
-                            "content": "Run interval job",
-                            "interval_seconds": 300,
-                            "start_at": "2026-03-07T00:00:00Z",
+                            "job_name": "prompted-cron-job",
+                            "content": "Run prompted cron job",
+                            "cron": "*/5 * * * *",
                             "prompt_context": ["Mention overdue alerts first."],
                         },
                     ]
@@ -150,9 +146,8 @@ class MainGitHubIngressTests(unittest.TestCase):
             self.assertEqual(len(jobs), 2)
             self.assertEqual(jobs[0].cron, "0 8 * * *")
             self.assertEqual(jobs[0].timezone_name, "Europe/London")
-            self.assertEqual(jobs[0].interval_seconds, 86400)
-            self.assertEqual(jobs[1].interval_seconds, 300)
-            self.assertEqual(jobs[1].cron, None)
+            self.assertEqual(jobs[1].cron, "*/5 * * * *")
+            self.assertEqual(jobs[1].timezone_name, "UTC")
             self.assertEqual(jobs[1].prompt_context, ["Mention overdue alerts first."])
 
     def test_load_schedule_jobs_rejects_invalid_prompt_context(self) -> None:
@@ -162,9 +157,9 @@ class MainGitHubIngressTests(unittest.TestCase):
                 json.dumps(
                     [
                         {
-                            "job_name": "interval-job",
-                            "content": "Run interval job",
-                            "interval_seconds": 300,
+                            "job_name": "cron-job",
+                            "content": "Run cron job",
+                            "cron": "*/5 * * * *",
                             "prompt_context": [""],
                         }
                     ]
@@ -199,9 +194,7 @@ class MainGitHubIngressTests(unittest.TestCase):
             self.assertEqual(len(jobs), 1)
             self.assertEqual(jobs[0].timezone_name, "UTC")
 
-    def test_load_schedule_jobs_ignores_interval_anchors_when_cron_is_present(
-        self,
-    ) -> None:
+    def test_load_schedule_jobs_rejects_unknown_legacy_schedule_keys(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             schedule_path = Path(tmpdir) / "schedule.json"
             schedule_path.write_text(
@@ -212,19 +205,14 @@ class MainGitHubIngressTests(unittest.TestCase):
                             "content": "Run cron job",
                             "cron": "0 8 * * *",
                             "interval_seconds": "legacy-value",
-                            "start_at": 123,
                         }
                     ]
                 ),
                 encoding="utf-8",
             )
 
-            jobs = _load_schedule_jobs(str(schedule_path))
-
-            self.assertEqual(len(jobs), 1)
-            self.assertEqual(jobs[0].cron, "0 8 * * *")
-            self.assertEqual(jobs[0].interval_seconds, None)
-            self.assertEqual(jobs[0].start_at, None)
+            with self.assertRaisesRegex(ValueError, "unknown keys"):
+                _load_schedule_jobs(str(schedule_path))
 
     def test_load_schedule_jobs_rejects_invalid_cron_timezone(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -246,16 +234,15 @@ class MainGitHubIngressTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "invalid timezone"):
                 _load_schedule_jobs(str(schedule_path))
 
-    def test_load_schedule_jobs_rejects_timezone_without_cron(self) -> None:
+    def test_load_schedule_jobs_requires_cron(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             schedule_path = Path(tmpdir) / "schedule.json"
             schedule_path.write_text(
                 json.dumps(
                     [
                         {
-                            "job_name": "interval-job",
+                            "job_name": "missing-cron",
                             "content": "Run interval job",
-                            "interval_seconds": 60,
                             "timezone": "UTC",
                         }
                     ]
@@ -263,7 +250,7 @@ class MainGitHubIngressTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            with self.assertRaisesRegex(ValueError, "timezone is only valid with cron"):
+            with self.assertRaisesRegex(ValueError, "cron must be a non-empty string"):
                 _load_schedule_jobs(str(schedule_path))
 
     def test_main_message_handler_publishes_assignment_event_once_and_uses_checkpoint(
@@ -597,7 +584,7 @@ class MainGitHubIngressTests(unittest.TestCase):
                         {
                             "job_name": "heartbeat",
                             "content": "daily check",
-                            "interval_seconds": 1,
+                            "cron": "* * * * *",
                             "reply_channel_type": "log",
                             "reply_channel_target": "ops",
                         }

--- a/tests/test_split_mode_e2e.py
+++ b/tests/test_split_mode_e2e.py
@@ -51,9 +51,8 @@ class SplitModeE2ETests(unittest.TestCase):
                 {
                     "job_name": "ci-split-smoke",
                     "content": "CI smoke task",
-                    "interval_seconds": 3600,
+                    "cron": "0 * * * *",
                     "context_refs": ["repo:/workspace/chatting"],
-                    "start_at": "2026-01-01T00:00:00Z",
                     "reply_channel_type": "log",
                     "reply_channel_target": "ci-split-smoke",
                 }

--- a/tests/test_split_mode_e2e.py
+++ b/tests/test_split_mode_e2e.py
@@ -88,10 +88,6 @@ class SplitModeE2ETests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            expected_envelope_id = "cron:ci-split-smoke:2026-01-01T00:00:00+00:00"
-            expected_task_id = f"task:{expected_envelope_id}"
-            expected_event_id = f"evt:{expected_task_id}:0:completion:internal"
-
             try:
                 server_proc = subprocess.Popen(
                     [str(server_bin)],
@@ -156,10 +152,14 @@ class SplitModeE2ETests(unittest.TestCase):
 
             worker_store = SQLiteStateStore(str(worker_db_path))
             worker_runs = worker_store.list_runs()
+            matching_worker_runs = [
+                run for run in worker_runs if run.envelope_id.startswith("cron:ci-split-smoke:")
+            ]
             self.assertTrue(
-                any(run.envelope_id == expected_envelope_id for run in worker_runs),
-                msg=f"missing worker run for expected envelope_id={expected_envelope_id!r}",
+                matching_worker_runs,
+                msg="missing worker run for ci-split-smoke cron schedule",
             )
+            expected_envelope_id = matching_worker_runs[0].envelope_id
             self.assertTrue(
                 any(
                     run.envelope_id == expected_envelope_id and run.result_status == "success"
@@ -169,6 +169,8 @@ class SplitModeE2ETests(unittest.TestCase):
             )
 
             handler_store = SQLiteStateStore(str(handler_db_path))
+            expected_task_id = f"task:{expected_envelope_id}"
+            expected_event_id = f"evt:{expected_task_id}:0:completion:internal"
             self.assertEqual(handler_store.list_dispatched_event_indices(run_id=expected_task_id), [])
             self.assertTrue(
                 handler_store.has_dispatched_event_id(

--- a/tests/test_split_mode_e2e.py
+++ b/tests/test_split_mode_e2e.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import time
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 from app.state import SQLiteStateStore
@@ -46,12 +47,14 @@ class SplitModeE2ETests(unittest.TestCase):
             schedule_path = temp_root / "schedule.json"
             handler_config_path = temp_root / "message-handler.json"
             worker_config_path = temp_root / "worker.json"
+            now = datetime.now(timezone.utc)
+            immediate_cron = f"{now.minute} {now.hour} * * *"
 
             schedule_payload = [
                 {
                     "job_name": "ci-split-smoke",
                     "content": "CI smoke task",
-                    "cron": "0 * * * *",
+                    "cron": immediate_cron,
                     "context_refs": ["repo:/workspace/chatting"],
                     "reply_channel_type": "log",
                     "reply_channel_target": "ci-split-smoke",
@@ -82,6 +85,7 @@ class SplitModeE2ETests(unittest.TestCase):
                         "poll_timeout_seconds": 1,
                         "sleep_seconds": 0.05,
                         "max_loops": 20,
+                        "activity_port": 0,
                         "codex_command": f"{sys.executable} {fake_codex}",
                     }
                 ),


### PR DESCRIPTION
## Summary
- remove legacy `interval_seconds` / `start_at` schedule support and require cron for scheduled jobs
- simplify the interval schedule connector to cron-only behavior
- update docs, example config, and tests to match the cron-only contract

## Testing
- uv run ruff check app tests
- uv run python -m unittest tests.test_connectors tests.test_main_github_ingress tests.test_split_mode_e2e
- uv run python -m unittest discover -s tests

Closes #151
