### PR TITLE
Normalize Telegram reply text before publish

### DIFF
--- a/app/handler/applier/integrated.py
+++ b/app/handler/applier/integrated.py
@@ -8,7 +8,6 @@ import mimetypes
 import smtplib
 import subprocess
 import html
-import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -19,7 +18,14 @@ from pathlib import Path
 from typing import Any, Callable, Protocol
 from urllib.parse import urlparse
 
-from app.models import ActionProposal, ApplyResult, OutboundMessage, PolicyDecision, TaskEnvelope
+from app.models import (
+    ActionProposal,
+    ApplyResult,
+    OutboundMessage,
+    PolicyDecision,
+    TaskEnvelope,
+)
+from app.telegram_text import normalize_telegram_outbound_text
 
 LOGGER = logging.getLogger(__name__)
 _MAX_HTTP_ERROR_LOG_BODY_CHARS = 500
@@ -127,7 +133,7 @@ class SmtpEmailSender:
             host,
             port,
             timeout=self.timeout_seconds,
-            )
+        )
 
 
 @dataclass(frozen=True)
@@ -138,7 +144,9 @@ class TelegramMessageSender:
     api_base_url: str = "https://api.telegram.org"
     parse_mode: str | None = "Markdown"
     timeout_seconds: float = 10.0
-    http_post_json: Callable[[str, dict[str, object], float], dict[str, object]] | None = None
+    http_post_json: (
+        Callable[[str, dict[str, object], float], dict[str, object]] | None
+    ) = None
     http_post_multipart: (
         Callable[[str, dict[str, object], str, Path, float], dict[str, object]] | None
     ) = None
@@ -148,8 +156,14 @@ class TelegramMessageSender:
             raise ValueError("bot_token is required")
         if not self.api_base_url:
             raise ValueError("api_base_url is required")
-        if self.parse_mode is not None and self.parse_mode not in {"Markdown", "MarkdownV2", "HTML"}:
-            raise ValueError("parse_mode must be one of Markdown, MarkdownV2, HTML, or None")
+        if self.parse_mode is not None and self.parse_mode not in {
+            "Markdown",
+            "MarkdownV2",
+            "HTML",
+        }:
+            raise ValueError(
+                "parse_mode must be one of Markdown, MarkdownV2, HTML, or None"
+            )
         if self.timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be positive")
 
@@ -168,7 +182,9 @@ class TelegramMessageSender:
         url = f"{self.api_base_url.rstrip('/')}/bot{self.bot_token}/{api_method}"
         payload: dict[str, object] = {"chat_id": target}
         if message.body is not None:
-            payload["caption"] = _normalize_telegram_text_for_parse_mode(message.body, self.parse_mode)
+            payload["caption"] = _normalize_telegram_text_for_parse_mode(
+                message.body, self.parse_mode
+            )
         if self.parse_mode is not None and message.body is not None:
             payload["parse_mode"] = self.parse_mode
 
@@ -177,11 +193,17 @@ class TelegramMessageSender:
         if response.get("ok") is True:
             return
 
-        if self.parse_mode is not None and message.body is not None and _is_telegram_parse_mode_error(response):
+        if (
+            self.parse_mode is not None
+            and message.body is not None
+            and _is_telegram_parse_mode_error(response)
+        ):
             fallback_payload = dict(payload)
             fallback_payload.pop("parse_mode", None)
             fallback_payload["caption"] = message.body
-            fallback_response = client(url, fallback_payload, field_name, file_path, self.timeout_seconds)
+            fallback_response = client(
+                url, fallback_payload, field_name, file_path, self.timeout_seconds
+            )
             if fallback_response.get("ok") is True:
                 return
 
@@ -193,9 +215,12 @@ class TelegramMessageSender:
 
         client = self.http_post_json or _default_http_post_json
         url = f"{self.api_base_url.rstrip('/')}/bot{self.bot_token}/sendMessage"
+        normalized_body = normalize_telegram_outbound_text(body)
         payload: dict[str, object] = {
             "chat_id": target,
-            "text": _normalize_telegram_text_for_parse_mode(body, self.parse_mode),
+            "text": _normalize_telegram_text_for_parse_mode(
+                normalized_body, self.parse_mode
+            ),
         }
         if self.parse_mode is not None:
             payload["parse_mode"] = self.parse_mode
@@ -205,12 +230,17 @@ class TelegramMessageSender:
 
         # Gracefully degrade to plain text when Telegram rejects formatting entities.
         if self.parse_mode is not None and _is_telegram_parse_mode_error(response):
-            plain_text_payload: dict[str, object] = {"chat_id": target, "text": body}
+            plain_text_payload: dict[str, object] = {
+                "chat_id": target,
+                "text": normalized_body,
+            }
             fallback_response = client(url, plain_text_payload, self.timeout_seconds)
             if fallback_response.get("ok") is True:
                 return
 
-        raise RuntimeError(_describe_telegram_response_error("telegram_send_failed", response))
+        raise RuntimeError(
+            _describe_telegram_response_error("telegram_send_failed", response)
+        )
 
     def react(self, target: str, message_id: int, emoji: str) -> None:
         if not target:
@@ -230,7 +260,9 @@ class TelegramMessageSender:
         response = client(url, payload, self.timeout_seconds)
         if response.get("ok") is True:
             return
-        raise RuntimeError(_describe_telegram_response_error("telegram_reaction_failed", response))
+        raise RuntimeError(
+            _describe_telegram_response_error("telegram_reaction_failed", response)
+        )
 
 
 @dataclass(frozen=True)
@@ -271,7 +303,9 @@ class IntegratedApplier:
     telegram_sender: TelegramSender | None = None
     github_sender: GitHubSender | None = None
 
-    def apply(self, decision: PolicyDecision, envelope: TaskEnvelope | None = None) -> ApplyResult:
+    def apply(
+        self, decision: PolicyDecision, envelope: TaskEnvelope | None = None
+    ) -> ApplyResult:
         applied_actions: list[ActionProposal] = []
         skipped_actions: list[ActionProposal] = []
         dispatched_messages: list[OutboundMessage] = []
@@ -311,11 +345,15 @@ class IntegratedApplier:
             )
 
             if dispatch_channel == "log":
-                LOGGER.info("log_dispatch target=%s body=%s", dispatch_target, message.body)
+                LOGGER.info(
+                    "log_dispatch target=%s body=%s", dispatch_target, message.body
+                )
                 dispatched_messages.append(normalized_message)
                 continue
             if dispatch_channel == "drop":
-                LOGGER.info("drop_marker target=%s body=%s", dispatch_target, message.body)
+                LOGGER.info(
+                    "drop_marker target=%s body=%s", dispatch_target, message.body
+                )
                 dispatched_messages.append(normalized_message)
                 continue
             if dispatch_channel == "email":
@@ -359,7 +397,9 @@ class IntegratedApplier:
                     self.telegram_sender.send(dispatch_target, message)
                     dispatched_messages.append(normalized_message)
                 except Exception as error:  # noqa: BLE001
-                    error_reason = _telegram_dispatch_reason_code(message, exception=error)
+                    error_reason = _telegram_dispatch_reason_code(
+                        message, exception=error
+                    )
                     LOGGER.exception(
                         "drop_dispatch reason=%s channel=%s target=%s",
                         error_reason,
@@ -410,7 +450,9 @@ class IntegratedApplier:
                         raise ValueError("telegram reaction emoji is required")
                     self.telegram_sender.react(
                         dispatch_target,
-                        _resolve_telegram_reaction_message_id(message=message, envelope=envelope),
+                        _resolve_telegram_reaction_message_id(
+                            message=message, envelope=envelope
+                        ),
                         message.body,
                     )
                     dispatched_messages.append(normalized_message)
@@ -484,11 +526,7 @@ def _format_email_reply(
     if not quoted_original:
         return reply_subject, cleaned_body
 
-    reply_body = (
-        f"{cleaned_body.rstrip()}\n\n"
-        "Original message:\n"
-        f"{quoted_original}\n"
-    )
+    reply_body = f"{cleaned_body.rstrip()}\n\nOriginal message:\n{quoted_original}\n"
     return reply_subject, reply_body
 
 
@@ -588,7 +626,9 @@ def _default_http_post_json(
         ) from error
     except urllib.error.URLError as error:
         LOGGER.error("telegram_http_error reason=%s", getattr(error, "reason", error))
-        raise RuntimeError(f"telegram_http_error reason={getattr(error, 'reason', error)}") from error
+        raise RuntimeError(
+            f"telegram_http_error reason={getattr(error, 'reason', error)}"
+        ) from error
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as error:
@@ -706,7 +746,9 @@ def _telegram_api_method_for_attachment(file_path: Path) -> str:
     return "sendDocument"
 
 
-def _telegram_dispatch_reason_code(message: OutboundMessage, exception: Exception | None) -> str:
+def _telegram_dispatch_reason_code(
+    message: OutboundMessage, exception: Exception | None
+) -> str:
     if exception is not None:
         reason = str(exception).strip()
         if reason.startswith("telegram_"):
@@ -725,7 +767,6 @@ def _is_telegram_parse_mode_error(response: dict[str, object]) -> bool:
 
 
 def _normalize_telegram_text_for_parse_mode(text: str, parse_mode: str | None) -> str:
-    text = _normalize_telegram_escaped_sequences(text)
     if parse_mode is None:
         return text
     if parse_mode == "HTML":
@@ -737,29 +778,36 @@ def _normalize_telegram_text_for_parse_mode(text: str, parse_mode: str | None) -
     return text
 
 
-def _normalize_telegram_escaped_sequences(text: str) -> str:
-    text = re.sub(r"\\+([nrt])", lambda match: _decode_backslash_escape(match.group(1)), text)
-    return re.sub(r"\\+([_*`\[\]()~>#\+\-=|{}.!])", r"\1", text)
-
-
-def _decode_backslash_escape(character: str) -> str:
-    if character == "n":
-        return "\n"
-    if character == "r":
-        return "\r"
-    if character == "t":
-        return "\t"
-    return character
-
-
 def _escape_telegram_markdown(text: str) -> str:
-    return _escape_with_backslash_prefix(text, {"\\", "_", "*", "`", "[", "]", "(", ")"})
+    return _escape_with_backslash_prefix(
+        text, {"\\", "_", "*", "`", "[", "]", "(", ")"}
+    )
 
 
 def _escape_telegram_markdown_v2(text: str) -> str:
     return _escape_with_backslash_prefix(
         text,
-        {"\\", "_", "*", "[", "]", "(", ")", "~", "`", ">", "#", "+", "-", "=", "|", "{", "}", ".", "!"},
+        {
+            "\\",
+            "_",
+            "*",
+            "[",
+            "]",
+            "(",
+            ")",
+            "~",
+            "`",
+            ">",
+            "#",
+            "+",
+            "-",
+            "=",
+            "|",
+            "{",
+            "}",
+            ".",
+            "!",
+        },
     )
 
 
@@ -803,7 +851,9 @@ def _describe_telegram_http_error(
         detail_parts.append(f"status={status_code}")
     if reason:
         detail_parts.append(f"reason={reason}")
-    detail_parts.append(f"response_body={_truncate_http_error_body_for_log(response_body)}")
+    detail_parts.append(
+        f"response_body={_truncate_http_error_body_for_log(response_body)}"
+    )
     return " ".join(detail_parts)
 
 

--- a/app/main_reply.py
+++ b/app/main_reply.py
@@ -12,9 +12,10 @@ from pathlib import Path
 
 from app.broker import BBMBQueueAdapter, EGRESS_QUEUE_NAME, EgressQueueMessage
 from app.handler.runtime import TaskLedgerStore
-from app.worker.main import WORKER_CONFIG_PATH_ENV_VAR, _load_config, _resolve_str
 from app.models import AttachmentRef, OutboundMessage
 from app.state import SQLiteStateStore
+from app.telegram_text import normalize_telegram_outbound_text
+from app.worker.main import WORKER_CONFIG_PATH_ENV_VAR, _load_config, _resolve_str
 
 
 def _parse_args() -> argparse.Namespace:
@@ -26,15 +27,34 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("task_id", help="Task identifier (for example: task:email:53).")
     parser.add_argument("--message", help="Reply body text.")
-    parser.add_argument("--attachment-path", help="Absolute path to a local file to send as an attachment.")
-    parser.add_argument("--attachment-name", help="Optional attachment filename override.")
-    parser.add_argument("--channel", required=True, help="Outbound channel (for example: email, telegram, github).")
+    parser.add_argument(
+        "--attachment-path",
+        help="Absolute path to a local file to send as an attachment.",
+    )
+    parser.add_argument(
+        "--attachment-name", help="Optional attachment filename override."
+    )
+    parser.add_argument(
+        "--channel",
+        required=True,
+        help="Outbound channel (for example: email, telegram, github).",
+    )
     parser.add_argument("--target", required=True, help="Outbound channel target.")
-    parser.add_argument("--telegram-reaction", help="React to the Telegram source message instead of sending a text message.")
-    parser.add_argument("--telegram-message-id", type=int, help="Telegram message id to react to.")
+    parser.add_argument(
+        "--telegram-reaction",
+        help="React to the Telegram source message instead of sending a text message.",
+    )
+    parser.add_argument(
+        "--telegram-message-id", type=int, help="Telegram message id to react to."
+    )
     parser.add_argument("--event-id", help="Optional stable event id for idempotency.")
-    parser.add_argument("--envelope-id", help="Envelope id (defaults to task_id without 'task:' prefix).")
-    parser.add_argument("--trace-id", help="Trace id (defaults to trace:<envelope_id>).")
+    parser.add_argument(
+        "--envelope-id",
+        help="Envelope id (defaults to task_id without 'task:' prefix).",
+    )
+    parser.add_argument(
+        "--trace-id", help="Trace id (defaults to trace:<envelope_id>)."
+    )
     parser.add_argument("--bbmb-address", help="BBMB broker address host:port.")
     parser.add_argument(
         "--config",
@@ -52,7 +72,9 @@ def _resolve_envelope_id(task_id: str, explicit_value: str | None) -> str:
             raise ValueError("envelope_id must not be empty")
         return explicit_value
     if not task_id.startswith("task:"):
-        raise ValueError("envelope_id is required when task_id does not start with 'task:'")
+        raise ValueError(
+            "envelope_id is required when task_id does not start with 'task:'"
+        )
     return task_id[len("task:") :]
 
 
@@ -96,14 +118,18 @@ def _resolve_telegram_message_id(
     if ledger_record is None:
         raise ValueError("telegram_message_id is required")
 
-    message_id = ledger_record.task_message.envelope.reply_channel.metadata.get("message_id")
+    message_id = ledger_record.task_message.envelope.reply_channel.metadata.get(
+        "message_id"
+    )
     if isinstance(message_id, int) and message_id > 0:
         return message_id
 
     raise ValueError("telegram_message_id is required")
 
 
-def _resolve_reply_message(args: argparse.Namespace, config: dict[str, object]) -> OutboundMessage:
+def _resolve_reply_message(
+    args: argparse.Namespace, config: dict[str, object]
+) -> OutboundMessage:
     if args.telegram_reaction is not None:
         if args.channel != "telegram":
             raise ValueError("telegram reactions require --channel telegram")
@@ -143,14 +169,16 @@ def _resolve_reply_message(args: argparse.Namespace, config: dict[str, object]) 
 
     body: str | None = None
     if args.message is not None:
-        body = args.message.strip()
+        body = normalize_telegram_outbound_text(args.message).strip()
         if not body:
             raise ValueError("message must not be empty")
 
     if body is None and attachment is None:
         raise ValueError("message or attachment is required")
 
-    return OutboundMessage(channel=args.channel, target=args.target, body=body, attachment=attachment)
+    return OutboundMessage(
+        channel=args.channel, target=args.target, body=body, attachment=attachment
+    )
 
 
 def main() -> int:

--- a/app/telegram_text.py
+++ b/app/telegram_text.py
@@ -1,0 +1,23 @@
+"""Shared Telegram/outbound text normalization helpers."""
+
+from __future__ import annotations
+
+import re
+
+
+def normalize_telegram_outbound_text(text: str) -> str:
+    """Collapse literal escape sequences into displayable text before send-time escaping."""
+    normalized = text.replace("\r\n", "\n")
+    for _ in range(3):
+        previous = normalized
+        normalized = re.sub(r"(?:\\)+r(?:\\)+n", "\n", normalized)
+        normalized = re.sub(r"(?:\\)+n", "\n", normalized)
+        normalized = re.sub(r"(?:\\)+r", "\n", normalized)
+        normalized = normalized.replace("\\t", "\t")
+        normalized = re.sub(r"(?:\\)+([\\_*`\[\]\(\)~>#\+\-=|{}.!])", r"\1", normalized)
+        if normalized == previous:
+            break
+    return normalized
+
+
+__all__ = ["normalize_telegram_outbound_text"]

--- a/tests/test_applier.py
+++ b/tests/test_applier.py
@@ -25,19 +25,27 @@ from app.models import (
     ReplyChannel,
     TaskEnvelope,
 )
+
+
 class NoOpApplierTests(unittest.TestCase):
     def test_skips_approved_actions_and_dispatches_messages(self) -> None:
         decision = PolicyDecision(
             approved_actions=[ActionProposal(type="write_file", path="docs/notes.md")],
             blocked_actions=[],
-            approved_messages=[OutboundMessage(channel="email", target="alice@example.com", body="Done.")],
+            approved_messages=[
+                OutboundMessage(
+                    channel="email", target="alice@example.com", body="Done."
+                )
+            ],
             reason_codes=[],
         )
 
         result = NoOpApplier().apply(decision)
 
         self.assertEqual(result.applied_actions, [])
-        self.assertEqual([action.type for action in result.skipped_actions], ["write_file"])
+        self.assertEqual(
+            [action.type for action in result.skipped_actions], ["write_file"]
+        )
         self.assertEqual(
             [message.channel for message in result.dispatched_messages],
             ["email"],
@@ -55,12 +63,16 @@ class NoOpApplierTests(unittest.TestCase):
         result = NoOpApplier().apply(decision)
 
         self.assertEqual(result.reason_codes, ["policy_blocked_actions_present"])
+
+
 @dataclass
 class _RecordingEmailSender:
     sent: list[tuple[str, str, str | None]]
 
     def send(self, target: str, body: str, *, subject: str | None = None) -> None:
         self.sent.append((target, body, subject))
+
+
 class IntegratedApplierTests(unittest.TestCase):
     def test_apply_writes_files_and_dispatches_email_and_log_messages(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -85,11 +97,15 @@ class IntegratedApplierTests(unittest.TestCase):
                 reason_codes=[],
             )
 
-            result = IntegratedApplier(base_dir=tmpdir, email_sender=sender).apply(decision)
+            result = IntegratedApplier(base_dir=tmpdir, email_sender=sender).apply(
+                decision
+            )
 
             written_path = Path(tmpdir) / "docs" / "generated.txt"
             self.assertTrue(written_path.exists())
-            self.assertEqual(written_path.read_text(encoding="utf-8"), "hello from applier")
+            self.assertEqual(
+                written_path.read_text(encoding="utf-8"), "hello from applier"
+            )
             self.assertEqual(result.applied_actions, decision.approved_actions)
             self.assertEqual(result.skipped_actions, [])
             self.assertEqual(
@@ -182,11 +198,22 @@ class IntegratedApplierTests(unittest.TestCase):
                 reason_codes=[],
             )
 
-            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(
+                decision
+            )
 
             self.assertEqual(
                 sender.sent,
-                [("12345", OutboundMessage(channel="telegram", target="12345", body="Done via telegram."))],
+                [
+                    (
+                        "12345",
+                        OutboundMessage(
+                            channel="telegram",
+                            target="12345",
+                            body="Done via telegram.",
+                        ),
+                    )
+                ],
             )
             self.assertEqual(
                 [message.channel for message in result.dispatched_messages],
@@ -211,7 +238,9 @@ class IntegratedApplierTests(unittest.TestCase):
                 reason_codes=[],
             )
 
-            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(
+                decision
+            )
 
             self.assertEqual(sender.reactions, [("12345", 321, "👍")])
             self.assertEqual(
@@ -240,18 +269,28 @@ class IntegratedApplierTests(unittest.TestCase):
                         channel="telegram",
                         target="12345",
                         body="caption",
-                        attachment=AttachmentRef(uri=image_path.as_uri(), name="menu.png"),
+                        attachment=AttachmentRef(
+                            uri=image_path.as_uri(), name="menu.png"
+                        ),
                     )
                 ],
                 reason_codes=[],
             )
 
-            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(
+                decision
+            )
 
             self.assertEqual(len(sender.sent), 1)
             self.assertEqual(sender.sent[0][0], "12345")
-            self.assertEqual(sender.sent[0][1].attachment, AttachmentRef(uri=image_path.as_uri(), name="menu.png"))
-            self.assertEqual(result.dispatched_messages[0].attachment, AttachmentRef(uri=image_path.as_uri(), name="menu.png"))
+            self.assertEqual(
+                sender.sent[0][1].attachment,
+                AttachmentRef(uri=image_path.as_uri(), name="menu.png"),
+            )
+            self.assertEqual(
+                result.dispatched_messages[0].attachment,
+                AttachmentRef(uri=image_path.as_uri(), name="menu.png"),
+            )
 
     def test_apply_dispatches_telegram_document_attachment(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -265,21 +304,30 @@ class IntegratedApplierTests(unittest.TestCase):
                     OutboundMessage(
                         channel="telegram",
                         target="12345",
-                        attachment=AttachmentRef(uri=pdf_path.as_uri(), name="menu.pdf"),
+                        attachment=AttachmentRef(
+                            uri=pdf_path.as_uri(), name="menu.pdf"
+                        ),
                     )
                 ],
                 reason_codes=[],
             )
 
-            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+            result = IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(
+                decision
+            )
 
             self.assertEqual(len(sender.sent), 1)
-            self.assertEqual(sender.sent[0][1].attachment, AttachmentRef(uri=pdf_path.as_uri(), name="menu.pdf"))
+            self.assertEqual(
+                sender.sent[0][1].attachment,
+                AttachmentRef(uri=pdf_path.as_uri(), name="menu.pdf"),
+            )
             self.assertIsNone(result.dispatched_messages[0].body)
 
     def test_apply_raises_attachment_dispatch_error_for_missing_file(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            sender = TelegramMessageSender(bot_token="token", http_post_multipart=lambda *_args: {"ok": True})
+            sender = TelegramMessageSender(
+                bot_token="token", http_post_multipart=lambda *_args: {"ok": True}
+            )
             decision = PolicyDecision(
                 approved_actions=[],
                 blocked_actions=[],
@@ -287,18 +335,26 @@ class IntegratedApplierTests(unittest.TestCase):
                     OutboundMessage(
                         channel="telegram",
                         target="12345",
-                        attachment=AttachmentRef(uri="file:///does/not/exist.pdf", name="missing.pdf"),
+                        attachment=AttachmentRef(
+                            uri="file:///does/not/exist.pdf", name="missing.pdf"
+                        ),
                     )
                 ],
                 reason_codes=[],
             )
 
             with self.assertRaises(MessageDispatchError) as context:
-                IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+                IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(
+                    decision
+                )
 
-            self.assertEqual(context.exception.reason_code, "telegram_attachment_missing")
+            self.assertEqual(
+                context.exception.reason_code, "telegram_attachment_missing"
+            )
 
-    def test_apply_raises_attachment_dispatch_error_on_telegram_api_failure(self) -> None:
+    def test_apply_raises_attachment_dispatch_error_on_telegram_api_failure(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             pdf_path = Path(tmpdir) / "menu.pdf"
             pdf_path.write_bytes(b"%PDF")
@@ -314,22 +370,30 @@ class IntegratedApplierTests(unittest.TestCase):
                         channel="telegram",
                         target="12345",
                         body="menu",
-                        attachment=AttachmentRef(uri=pdf_path.as_uri(), name="menu.pdf"),
+                        attachment=AttachmentRef(
+                            uri=pdf_path.as_uri(), name="menu.pdf"
+                        ),
                     )
                 ],
                 reason_codes=[],
             )
 
             with self.assertRaises(MessageDispatchError) as context:
-                IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+                IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(
+                    decision
+                )
 
-            self.assertEqual(context.exception.reason_code, "telegram_attachment_send_failed")
+            self.assertEqual(
+                context.exception.reason_code, "telegram_attachment_send_failed"
+            )
 
     def test_apply_skips_write_outside_base_dir(self) -> None:
         with TemporaryDirectory() as tmpdir:
             decision = PolicyDecision(
                 approved_actions=[
-                    ActionProposal(type="write_file", path="../escape.txt", content="nope")
+                    ActionProposal(
+                        type="write_file", path="../escape.txt", content="nope"
+                    )
                 ],
                 blocked_actions=[],
                 approved_messages=[],
@@ -418,16 +482,27 @@ class IntegratedApplierTests(unittest.TestCase):
                 reason_codes=[],
             )
 
-            result = IntegratedApplier(base_dir=tmpdir, github_sender=sender).apply(decision)
+            result = IntegratedApplier(base_dir=tmpdir, github_sender=sender).apply(
+                decision
+            )
 
             self.assertEqual(
                 sender.sent,
-                [("https://github.com/brokensbone/chatting/issues/12", "Done via GitHub.")],
+                [
+                    (
+                        "https://github.com/brokensbone/chatting/issues/12",
+                        "Done via GitHub.",
+                    )
+                ],
             )
-            self.assertEqual([message.channel for message in result.dispatched_messages], ["github"])
+            self.assertEqual(
+                [message.channel for message in result.dispatched_messages], ["github"]
+            )
             self.assertEqual(result.reason_codes, [])
 
-    def test_apply_raises_dispatch_error_with_partial_progress_on_github_failure(self) -> None:
+    def test_apply_raises_dispatch_error_with_partial_progress_on_github_failure(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             sender = _FailingGitHubSender()
             decision = PolicyDecision(
@@ -463,7 +538,9 @@ class IntegratedApplierTests(unittest.TestCase):
                 ],
             )
 
-    def test_apply_maps_final_channel_to_envelope_reply_channel_for_telegram(self) -> None:
+    def test_apply_maps_final_channel_to_envelope_reply_channel_for_telegram(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             sender = _RecordingTelegramSender(sent=[])
             decision = PolicyDecision(
@@ -497,7 +574,14 @@ class IntegratedApplierTests(unittest.TestCase):
 
             self.assertEqual(
                 sender.sent,
-                [("8605042448", OutboundMessage(channel="final", target="user", body="Answer from model."))],
+                [
+                    (
+                        "8605042448",
+                        OutboundMessage(
+                            channel="final", target="user", body="Answer from model."
+                        ),
+                    )
+                ],
             )
             self.assertEqual(
                 [message.channel for message in result.dispatched_messages],
@@ -509,7 +593,9 @@ class IntegratedApplierTests(unittest.TestCase):
             )
             self.assertEqual(result.reason_codes, [])
 
-    def test_apply_raises_dispatch_error_with_partial_progress_on_telegram_failure(self) -> None:
+    def test_apply_raises_dispatch_error_with_partial_progress_on_telegram_failure(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             sender = _FailingTelegramSender()
             decision = PolicyDecision(
@@ -523,13 +609,17 @@ class IntegratedApplierTests(unittest.TestCase):
             )
 
             with self.assertRaises(MessageDispatchError) as context:
-                IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(decision)
+                IntegratedApplier(base_dir=tmpdir, telegram_sender=sender).apply(
+                    decision
+                )
 
             self.assertEqual(context.exception.reason_code, "telegram_dispatch_failed")
             self.assertEqual(
                 context.exception.dispatched_messages,
                 [OutboundMessage(channel="telegram", target="12345", body="👀")],
             )
+
+
 class SmtpEmailSenderTests(unittest.TestCase):
     def test_send_uses_smtp_client(self) -> None:
         client = _FakeSmtpClient()
@@ -551,6 +641,8 @@ class SmtpEmailSenderTests(unittest.TestCase):
         self.assertEqual(message["From"], "bot@example.com")
         self.assertEqual(message["Subject"], "Automation response")
         self.assertTrue(client.quit_called)
+
+
 class TelegramMessageSenderTests(unittest.TestCase):
     def test_send_posts_message_and_validates_ok_response(self) -> None:
         seen_calls: list[tuple[str, dict[str, object], float]] = []
@@ -568,7 +660,9 @@ class TelegramMessageSenderTests(unittest.TestCase):
             http_post_json=fake_http_post_json,
         )
 
-        sender.send("12345", OutboundMessage(channel="telegram", target="12345", body="hello"))
+        sender.send(
+            "12345", OutboundMessage(channel="telegram", target="12345", body="hello")
+        )
 
         self.assertEqual(len(seen_calls), 1)
         call_url, call_payload, call_timeout = seen_calls[0]
@@ -582,7 +676,9 @@ class TelegramMessageSenderTests(unittest.TestCase):
         )
         self.assertEqual(call_timeout, 10.0)
 
-    def test_send_retries_without_parse_mode_when_telegram_rejects_entities(self) -> None:
+    def test_send_retries_without_parse_mode_when_telegram_rejects_entities(
+        self,
+    ) -> None:
         seen_calls: list[tuple[str, dict[str, object], float]] = []
 
         def fake_http_post_json(
@@ -600,7 +696,9 @@ class TelegramMessageSenderTests(unittest.TestCase):
             http_post_json=fake_http_post_json,
         )
 
-        sender.send("12345", OutboundMessage(channel="telegram", target="12345", body="hello"))
+        sender.send(
+            "12345", OutboundMessage(channel="telegram", target="12345", body="hello")
+        )
 
         self.assertEqual(len(seen_calls), 2)
         self.assertEqual(
@@ -619,7 +717,10 @@ class TelegramMessageSenderTests(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(RuntimeError, "telegram_send_failed"):
-            sender.send("12345", OutboundMessage(channel="telegram", target="12345", body="hello"))
+            sender.send(
+                "12345",
+                OutboundMessage(channel="telegram", target="12345", body="hello"),
+            )
 
     def test_send_escapes_markdown_sensitive_text_before_first_send(self) -> None:
         seen_calls: list[tuple[str, dict[str, object], float]] = []
@@ -656,7 +757,9 @@ class TelegramMessageSenderTests(unittest.TestCase):
             },
         )
 
-    def test_send_normalizes_double_escaped_newlines_and_markdown_punctuation(self) -> None:
+    def test_send_normalizes_literal_escape_sequences_before_markdown_escape(
+        self,
+    ) -> None:
         seen_calls: list[tuple[str, dict[str, object], float]] = []
 
         def fake_http_post_json(
@@ -677,7 +780,7 @@ class TelegramMessageSenderTests(unittest.TestCase):
             OutboundMessage(
                 channel="telegram",
                 target="12345",
-                body=r"Your three 1960s albums are:\\n\\n- Gal Costa \\(second edition\\)",
+                body=r"Your three 1960s saved albums are all from 1969:\n\n- Gal Costa \(second edition\)",
             ),
         )
 
@@ -686,42 +789,7 @@ class TelegramMessageSenderTests(unittest.TestCase):
             seen_calls[0][1],
             {
                 "chat_id": "12345",
-                "text": "Your three 1960s albums are:\n\n- Gal Costa \\(second edition\\)",
-                "parse_mode": "Markdown",
-            },
-        )
-
-    def test_send_normalizes_repeated_backslashes_before_newline_escape(self) -> None:
-        seen_calls: list[tuple[str, dict[str, object], float]] = []
-
-        def fake_http_post_json(
-            url: str,
-            payload: dict[str, object],
-            timeout: float,
-        ) -> dict[str, object]:
-            seen_calls.append((url, payload, timeout))
-            return {"ok": True, "result": {"message_id": 7}}
-
-        sender = TelegramMessageSender(
-            bot_token="token",
-            http_post_json=fake_http_post_json,
-        )
-
-        sender.send(
-            "12345",
-            OutboundMessage(
-                channel="telegram",
-                target="12345",
-                body=r"Line one\\\\nLine two",
-            ),
-        )
-
-        self.assertEqual(len(seen_calls), 1)
-        self.assertEqual(
-            seen_calls[0][1],
-            {
-                "chat_id": "12345",
-                "text": "Line one\nLine two",
+                "text": "Your three 1960s saved albums are all from 1969:\n\n- Gal Costa \\(second edition\\)",
                 "parse_mode": "Markdown",
             },
         )
@@ -802,11 +870,83 @@ class TelegramMessageSenderTests(unittest.TestCase):
             )
 
         self.assertEqual(len(seen_calls), 2)
-        self.assertEqual(seen_calls[0][0], "https://api.telegram.org/bottoken/sendDocument")
+        self.assertEqual(
+            seen_calls[0][0], "https://api.telegram.org/bottoken/sendDocument"
+        )
         self.assertEqual(seen_calls[0][1]["parse_mode"], "Markdown")
         self.assertNotIn("parse_mode", seen_calls[1][1])
         self.assertEqual(seen_calls[0][2], "document")
         self.assertEqual(seen_calls[1][1]["caption"], "**menu**")
+
+    def test_send_retries_with_normalized_plain_text_after_parse_error(self) -> None:
+        seen_calls: list[tuple[str, dict[str, object], float]] = []
+
+        def fake_http_post_json(
+            url: str,
+            payload: dict[str, object],
+            timeout: float,
+        ) -> dict[str, object]:
+            seen_calls.append((url, payload, timeout))
+            if len(seen_calls) == 1:
+                return {"ok": False, "description": "Bad Request: can't parse entities"}
+            return {"ok": True, "result": {"message_id": 7}}
+
+        sender = TelegramMessageSender(
+            bot_token="token",
+            http_post_json=fake_http_post_json,
+        )
+
+        sender.send(
+            "12345",
+            OutboundMessage(
+                channel="telegram",
+                target="12345",
+                body=r"Heading\n\n- Item \(note\)",
+            ),
+        )
+
+        self.assertEqual(len(seen_calls), 2)
+        self.assertEqual(
+            seen_calls[1][1],
+            {"chat_id": "12345", "text": "Heading\n\n- Item (note)"},
+        )
+
+    def test_send_normalizes_double_escaped_sequences_before_markdown_escape(
+        self,
+    ) -> None:
+        seen_calls: list[tuple[str, dict[str, object], float]] = []
+
+        def fake_http_post_json(
+            url: str,
+            payload: dict[str, object],
+            timeout: float,
+        ) -> dict[str, object]:
+            seen_calls.append((url, payload, timeout))
+            return {"ok": True, "result": {"message_id": 8}}
+
+        sender = TelegramMessageSender(
+            bot_token="token",
+            http_post_json=fake_http_post_json,
+        )
+
+        sender.send(
+            "12345",
+            OutboundMessage(
+                channel="telegram",
+                target="12345",
+                body=r"Your three 1960s saved albums are all from 1969:\\n\\n- Gal Costa \\(second edition\\)",
+            ),
+        )
+
+        self.assertEqual(len(seen_calls), 1)
+        self.assertEqual(
+            seen_calls[0][1],
+            {
+                "chat_id": "12345",
+                "text": "Your three 1960s saved albums are all from 1969:\n\n- Gal Costa \\(second edition\\)",
+                "parse_mode": "Markdown",
+            },
+        )
 
     def test_send_attachment_raises_when_telegram_response_not_ok(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -817,17 +957,23 @@ class TelegramMessageSenderTests(unittest.TestCase):
                 http_post_multipart=lambda *_args: {"ok": False},
             )
 
-            with self.assertRaisesRegex(RuntimeError, "telegram_attachment_send_failed"):
+            with self.assertRaisesRegex(
+                RuntimeError, "telegram_attachment_send_failed"
+            ):
                 sender.send(
                     "12345",
                     OutboundMessage(
                         channel="telegram",
                         target="12345",
-                        attachment=AttachmentRef(uri=pdf_path.as_uri(), name="menu.pdf"),
+                        attachment=AttachmentRef(
+                            uri=pdf_path.as_uri(), name="menu.pdf"
+                        ),
                     ),
                 )
 
-    def test_default_http_post_json_returns_error_payload_and_logs_http_error_body(self) -> None:
+    def test_default_http_post_json_returns_error_payload_and_logs_http_error_body(
+        self,
+    ) -> None:
         http_error = urllib.error.HTTPError(
             url="https://api.telegram.org/bottoken/sendMessage",
             code=400,
@@ -837,8 +983,13 @@ class TelegramMessageSenderTests(unittest.TestCase):
         )
 
         with (
-            patch("app.handler.applier.integrated.urllib.request.urlopen", side_effect=http_error),
-            self.assertLogs("app.handler.applier.integrated", level="ERROR") as captured,
+            patch(
+                "app.handler.applier.integrated.urllib.request.urlopen",
+                side_effect=http_error,
+            ),
+            self.assertLogs(
+                "app.handler.applier.integrated", level="ERROR"
+            ) as captured,
         ):
             response = _default_http_post_json(
                 "https://api.telegram.org/bottoken/sendMessage",
@@ -853,7 +1004,7 @@ class TelegramMessageSenderTests(unittest.TestCase):
         self.assertEqual(len(captured.records), 1)
         self.assertIn("status=400", captured.output[0])
         self.assertIn("Bad Request", captured.output[0])
-        self.assertIn('chat not found', captured.output[0])
+        self.assertIn("chat not found", captured.output[0])
 
     def test_react_posts_set_message_reaction_request(self) -> None:
         seen_calls: list[tuple[str, dict[str, object], float]] = []
@@ -887,6 +1038,8 @@ class TelegramMessageSenderTests(unittest.TestCase):
                 )
             ],
         )
+
+
 class GitHubIssueCommentSenderTests(unittest.TestCase):
     def test_send_uses_gh_cli_for_issue_url_target(self) -> None:
         seen_commands: list[list[str]] = []
@@ -903,7 +1056,18 @@ class GitHubIssueCommentSenderTests(unittest.TestCase):
 
         self.assertEqual(
             seen_commands,
-            [["gh", "issue", "comment", "12", "--repo", "brokensbone/chatting", "--body", "hello"]],
+            [
+                [
+                    "gh",
+                    "issue",
+                    "comment",
+                    "12",
+                    "--repo",
+                    "brokensbone/chatting",
+                    "--body",
+                    "hello",
+                ]
+            ],
         )
 
     def test_send_uses_gh_cli_for_slug_target(self) -> None:
@@ -921,7 +1085,18 @@ class GitHubIssueCommentSenderTests(unittest.TestCase):
 
         self.assertEqual(
             seen_commands,
-            [["gh", "issue", "comment", "13", "--repo", "brokensbone/chatting", "--body", "hello"]],
+            [
+                [
+                    "gh",
+                    "issue",
+                    "comment",
+                    "13",
+                    "--repo",
+                    "brokensbone/chatting",
+                    "--body",
+                    "hello",
+                ]
+            ],
         )
 
     def test_send_uses_gh_cli_for_pull_request_url_target(self) -> None:
@@ -939,7 +1114,18 @@ class GitHubIssueCommentSenderTests(unittest.TestCase):
 
         self.assertEqual(
             seen_commands,
-            [["gh", "issue", "comment", "60", "--repo", "brokensbone/chatting", "--body", "hello"]],
+            [
+                [
+                    "gh",
+                    "issue",
+                    "comment",
+                    "60",
+                    "--repo",
+                    "brokensbone/chatting",
+                    "--body",
+                    "hello",
+                ]
+            ],
         )
 
     def test_send_raises_for_invalid_target(self) -> None:
@@ -954,6 +1140,8 @@ class GitHubIssueCommentSenderTests(unittest.TestCase):
         sender = GitHubIssueCommentSender(command_runner=lambda _command: _Result())
         with self.assertRaisesRegex(RuntimeError, "github_issue_comment_failed"):
             sender.send("brokensbone/chatting#13", "hello")
+
+
 class _FakeSmtpClient:
     def __init__(self) -> None:
         self.login_args: tuple[str, str] | None = None
@@ -968,6 +1156,8 @@ class _FakeSmtpClient:
 
     def quit(self) -> None:
         self.quit_called = True
+
+
 @dataclass
 class _RecordingTelegramSender:
     sent: list[tuple[str, OutboundMessage]]
@@ -978,6 +1168,8 @@ class _RecordingTelegramSender:
 
     def react(self, target: str, message_id: int, emoji: str) -> None:
         self.reactions.append((target, message_id, emoji))
+
+
 class _FailingTelegramSender:
     def __init__(self) -> None:
         self._count = 0
@@ -986,12 +1178,16 @@ class _FailingTelegramSender:
         self._count += 1
         if self._count == 2:
             raise RuntimeError("simulated dispatch failure")
+
+
 @dataclass
 class _RecordingGitHubSender:
     sent: list[tuple[str, str]]
 
     def send(self, target: str, body: str) -> None:
         self.sent.append((target, body))
+
+
 class _FailingGitHubSender:
     def __init__(self) -> None:
         self._count = 0
@@ -1000,6 +1196,8 @@ class _FailingGitHubSender:
         self._count += 1
         if self._count == 2:
             raise RuntimeError("simulated dispatch failure")
+
+
 def _email_envelope(*, subject: str, body: str):
     from app.models import ReplyChannel, TaskEnvelope
 
@@ -1014,5 +1212,7 @@ def _email_envelope(*, subject: str, body: str):
         reply_channel=ReplyChannel(type="email", target="alice@example.com"),
         dedupe_key="email:test",
     )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_main_reply.py
+++ b/tests/test_main_reply.py
@@ -25,6 +25,8 @@ class _FakeBroker:
     def publish_json(self, queue_name: str, payload: dict[str, object]) -> str:
         self.published.append((queue_name, payload))
         return "guid-1"
+
+
 class MainReplyCliTests(unittest.TestCase):
     def test_main_reply_publishes_unsequenced_incremental_v2_payload(self) -> None:
         broker = _FakeBroker("127.0.0.1:9876")
@@ -71,11 +73,15 @@ class MainReplyCliTests(unittest.TestCase):
     def test_main_reply_uses_bbmb_address_from_worker_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "worker.json"
-            config_path.write_text(json.dumps({"bbmb_address": "10.0.0.5:9999"}), encoding="utf-8")
+            config_path.write_text(
+                json.dumps({"bbmb_address": "10.0.0.5:9999"}), encoding="utf-8"
+            )
             broker = _FakeBroker("placeholder")
             stdout = io.StringIO()
             with (
-                patch("app.main_reply.BBMBQueueAdapter", return_value=broker) as broker_ctor,
+                patch(
+                    "app.main_reply.BBMBQueueAdapter", return_value=broker
+                ) as broker_ctor,
                 patch("sys.stdout", stdout),
                 patch(
                     "sys.argv",
@@ -92,7 +98,7 @@ class MainReplyCliTests(unittest.TestCase):
                         str(config_path),
                     ],
                 ),
-                ):
+            ):
                 exit_code = main()
 
         self.assertEqual(exit_code, 0)
@@ -116,7 +122,9 @@ class MainReplyCliTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "envelope_id is required"):
                 main()
 
-    def test_main_reply_publishes_telegram_reaction_using_explicit_message_id(self) -> None:
+    def test_main_reply_publishes_telegram_reaction_using_explicit_message_id(
+        self,
+    ) -> None:
         broker = _FakeBroker("127.0.0.1:9876")
         with (
             patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
@@ -144,11 +152,15 @@ class MainReplyCliTests(unittest.TestCase):
         self.assertEqual(payload["message"]["body"], "👍")
         self.assertEqual(payload["message"]["metadata"], {"message_id": 123})
 
-    def test_main_reply_publishes_telegram_reaction_using_task_ledger_message_id(self) -> None:
+    def test_main_reply_publishes_telegram_reaction_using_task_ledger_message_id(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "state.db"
             config_path = Path(tmpdir) / "worker.json"
-            config_path.write_text(json.dumps({"db_path": str(db_path)}), encoding="utf-8")
+            config_path.write_text(
+                json.dumps({"db_path": str(db_path)}), encoding="utf-8"
+            )
             ledger = TaskLedgerStore(str(db_path))
             envelope = TaskEnvelope(
                 id="telegram:53",
@@ -165,7 +177,9 @@ class MainReplyCliTests(unittest.TestCase):
                 ),
                 dedupe_key="telegram:53",
             )
-            ledger.record_task(TaskQueueMessage.from_envelope(envelope, trace_id="trace:telegram:53"))
+            ledger.record_task(
+                TaskQueueMessage.from_envelope(envelope, trace_id="trace:telegram:53")
+            )
 
             broker = _FakeBroker("127.0.0.1:9876")
             with (
@@ -223,13 +237,19 @@ class MainReplyCliTests(unittest.TestCase):
         _, payload = broker.published[0]
         self.assertEqual(payload["message"]["body"], "This week's menu")
         self.assertEqual(payload["message"]["attachment"]["name"], "menu.pdf")
-        self.assertEqual(payload["message"]["attachment"]["uri"], attachment_path.as_uri())
+        self.assertEqual(
+            payload["message"]["attachment"]["uri"], attachment_path.as_uri()
+        )
 
-    def test_main_reply_records_worker_activity_when_db_path_is_configured(self) -> None:
+    def test_main_reply_records_worker_activity_when_db_path_is_configured(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "state.db"
             config_path = Path(tmpdir) / "worker.json"
-            config_path.write_text(json.dumps({"db_path": str(db_path)}), encoding="utf-8")
+            config_path.write_text(
+                json.dumps({"db_path": str(db_path)}), encoding="utf-8"
+            )
             broker = _FakeBroker("127.0.0.1:9876")
             with (
                 patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
@@ -252,10 +272,69 @@ class MainReplyCliTests(unittest.TestCase):
                 exit_code = main()
 
             self.assertEqual(exit_code, 0)
-            activity = SQLiteStateStore(str(db_path)).list_recent_worker_activity(limit=5, include_internal=True)
+            activity = SQLiteStateStore(str(db_path)).list_recent_worker_activity(
+                limit=5, include_internal=True
+            )
             self.assertEqual(len(activity), 1)
             self.assertEqual(activity[0]["phase"], "egress_incremental")
             self.assertEqual(activity[0]["detail"]["publish_source"], "main_reply")
+
+    def test_main_reply_normalizes_literal_escape_sequences_in_message_body(
+        self,
+    ) -> None:
+        broker = _FakeBroker("127.0.0.1:9876")
+        with (
+            patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+            patch(
+                "sys.argv",
+                [
+                    "main_reply.py",
+                    "task:telegram:53",
+                    "--message",
+                    r"Proof line 1.\nProof line 2.\n\nTabs:\tokay",
+                    "--channel",
+                    "telegram",
+                    "--target",
+                    "8605042448",
+                ],
+            ),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        _, payload = broker.published[0]
+        self.assertEqual(
+            payload["message"]["body"], "Proof line 1.\nProof line 2.\n\nTabs:\tokay"
+        )
+
+    def test_main_reply_normalizes_double_escaped_sequences_in_message_body(
+        self,
+    ) -> None:
+        broker = _FakeBroker("127.0.0.1:9876")
+        with (
+            patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+            patch(
+                "sys.argv",
+                [
+                    "main_reply.py",
+                    "task:telegram:53",
+                    "--message",
+                    r"Proof line 1.\\nProof line 2.\\n\\nEscaped \\(paren\\)",
+                    "--channel",
+                    "telegram",
+                    "--target",
+                    "8605042448",
+                ],
+            ),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        _, payload = broker.published[0]
+        self.assertEqual(
+            payload["message"]["body"],
+            "Proof line 1.\nProof line 2.\n\nEscaped (paren)",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_text.py
+++ b/tests/test_telegram_text.py
@@ -1,0 +1,23 @@
+import unittest
+
+from app.telegram_text import normalize_telegram_outbound_text
+
+
+class NormalizeTelegramOutboundTextTests(unittest.TestCase):
+    def test_normalizes_literal_escape_sequences(self) -> None:
+        self.assertEqual(
+            normalize_telegram_outbound_text(r"Line 1.\nLine 2.\n\nTabs:\tokay"),
+            "Line 1.\nLine 2.\n\nTabs:\tokay",
+        )
+
+    def test_normalizes_double_escaped_sequences(self) -> None:
+        self.assertEqual(
+            normalize_telegram_outbound_text(
+                r"Line 1.\\nLine 2.\\n\\nEscaped \\(paren\\)"
+            ),
+            "Line 1.\nLine 2.\n\nEscaped (paren)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize Telegram reply text in `app.main_reply` before it is queued
- move outbound Telegram text normalization into a shared helper used by both the reply CLI and the integrated Telegram sender
- add regression coverage for literal `\n` and doubly escaped `\\n` sequences across both paths, including parse-mode fallback

## Testing
- `uv run ruff format --check app/main_reply.py app/handler/applier/integrated.py app/telegram_text.py tests/test_main_reply.py tests/test_applier.py tests/test_telegram_text.py`
- `uv run ruff check app/main_reply.py app/handler/applier/integrated.py app/telegram_text.py tests/test_main_reply.py tests/test_applier.py tests/test_telegram_text.py`
- `uv run python -m unittest tests.test_main_reply tests.test_applier tests.test_telegram_text`
