### PR TITLE
Stabilize worker activity UI selection

### DIFF
--- a/app/state/sqlite_store.py
+++ b/app/state/sqlite_store.py
@@ -689,7 +689,7 @@ class SQLiteStateStore:
             if include_internal:
                 rows = connection.execute(
                     """
-                    SELECT occurred_at, task_id, envelope_id, run_id, source, workflow, phase, summary, detail_json, is_internal
+                    SELECT activity_id, occurred_at, task_id, envelope_id, run_id, source, workflow, phase, summary, detail_json, is_internal
                     FROM worker_activity_events
                     ORDER BY activity_id DESC
                     LIMIT ?
@@ -699,7 +699,7 @@ class SQLiteStateStore:
             else:
                 rows = connection.execute(
                     """
-                    SELECT occurred_at, task_id, envelope_id, run_id, source, workflow, phase, summary, detail_json, is_internal
+                    SELECT activity_id, occurred_at, task_id, envelope_id, run_id, source, workflow, phase, summary, detail_json, is_internal
                     FROM worker_activity_events
                     WHERE is_internal = 0
                     ORDER BY activity_id DESC
@@ -709,6 +709,7 @@ class SQLiteStateStore:
                 ).fetchall()
         return [
             {
+                "activity_id": row["activity_id"],
                 "occurred_at": row["occurred_at"],
                 "task_id": row["task_id"],
                 "envelope_id": row["envelope_id"],

--- a/app/worker/activity.py
+++ b/app/worker/activity.py
@@ -486,6 +486,9 @@ def _render_html(
         let timerId = null;
 
         function eventId(item) {{
+          if (item && Number.isInteger(item.activity_id)) {{
+            return String(item.activity_id);
+          }}
           return [
             item.occurred_at || "",
             item.phase || "",
@@ -872,6 +875,9 @@ def _list_meta_entries(item: dict[str, object]) -> list[tuple[str, str]]:
 
 
 def _event_id(item: dict[str, object]) -> str:
+    activity_id = item.get("activity_id")
+    if isinstance(activity_id, int):
+        return str(activity_id)
     parts = [
         str(item.get("occurred_at", "")),
         str(item.get("phase", "")),

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -282,10 +282,12 @@ class SQLiteStateStoreTests(unittest.TestCase):
             visible = store.list_recent_worker_activity(limit=10)
             self.assertEqual(len(visible), 1)
             self.assertEqual(visible[0]["phase"], "task_received")
+            self.assertIsInstance(visible[0]["activity_id"], int)
 
             all_events = store.list_recent_worker_activity(limit=10, include_internal=True)
             self.assertEqual(len(all_events), 2)
             self.assertEqual(all_events[0]["phase"], "egress_message")
             self.assertEqual(all_events[1]["phase"], "task_received")
+            self.assertGreater(all_events[0]["activity_id"], all_events[1]["activity_id"])
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_worker_activity.py
+++ b/tests/test_worker_activity.py
@@ -150,6 +150,8 @@ class WorkerActivityTests(unittest.TestCase):
                 self.assertIn("pause refresh", html_body)
                 self.assertIn("fetch(`/activity.json", html_body)
                 self.assertNotIn('http-equiv="refresh"', html_body)
+                self.assertIn("data-event-id='3'", html_body)
+                self.assertIn("Number.isInteger(item.activity_id)", html_body)
 
                 with urllib.request.urlopen(
                     f"http://127.0.0.1:{port}/?refresh_off=1"
@@ -158,6 +160,46 @@ class WorkerActivityTests(unittest.TestCase):
                 self.assertIn("resume refresh", paused_html_body)
                 self.assertIn("Auto-refresh paused.", paused_html_body)
                 self.assertNotIn('http-equiv="refresh"', paused_html_body)
+            finally:
+                server.shutdown()
+
+    def test_activity_html_uses_stable_activity_ids_for_duplicate_like_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            monitor = WorkerActivityMonitor(store=store, history_limit=10)
+            task_message = self._build_task_message()
+
+            monitor.record_executor_output(
+                task_message=task_message,
+                workflow="respond_and_optionally_edit",
+                stream="stdout",
+                content="same output",
+            )
+            monitor.record_executor_output(
+                task_message=task_message,
+                workflow="respond_and_optionally_edit",
+                stream="stdout",
+                content="same output",
+            )
+
+            server = start_worker_activity_server(
+                host="127.0.0.1", port=0, monitor=monitor
+            )
+            port = server.server.server_address[1]
+            try:
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/activity.json"
+                ) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+                self.assertEqual(
+                    [item["activity_id"] for item in payload["recent_activity"]],
+                    [2, 1],
+                )
+
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}/") as response:
+                    html_body = response.read().decode("utf-8")
+                self.assertIn("data-event-id='2'", html_body)
+                self.assertIn("data-event-id='1'", html_body)
             finally:
                 server.shutdown()
 


### PR DESCRIPTION
## Summary
- carry `activity_id` through worker activity snapshots and use it as the UI selection key
- keep the existing synthetic key only as a fallback for older snapshots
- add regression coverage for duplicate-looking events and ordering in the worker activity tests
