### PR TITLE
Make worker activity UI conversation-first

### DIFF
--- a/app/worker/activity.py
+++ b/app/worker/activity.py
@@ -230,9 +230,14 @@ class WorkerActivityMonitor:
             limit=self._history_limit,
             include_internal=include_internal,
         )
+        conversation_feed = _build_conversation_feed(
+            activity,
+            limit=self._history_limit,
+        )
         return {
             "current_executor": current_executor,
             "recent_activity": activity,
+            "recent_feed": conversation_feed,
             "history_limit": self._history_limit,
             "history_truncated": len(activity) >= self._history_limit,
             "include_internal": include_internal,
@@ -342,11 +347,13 @@ def _render_html(
 ) -> str:
     current_executor = snapshot["current_executor"]
     activity = snapshot["recent_activity"]
+    feed = snapshot.get("recent_feed", activity)
     assert isinstance(current_executor, dict)
     assert isinstance(activity, list)
+    assert isinstance(feed, list)
     activity_json = _json_script_value(snapshot)
-    initial_list_markup = _render_activity_list(activity)
-    initial_detail_markup = _render_detail_panel(activity[0] if activity else None)
+    initial_list_markup = _render_activity_list(feed)
+    initial_detail_markup = _render_detail_panel(feed[0] if feed else None)
     current_state_markup = _render_current_executor(current_executor)
 
     showing_note = ""
@@ -460,7 +467,7 @@ def _render_html(
     <div class="layout">
       <section class="panel list-panel">
         <div class="list-header">
-          <h2>Recent Activity</h2>
+          <h2>Recent Conversations</h2>
           {showing_note}
         </div>
         <ul class="activity-list" id="activity-list">{initial_list_markup}</ul>
@@ -480,7 +487,9 @@ def _render_html(
         const includeInternal = {str(include_internal).lower()};
         let autoRefresh = {str(auto_refresh).lower()};
         let selectedId = null;
-        let currentActivity = Array.isArray(initialSnapshot.recent_activity)
+        let currentActivity = Array.isArray(initialSnapshot.recent_feed)
+          ? initialSnapshot.recent_feed
+          : Array.isArray(initialSnapshot.recent_activity)
           ? initialSnapshot.recent_activity
           : [];
         let timerId = null;
@@ -686,7 +695,9 @@ def _render_html(
             throw new Error(`activity fetch failed: ${{response.status}}`);
           }}
           const snapshot = await response.json();
-          currentActivity = Array.isArray(snapshot.recent_activity)
+          currentActivity = Array.isArray(snapshot.recent_feed)
+            ? snapshot.recent_feed
+            : Array.isArray(snapshot.recent_activity)
             ? snapshot.recent_activity
             : [];
           renderCurrentExecutor(snapshot.current_executor || {{}});
@@ -772,6 +783,17 @@ def _render_current_executor(current_executor: dict[str, object]) -> str:
             "</dl>"
         )
     return f"<div class='detail-grid'>{''.join(blocks)}</div>"
+
+
+def _build_conversation_feed(
+    activity: list[dict[str, object]],
+    *,
+    limit: int,
+) -> list[dict[str, object]]:
+    message_events = [item for item in activity if _is_conversation_event(item)]
+    if message_events:
+        return message_events[:limit]
+    return activity[:limit]
 
 
 def _render_activity_list(activity: list[object]) -> str:
@@ -937,3 +959,22 @@ def _detail_without_message(detail: object) -> object:
     return {
         key: value for key, value in detail.items() if key not in {"body", "content"}
     }
+
+
+def _is_conversation_event(item: dict[str, object]) -> bool:
+    if bool(item.get("is_internal")):
+        return False
+    message = _message_text(item)
+    if message is None:
+        return False
+    phase = str(item.get("phase", ""))
+    if phase == "task_received":
+        source = str(item.get("source", ""))
+        return source not in {"cron", "internal"}
+    if not phase.startswith("egress_"):
+        return False
+    detail = item.get("detail")
+    if not isinstance(detail, dict):
+        return False
+    channel = str(detail.get("channel", ""))
+    return channel not in {"internal", "log"}

--- a/tests/test_worker_activity.py
+++ b/tests/test_worker_activity.py
@@ -87,6 +87,8 @@ class WorkerActivityTests(unittest.TestCase):
             self.assertEqual(
                 snapshot["recent_activity"][1]["phase"], "egress_incremental"
             )
+            self.assertEqual(snapshot["recent_feed"][0]["phase"], "egress_incremental")
+            self.assertEqual(snapshot["recent_feed"][1]["phase"], "task_received")
             self.assertEqual(snapshot["recent_activity"][2]["phase"], "executor_stdout")
             self.assertEqual(
                 snapshot["recent_activity"][2]["detail"]["content"],
@@ -138,7 +140,7 @@ class WorkerActivityTests(unittest.TestCase):
                 with urllib.request.urlopen(f"http://127.0.0.1:{port}/") as response:
                     html_body = response.read().decode("utf-8")
                 self.assertIn("Worker Now", html_body)
-                self.assertIn("Recent Activity", html_body)
+                self.assertIn("Recent Conversations", html_body)
                 self.assertIn("Message Detail", html_body)
                 self.assertIn("task_received", html_body)
                 self.assertIn("hello", html_body)
@@ -150,7 +152,7 @@ class WorkerActivityTests(unittest.TestCase):
                 self.assertIn("pause refresh", html_body)
                 self.assertIn("fetch(`/activity.json", html_body)
                 self.assertNotIn('http-equiv="refresh"', html_body)
-                self.assertIn("data-event-id='3'", html_body)
+                self.assertIn("data-event-id='1'", html_body)
                 self.assertIn("Number.isInteger(item.activity_id)", html_body)
 
                 with urllib.request.urlopen(
@@ -202,6 +204,41 @@ class WorkerActivityTests(unittest.TestCase):
                 self.assertIn("data-event-id='1'", html_body)
             finally:
                 server.shutdown()
+
+    def test_snapshot_recent_feed_prefers_conversation_events_over_cron_noise(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            monitor = WorkerActivityMonitor(store=store, history_limit=10)
+            task_message = self._build_task_message()
+
+            cron_envelope = TaskEnvelope(
+                id="cron:1",
+                source="cron",
+                received_at=datetime(2026, 3, 31, 12, 1, tzinfo=timezone.utc),
+                actor="scheduler",
+                content="Tidy up your workspace.",
+                attachments=[],
+                context_refs=[],
+                reply_channel=ReplyChannel(type="log", target="cron"),
+                dedupe_key="cron:1",
+            )
+            cron_task = TaskQueueMessage.from_envelope(
+                cron_envelope,
+                trace_id="trace:cron:1",
+            )
+
+            monitor.record_task_received(task_message=task_message)
+            monitor.record_task_received(task_message=cron_task)
+
+            snapshot = monitor.snapshot()
+            self.assertEqual(
+                [item["source"] for item in snapshot["recent_activity"]],
+                ["cron", "im"],
+            )
+            self.assertEqual(
+                [item["source"] for item in snapshot["recent_feed"]],
+                ["im"],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make the worker activity UI sidebar conversation-first instead of raw-event-first
- keep exposing the full raw worker activity log in `/activity.json` via `recent_activity`
- add regression coverage that chat traffic wins over cron/task bookkeeping in the HTML feed

## Testing
- `uv run ruff check app/worker/activity.py tests/test_worker_activity.py`
- `uv run python -m unittest tests.test_worker_activity`
- `uv run python -m unittest tests.test_worker_runtime tests.test_main_worker`
