### PR TITLE
Add contract golden fixtures

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -400,6 +400,9 @@ enough to land as one PR and should leave the repo in a working state.
 
 ### 1. Contract Golden Fixtures
 
+Status: complete. Shared fixtures now live under `tests/fixtures/contracts/`, and
+both the Python and Go contract tests load and round-trip them.
+
 Add golden JSON fixtures under `tests/fixtures/contracts/` for:
 - one `chatting.task.v1`
 - one sequenced `chatting.egress.v2` message

--- a/go/handler/internal/contracts/contracts_test.go
+++ b/go/handler/internal/contracts/contracts_test.go
@@ -2,6 +2,10 @@ package contracts
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -181,6 +185,96 @@ func TestAuxiliaryIngressQueueMessageRoundTrip(t *testing.T) {
 	if parsed.EventID != "aux:1" {
 		t.Fatalf("EventID = %q", parsed.EventID)
 	}
+}
+
+func TestGoldenContractFixtures(t *testing.T) {
+	tests := []struct {
+		name   string
+		decode func([]byte) ([]byte, error)
+	}{
+		{
+			name: "task.v1.json",
+			decode: func(raw []byte) ([]byte, error) {
+				parsed, err := DecodeTaskQueueMessage(raw)
+				if err != nil {
+					return nil, err
+				}
+				return json.Marshal(parsed)
+			},
+		},
+		{
+			name: "egress.v2.sequenced.json",
+			decode: func(raw []byte) ([]byte, error) {
+				parsed, err := DecodeEgressQueueMessage(raw)
+				if err != nil {
+					return nil, err
+				}
+				if parsed.Sequence == nil || *parsed.Sequence != 0 {
+					t.Fatalf("%s sequence = %#v", "egress.v2.sequenced.json", parsed.Sequence)
+				}
+				return json.Marshal(parsed)
+			},
+		},
+		{
+			name: "egress.v2.incremental.json",
+			decode: func(raw []byte) ([]byte, error) {
+				parsed, err := DecodeEgressQueueMessage(raw)
+				if err != nil {
+					return nil, err
+				}
+				if parsed.Sequence != nil {
+					t.Fatalf("%s sequence = %#v", "egress.v2.incremental.json", parsed.Sequence)
+				}
+				return json.Marshal(parsed)
+			},
+		},
+		{
+			name: "auxiliary_ingress.v1.json",
+			decode: func(raw []byte) ([]byte, error) {
+				parsed, err := DecodeAuxiliaryIngressQueueMessage(raw)
+				if err != nil {
+					return nil, err
+				}
+				return json.Marshal(parsed)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := readFixture(t, test.name)
+			encoded, err := test.decode(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var original map[string]any
+			if err := json.Unmarshal(raw, &original); err != nil {
+				t.Fatal(err)
+			}
+			var roundTripped map[string]any
+			if err := json.Unmarshal(encoded, &roundTripped); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(roundTripped, original) {
+				t.Fatalf("round trip changed fixture\noriginal: %#v\nroundTripped: %#v", original, roundTripped)
+			}
+		})
+	}
+}
+
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not locate current test file")
+	}
+	path := filepath.Join(filepath.Dir(currentFile), "..", "..", "..", "..", "tests", "fixtures", "contracts", name)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
 }
 
 func mustTimestamp(t *testing.T, raw string) Timestamp {

--- a/tests/fixtures/contracts/auxiliary_ingress.v1.json
+++ b/tests/fixtures/contracts/auxiliary_ingress.v1.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "message_type": "chatting.auxiliary_ingress.v1",
+  "event_id": "aux:fixture:1",
+  "received_at": "2026-05-12T09:01:00Z",
+  "body": {
+    "source": "github",
+    "installation_id": 12345,
+    "repository": {
+      "full_name": "example/chatting"
+    },
+    "labels": [
+      "codex",
+      "handler-port"
+    ],
+    "dry_run": true
+  }
+}

--- a/tests/fixtures/contracts/egress.v2.incremental.json
+++ b/tests/fixtures/contracts/egress.v2.incremental.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "message_type": "chatting.egress.v2",
+  "task_id": "task:email:fixture:1",
+  "envelope_id": "email:fixture:1",
+  "trace_id": "trace:fixture:email:1",
+  "event_id": "evt:task:email:fixture:1:incremental:1",
+  "event_kind": "incremental",
+  "emitted_at": "2026-05-12T09:00:03Z",
+  "message": {
+    "channel": "email",
+    "target": "alice@example.com",
+    "body": "Working on the summary."
+  }
+}

--- a/tests/fixtures/contracts/egress.v2.sequenced.json
+++ b/tests/fixtures/contracts/egress.v2.sequenced.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.0",
+  "message_type": "chatting.egress.v2",
+  "task_id": "task:email:fixture:1",
+  "envelope_id": "email:fixture:1",
+  "trace_id": "trace:fixture:email:1",
+  "event_id": "evt:task:email:fixture:1:0",
+  "event_kind": "message",
+  "sequence": 0,
+  "emitted_at": "2026-05-12T09:00:05Z",
+  "message": {
+    "channel": "email",
+    "target": "alice@example.com",
+    "body": "Here is the requested summary.",
+    "metadata": {
+      "thread_id": "thread-fixture-1"
+    }
+  }
+}

--- a/tests/fixtures/contracts/task.v1.json
+++ b/tests/fixtures/contracts/task.v1.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "1.0",
+  "message_type": "chatting.task.v1",
+  "trace_id": "trace:fixture:email:1",
+  "task_id": "task:email:fixture:1",
+  "emitted_at": "2026-05-12T09:00:01Z",
+  "envelope": {
+    "schema_version": "1.0",
+    "id": "email:fixture:1",
+    "source": "email",
+    "received_at": "2026-05-12T09:00:00Z",
+    "actor": "alice@example.com",
+    "content": "Please summarize the attached notes.",
+    "attachments": [
+      {
+        "uri": "file:///tmp/chatting-fixtures/notes.md",
+        "name": "notes.md"
+      }
+    ],
+    "context_refs": [
+      "repo:/Users/edward/develop/chatting"
+    ],
+    "prompt_context": {
+      "global_instructions": [
+        "Keep replies concise."
+      ],
+      "source_instructions": [
+        "Treat email body text as user-authored input."
+      ],
+      "reply_channel_instructions": [
+        "Reply in plain text."
+      ],
+      "task_instructions": [
+        "Summarize the notes in three bullets."
+      ],
+      "assembled_instructions": [
+        "Keep replies concise.",
+        "Treat email body text as user-authored input.",
+        "Reply in plain text.",
+        "Summarize the notes in three bullets."
+      ]
+    },
+    "reply_channel": {
+      "type": "email",
+      "target": "alice@example.com",
+      "metadata": {
+        "thread_id": "thread-fixture-1"
+      }
+    },
+    "dedupe_key": "email:fixture:1"
+  }
+}

--- a/tests/test_contract_fixtures.py
+++ b/tests/test_contract_fixtures.py
@@ -1,0 +1,62 @@
+import json
+import unittest
+from pathlib import Path
+
+from app.broker.messages import (
+    AuxiliaryIngressQueueMessage,
+    EgressQueueMessage,
+    TaskQueueMessage,
+)
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "contracts"
+
+
+def load_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+class ContractFixtureTests(unittest.TestCase):
+    def test_task_fixture_parses_and_serializes(self) -> None:
+        payload = load_fixture("task.v1.json")
+
+        parsed = TaskQueueMessage.from_dict(payload)
+
+        self.assertEqual(parsed.message_type, "chatting.task.v1")
+        self.assertEqual(parsed.task_id, "task:email:fixture:1")
+        self.assertEqual(parsed.envelope.id, "email:fixture:1")
+        self.assertEqual(parsed.to_dict(), payload)
+
+    def test_sequenced_egress_fixture_parses_and_serializes(self) -> None:
+        payload = load_fixture("egress.v2.sequenced.json")
+
+        parsed = EgressQueueMessage.from_dict(payload)
+
+        self.assertEqual(parsed.message_type, "chatting.egress.v2")
+        self.assertEqual(parsed.event_kind, "message")
+        self.assertEqual(parsed.sequence, 0)
+        self.assertEqual(parsed.to_dict(), payload)
+
+    def test_incremental_egress_fixture_parses_and_serializes(self) -> None:
+        payload = load_fixture("egress.v2.incremental.json")
+
+        parsed = EgressQueueMessage.from_dict(payload)
+
+        self.assertEqual(parsed.message_type, "chatting.egress.v2")
+        self.assertEqual(parsed.event_kind, "incremental")
+        self.assertIsNone(parsed.sequence)
+        self.assertNotIn("sequence", parsed.to_dict())
+        self.assertEqual(parsed.to_dict(), payload)
+
+    def test_auxiliary_ingress_fixture_parses_and_serializes(self) -> None:
+        payload = load_fixture("auxiliary_ingress.v1.json")
+
+        parsed = AuxiliaryIngressQueueMessage.from_dict(payload)
+
+        self.assertEqual(parsed.message_type, "chatting.auxiliary_ingress.v1")
+        self.assertEqual(parsed.event_id, "aux:fixture:1")
+        self.assertEqual(parsed.to_dict(), payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add shared JSON golden fixtures for task, sequenced egress, incremental egress, and auxiliary ingress contracts
- add Python tests that parse and round-trip each fixture through current contract code
- add Go tests that parse and round-trip the same fixtures through internal/contracts
- mark the contract fixture slice complete in the Go handler porting plan

## Tests
- uv run python -m unittest tests.test_contract_fixtures tests.test_broker_messages
- cd go/handler && go test ./...