### PR TITLE
Hardcode the workflow label

### DIFF
--- a/app/worker/activity.py
+++ b/app/worker/activity.py
@@ -516,7 +516,6 @@ def _render_html(
           return [
             ["task", item && item.task_id ? item.task_id : null],
             ["source", item && item.source ? item.source : null],
-            ["workflow", item && item.workflow ? item.workflow : null],
           ].filter(([, value]) => value);
         }}
 
@@ -557,7 +556,6 @@ def _render_html(
             ["phase", currentExecutor && currentExecutor.phase ? currentExecutor.phase : "idle"],
             ["task_id", currentExecutor && currentExecutor.task_id],
             ["envelope_id", currentExecutor && currentExecutor.envelope_id],
-            ["workflow", currentExecutor && currentExecutor.workflow],
             ["attempt", currentExecutor && currentExecutor.attempt],
             ["pid", currentExecutor && currentExecutor.pid],
             [
@@ -635,7 +633,6 @@ def _render_html(
             ["Envelope", selectedItem.envelope_id || ""],
             ["Run", selectedItem.run_id || ""],
             ["Source", selectedItem.source || ""],
-            ["Workflow", selectedItem.workflow || ""],
           ].filter(([, value]) => value);
           detailElement.innerHTML = `
             <h2>Message Detail</h2>
@@ -747,7 +744,7 @@ def _render_current_executor(current_executor: dict[str, object]) -> str:
         ("state", "running" if active else "idle"),
         ("phase", str(current_executor.get("phase", "idle"))),
     ]
-    for key in ("task_id", "envelope_id", "workflow", "attempt", "pid", "started_at"):
+    for key in ("task_id", "envelope_id", "attempt", "pid", "started_at"):
         value = current_executor.get(key)
         if value is not None:
             if key.endswith("_at"):
@@ -818,7 +815,6 @@ def _render_detail_panel(item: object) -> str:
         ("Envelope", str(item.get("envelope_id", ""))),
         ("Run", str(item.get("run_id", ""))),
         ("Source", str(item.get("source", ""))),
-        ("Workflow", str(item.get("workflow", ""))),
     ]
     blocks = []
     for label, value in entries:
@@ -859,7 +855,6 @@ def _list_meta_entries(item: dict[str, object]) -> list[tuple[str, str]]:
     entries = [
         ("task", str(item.get("task_id", ""))),
         ("source", str(item.get("source", ""))),
-        ("workflow", str(item.get("workflow", ""))),
     ]
     return [(label, value) for label, value in entries if value]
 

--- a/app/worker/activity.py
+++ b/app/worker/activity.py
@@ -62,7 +62,6 @@ class WorkerActivityMonitor:
             task_id=task_message.task_id,
             envelope_id=envelope.id,
             source=envelope.source,
-            workflow=None,
             occurred_at=envelope.received_at,
             is_internal=envelope.source == "internal",
             detail={
@@ -78,7 +77,6 @@ class WorkerActivityMonitor:
         *,
         task_message: TaskQueueMessage,
         attempt: int,
-        workflow: str,
     ) -> None:
         envelope = task_message.envelope
         occurred_at = self._now_fn()
@@ -87,7 +85,6 @@ class WorkerActivityMonitor:
             "task_id": task_message.task_id,
             "envelope_id": envelope.id,
             "source": envelope.source,
-            "workflow": workflow,
             "attempt": attempt,
             "started_at": _isoformat(occurred_at),
             "pid": None,
@@ -101,7 +98,6 @@ class WorkerActivityMonitor:
             task_id=task_message.task_id,
             envelope_id=envelope.id,
             source=envelope.source,
-            workflow=workflow,
             occurred_at=occurred_at,
             is_internal=envelope.source == "internal",
             detail={"attempt": attempt},
@@ -120,7 +116,6 @@ class WorkerActivityMonitor:
         *,
         task_message: TaskQueueMessage,
         run_id: str,
-        workflow: str,
         result_status: str,
         attempt_count: int,
         reason_codes: list[str],
@@ -137,7 +132,6 @@ class WorkerActivityMonitor:
             envelope_id=envelope.id,
             run_id=run_id,
             source=envelope.source,
-            workflow=workflow,
             occurred_at=occurred_at,
             is_internal=envelope.source == "internal",
             detail={
@@ -152,7 +146,6 @@ class WorkerActivityMonitor:
         self,
         *,
         task_message: TaskQueueMessage,
-        workflow: str,
         stream: str,
         content: str,
     ) -> None:
@@ -163,7 +156,6 @@ class WorkerActivityMonitor:
             task_id=task_message.task_id,
             envelope_id=envelope.id,
             source=envelope.source,
-            workflow=workflow,
             is_internal=envelope.source == "internal",
             detail={"stream": stream, "content": content},
         )
@@ -173,7 +165,6 @@ class WorkerActivityMonitor:
         *,
         task_message: TaskQueueMessage,
         attempt: int,
-        workflow: str,
         error: str,
     ) -> None:
         envelope = task_message.envelope
@@ -183,7 +174,6 @@ class WorkerActivityMonitor:
             task_id=task_message.task_id,
             envelope_id=envelope.id,
             source=envelope.source,
-            workflow=workflow,
             is_internal=envelope.source == "internal",
             detail={"attempt": attempt, "error": error},
         )

--- a/app/worker/executor/codex.py
+++ b/app/worker/executor/codex.py
@@ -69,15 +69,10 @@ def _task_payload(
 ) -> dict[str, Any]:
     if current_time.tzinfo is None:
         raise ValueError("current_time must be timezone-aware")
-    workflow = (
-        "scheduled_automation"
-        if envelope.source == "cron"
-        else "respond_and_optionally_edit"
-    )
     task_dict: dict[str, Any] = {
         "task_id": f"task:{envelope.id}",
         "envelope_id": envelope.id,
-        "workflow": workflow,
+        "workflow": "default",
         "event_time": envelope.received_at.astimezone(timezone.utc)
         .isoformat()
         .replace("+00:00", "Z"),

--- a/app/worker/runtime.py
+++ b/app/worker/runtime.py
@@ -50,11 +50,6 @@ def process_task_message(
         )
 
     run_id = f"run:{task_message.task_id}:{time.time_ns()}"
-    workflow = (
-        "scheduled_automation"
-        if envelope.source == "cron"
-        else "respond_and_optionally_edit"
-    )
     started = time.perf_counter()
 
     reason_codes: list[str] = []
@@ -72,21 +67,18 @@ def process_task_message(
             activity_monitor.record_executor_started(
                 task_message=task_message,
                 attempt=attempt,
-                workflow=workflow,
             )
             execution_result = executor_impl.execute(envelope)
             execution_payload = execution_result.to_dict()
             if execution_result.stdout:
                 activity_monitor.record_executor_output(
                     task_message=task_message,
-                    workflow=workflow,
                     stream="stdout",
                     content=execution_result.stdout,
                 )
             if execution_result.stderr:
                 activity_monitor.record_executor_output(
                     task_message=task_message,
-                    workflow=workflow,
                     stream="stderr",
                     content=execution_result.stderr,
                 )
@@ -111,7 +103,6 @@ def process_task_message(
             activity_monitor.record_executor_failure(
                 task_message=task_message,
                 attempt=attempt,
-                workflow=workflow,
                 error=last_error,
             )
             if attempt == max_attempts:
@@ -131,7 +122,7 @@ def process_task_message(
         run_id=run_id,
         envelope_id=envelope.id,
         source=envelope.source,
-        workflow=workflow,
+        workflow="default",
         latency_ms=latency_ms,
         result_status=result_status,
         created_at=datetime.now(timezone.utc),
@@ -176,7 +167,6 @@ def process_task_message(
     activity_monitor.record_executor_finished(
         task_message=task_message,
         run_id=run_record.run_id,
-        workflow=workflow,
         result_status=run_record.result_status,
         attempt_count=attempt_count,
         reason_codes=reason_codes,
@@ -210,7 +200,7 @@ def _process_internal_heartbeat(
         run_id=f"run:{task_message.task_id}:{time.time_ns()}",
         envelope_id=task_message.envelope.id,
         source=task_message.envelope.source,
-        workflow="internal_heartbeat",
+        workflow="default",
         latency_ms=max(
             int((worker_received_at - ping_emitted_at).total_seconds() * 1000), 0
         ),

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -93,7 +93,7 @@ class CodexExecutorTests(unittest.TestCase):
         payload = json.loads(run_mock.call_args.kwargs["input"])
         self.assertEqual(payload["task"]["task_id"], "task:evt_1")
         self.assertEqual(payload["task"]["envelope_id"], "evt_1")
-        self.assertEqual(payload["task"]["workflow"], "respond_and_optionally_edit")
+        self.assertEqual(payload["task"]["workflow"], "default")
         self.assertEqual(payload["task"]["event_time"], "2026-02-27T16:00:00Z")
         self.assertEqual(payload["task"]["source"], "email")
         self.assertEqual(payload["task"]["actor"], "alice@example.com")
@@ -128,28 +128,6 @@ class CodexExecutorTests(unittest.TestCase):
             payload["reply_contract"]["executor_stdout_stderr_are_operator_transcript"],
             True,
         )
-
-    @patch("app.worker.executor.codex.subprocess.run")
-    def test_execute_workflow_for_cron_source(self, run_mock) -> None:
-        run_mock.return_value = subprocess.CompletedProcess(
-            args=["codex", "exec", "--json"], returncode=0, stdout="", stderr=""
-        )
-        cron_envelope = TaskEnvelope(
-            id="cron_1",
-            source="cron",
-            received_at=datetime(2026, 2, 27, 16, 0, tzinfo=timezone.utc),
-            actor=None,
-            content="Run daily summary",
-            attachments=[],
-            context_refs=[],
-            reply_channel=ReplyChannel(type="internal", target="cron"),
-            dedupe_key="cron_1",
-        )
-
-        CodexExecutor().execute(cron_envelope)
-
-        payload = json.loads(run_mock.call_args.kwargs["input"])
-        self.assertEqual(payload["task"]["workflow"], "scheduled_automation")
 
     @patch("app.worker.executor.codex.subprocess.run")
     def test_execute_passes_configured_working_directory(self, run_mock) -> None:

--- a/tests/test_worker_activity.py
+++ b/tests/test_worker_activity.py
@@ -36,11 +36,9 @@ class WorkerActivityTests(unittest.TestCase):
             monitor.record_executor_started(
                 task_message=task_message,
                 attempt=1,
-                workflow="respond_and_optionally_edit",
             )
             monitor.record_executor_output(
                 task_message=task_message,
-                workflow="respond_and_optionally_edit",
                 stream="stdout",
                 content="codex transcript line",
             )
@@ -74,7 +72,6 @@ class WorkerActivityTests(unittest.TestCase):
             monitor.record_executor_finished(
                 task_message=task_message,
                 run_id="run:telegram:1",
-                workflow="respond_and_optionally_edit",
                 result_status="success",
                 attempt_count=1,
                 reason_codes=[],
@@ -112,11 +109,9 @@ class WorkerActivityTests(unittest.TestCase):
             monitor.record_executor_started(
                 task_message=task_message,
                 attempt=1,
-                workflow="respond_and_optionally_edit",
             )
             monitor.record_executor_output(
                 task_message=task_message,
-                workflow="respond_and_optionally_edit",
                 stream="stderr",
                 content="warning line",
             )
@@ -171,13 +166,11 @@ class WorkerActivityTests(unittest.TestCase):
 
             monitor.record_executor_output(
                 task_message=task_message,
-                workflow="respond_and_optionally_edit",
                 stream="stdout",
                 content="same output",
             )
             monitor.record_executor_output(
                 task_message=task_message,
-                workflow="respond_and_optionally_edit",
                 stream="stdout",
                 content="same output",
             )

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -247,7 +247,7 @@ class WorkerRuntimeTests(unittest.TestCase):
             )
 
             self.assertEqual(result.run_record.result_status, "success")
-            self.assertEqual(result.run_record.workflow, "internal_heartbeat")
+            self.assertEqual(result.run_record.workflow, "default")
             self.assertEqual(result.run_record.source, "internal")
             self.assertEqual(len(result.egress_messages), 2)
             visible_egress_message = result.egress_messages[0]
@@ -261,7 +261,7 @@ class WorkerRuntimeTests(unittest.TestCase):
             )
             self.assertEqual(completion_egress_message.event_kind, "completion")
             audit_event = store.list_audit_events()[0]
-            self.assertEqual(audit_event.workflow, "internal_heartbeat")
+            self.assertEqual(audit_event.workflow, "default")
             self.assertEqual(audit_event.detail["reason_codes"], ["internal_heartbeat"])
             self.assertEqual(audit_event.detail["heartbeat"]["kind"], "heartbeat_pong")
 


### PR DESCRIPTION
`workflow` was a derived string with no Python reader. After the router collapse (#159) it was being computed as a one-liner from `envelope.source` (cron → "scheduled_automation", everything else → "respond_and_optionally_edit") and passed through five `WorkerActivityMonitor` methods just to land on `RunRecord.workflow`, `AuditEvent.workflow`, and the activity UI. The UI also shows `source` directly next to it, so the value carried no information.

Removes the parameter from `WorkerActivityMonitor.record_executor_started` / `record_executor_finished` / `record_executor_output` / `record_executor_failure` (and trims the runtime call sites). Hardcodes `"default"` in `RunRecord` and `AuditEvent` writes, and in the Codex prompt JSON. A follow-up commit also drops the workflow field from the activity UI (list, detail panel, current-executor sidebar) since it would otherwise just show "default" everywhere.

**Breaking-change profile**
- **DB**: column kept on `run_records`, `audit_events`, `worker_activity`. Old rows still readable with their historical values (`scheduled_automation` / `respond_and_optionally_edit` / `internal_heartbeat`). New rows write `"default"`. No migration needed.
- **BBMB / wire format**: no change.
- **Codex prompt JSON**: `task.workflow` is now always `"default"`. If any Codex prompt downstream branched on this string, behavior changes. Same risk profile as the priority/max_tokens drop in #159; user confirmed.
- **Activity UI**: the workflow field is no longer displayed. The column stays on disk for audit continuity, so historical values are preserved but not surfaced.
- **Rollback**: revert the merge.

**Verification**
- `uv run python -m unittest discover -s tests` → 230 passed, 3 skipped
- `uv run ruff check app tests` → clean
- `uv run pyright app` → 0 errors