### PR TITLE
Run Go handler tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go/handler/go.mod
+          cache-dependency-path: go/handler/go.mod
+
       - name: Sync dependencies
         run: uv sync --locked
 
@@ -52,3 +58,7 @@ jobs:
         env:
           CHATTING_BBMB_SERVER_BIN: ${{ runner.temp }}/bbmb-server-linux-amd64
         run: uv run python -m unittest discover -s tests
+
+      - name: Run Go handler tests
+        working-directory: go/handler
+        run: go test ./...

--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -414,6 +414,16 @@ Validation:
 - Go tests load each fixture and parse it with `internal/contracts`
 - re-serializing should preserve the contract-relevant shape
 
+### 1a. Go Handler CI Test Wiring
+
+Status: complete. The main CI workflow runs `go test ./...` under `go/handler`
+using the module Go version from `go/handler/go.mod`.
+
+Validation:
+- CI installs Go for pull requests and pushes to `main`
+- Go handler unit tests run alongside the existing Python unit suite
+- local verification remains `cd go/handler && go test ./...`
+
 ### 2. E2E Implementation Selector
 
 Extend the E2E harness so tests can choose a handler implementation:


### PR DESCRIPTION
## Summary
- install Go in the main CI workflow using go/handler/go.mod
- run go test ./... under go/handler alongside the existing Python unit suite
- update the Go handler porting plan with the completed CI wiring slice

## Tests
- go test ./...
- uv run python -m unittest tests.test_contract_fixtures tests.test_broker_messages