### PR TITLE
Sort worker activity by event time

### DIFF
--- a/app/state/sqlite_store.py
+++ b/app/state/sqlite_store.py
@@ -691,7 +691,7 @@ class SQLiteStateStore:
                     """
                     SELECT activity_id, occurred_at, task_id, envelope_id, run_id, source, workflow, phase, summary, detail_json, is_internal
                     FROM worker_activity_events
-                    ORDER BY activity_id DESC
+                    ORDER BY occurred_at DESC, activity_id DESC
                     LIMIT ?
                     """,
                     (limit,),
@@ -702,7 +702,7 @@ class SQLiteStateStore:
                     SELECT activity_id, occurred_at, task_id, envelope_id, run_id, source, workflow, phase, summary, detail_json, is_internal
                     FROM worker_activity_events
                     WHERE is_internal = 0
-                    ORDER BY activity_id DESC
+                    ORDER BY occurred_at DESC, activity_id DESC
                     LIMIT ?
                     """,
                     (limit,),

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -289,5 +289,36 @@ class SQLiteStateStoreTests(unittest.TestCase):
             self.assertEqual(all_events[0]["phase"], "egress_message")
             self.assertEqual(all_events[1]["phase"], "task_received")
             self.assertGreater(all_events[0]["activity_id"], all_events[1]["activity_id"])
+
+    def test_worker_activity_orders_by_occurred_at_not_insert_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            store = SQLiteStateStore(db_path)
+
+            store.append_worker_activity(
+                occurred_at=datetime(2026, 4, 27, 19, 0, tzinfo=timezone.utc),
+                task_id="task:im:new",
+                envelope_id="im:new",
+                source="im",
+                phase="task_received",
+                summary="newer chat task received",
+                detail={"reply_channel": "telegram"},
+            )
+            store.append_worker_activity(
+                occurred_at=datetime(2026, 4, 20, 9, 0, tzinfo=timezone.utc),
+                task_id="task:cron:old",
+                envelope_id="cron:old",
+                source="cron",
+                phase="egress_incremental",
+                summary="old cron replayed later",
+                detail={"channel": "telegram"},
+            )
+
+            visible = store.list_recent_worker_activity(limit=10)
+            self.assertEqual(
+                [item["task_id"] for item in visible],
+                ["task:im:new", "task:cron:old"],
+            )
+            self.assertGreater(visible[1]["activity_id"], visible[0]["activity_id"])
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_worker_activity.py
+++ b/tests/test_worker_activity.py
@@ -84,13 +84,13 @@ class WorkerActivityTests(unittest.TestCase):
             snapshot = monitor.snapshot()
             self.assertEqual(snapshot["current_executor"]["active"], False)
             self.assertEqual(snapshot["recent_activity"][0]["phase"], "task_finished")
+            self.assertEqual(snapshot["recent_activity"][1]["phase"], "executor_stdout")
             self.assertEqual(
-                snapshot["recent_activity"][1]["phase"], "egress_incremental"
-            )
-            self.assertEqual(snapshot["recent_activity"][2]["phase"], "executor_stdout")
-            self.assertEqual(
-                snapshot["recent_activity"][2]["detail"]["content"],
+                snapshot["recent_activity"][1]["detail"]["content"],
                 "codex transcript line",
+            )
+            self.assertEqual(
+                snapshot["recent_activity"][-2]["phase"], "egress_incremental"
             )
             self.assertEqual(
                 snapshot["recent_activity"][-1]["detail"]["content"], "hello"


### PR DESCRIPTION
## Summary
- sort worker activity by `occurred_at` first so replayed old events do not jump above newer chat activity
- keep `activity_id` as the stable tie-breaker for duplicate timestamps and row selection
- add coverage for out-of-order inserts and update worker activity expectations to match true timestamp ordering

## Testing
- `uv run python -m unittest tests.test_sqlite_store tests.test_worker_activity`
- `uv run ruff check app/state/sqlite_store.py tests/test_sqlite_store.py tests/test_worker_activity.py`
