### PR TITLE
Add E2E handler implementation selector

### DIFF
--- a/docs/debug-and-test.md
+++ b/docs/debug-and-test.md
@@ -37,6 +37,15 @@ uv run python -m unittest tests.test_worker_runtime tests.test_message_handler_r
 ```bash
 uv run python -m unittest tests.test_split_mode_e2e -v
 ```
+
+Select the handler implementation used by E2E tests:
+
+```bash
+CHATTING_E2E_HANDLER_IMPLEMENTATION=python uv run python -m unittest tests.test_split_mode_e2e -v
+```
+
+Supported values are `python` and `go`. The default is `python`. Selecting `go`
+currently fails clearly because the Go handler runtime is not implemented yet.
 This skips locally unless `CHATTING_BBMB_SERVER_BIN` points to a built `bbmb-server`.
 
 ## Useful runtime inspection commands

--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -426,6 +426,10 @@ Validation:
 
 ### 2. E2E Implementation Selector
 
+Status: complete. E2E tests select the handler implementation with
+`CHATTING_E2E_HANDLER_IMPLEMENTATION`; `python` remains the default, and `go`
+fails explicitly until the Go runtime is implemented.
+
 Extend the E2E harness so tests can choose a handler implementation:
 - `python`
 - `go`

--- a/tests/e2e/handler_selector.py
+++ b/tests/e2e/handler_selector.py
@@ -1,0 +1,49 @@
+"""Handler implementation selection for E2E tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Mapping
+
+
+HANDLER_IMPLEMENTATION_ENV = "CHATTING_E2E_HANDLER_IMPLEMENTATION"
+SUPPORTED_HANDLER_IMPLEMENTATIONS = ("python", "go")
+
+
+def selected_handler_implementation(
+    env: Mapping[str, str] | None = None,
+) -> str:
+    values = os.environ if env is None else env
+    selected = values.get(HANDLER_IMPLEMENTATION_ENV, "python").strip().lower()
+    if not selected:
+        selected = "python"
+    if selected not in SUPPORTED_HANDLER_IMPLEMENTATIONS:
+        supported = ", ".join(SUPPORTED_HANDLER_IMPLEMENTATIONS)
+        raise ValueError(
+            f"{HANDLER_IMPLEMENTATION_ENV} must be one of {supported}; got {selected!r}"
+        )
+    return selected
+
+
+def message_handler_command(
+    config_path: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+    python_executable: str = sys.executable,
+) -> list[str]:
+    implementation = selected_handler_implementation(env)
+    if implementation == "python":
+        return [
+            python_executable,
+            "-m",
+            "app.main_message_handler",
+            "--config",
+            str(config_path),
+        ]
+    raise NotImplementedError(
+        f"{HANDLER_IMPLEMENTATION_ENV}=go was selected, but the Go handler "
+        "runtime is not implemented yet. This is intentional and must not "
+        "fall back to the Python handler."
+    )

--- a/tests/e2e/test_auxiliary_ingress_e2e.py
+++ b/tests/e2e/test_auxiliary_ingress_e2e.py
@@ -14,6 +14,7 @@ import unittest
 from pathlib import Path
 
 from app.state import SQLiteStateStore
+from tests.e2e.handler_selector import message_handler_command
 
 
 def _is_port_open(host: str, port: int) -> bool:
@@ -238,13 +239,7 @@ class AuxiliaryIngressE2ETests(unittest.TestCase):
                     env=env,
                 )
                 handler_proc = subprocess.Popen(
-                    [
-                        sys.executable,
-                        "-m",
-                        "app.main_message_handler",
-                        "--config",
-                        str(handler_config_path),
-                    ],
+                    message_handler_command(handler_config_path),
                     cwd=repo_root,
                     stdout=handler_log_fh,
                     stderr=subprocess.STDOUT,

--- a/tests/e2e/test_email_e2e.py
+++ b/tests/e2e/test_email_e2e.py
@@ -11,6 +11,8 @@ import time
 import unittest
 from email.message import EmailMessage
 from pathlib import Path
+
+from tests.e2e.handler_selector import message_handler_command
 def _is_port_open(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         probe.settimeout(0.2)
@@ -148,13 +150,7 @@ class EmailE2ETests(unittest.TestCase):
                     env=env,
                 )
                 handler_proc = subprocess.Popen(
-                    [
-                        sys.executable,
-                        "-m",
-                        "app.main_message_handler",
-                        "--config",
-                        str(handler_config_path),
-                    ],
+                    message_handler_command(handler_config_path),
                     cwd=repo_root,
                     stdout=handler_log_fh,
                     stderr=subprocess.STDOUT,

--- a/tests/test_e2e_handler_selector.py
+++ b/tests/test_e2e_handler_selector.py
@@ -1,0 +1,49 @@
+import unittest
+from pathlib import Path
+
+from tests.e2e.handler_selector import (
+    HANDLER_IMPLEMENTATION_ENV,
+    message_handler_command,
+    selected_handler_implementation,
+)
+
+
+class E2EHandlerSelectorTests(unittest.TestCase):
+    def test_default_handler_implementation_is_python(self) -> None:
+        self.assertEqual(selected_handler_implementation({}), "python")
+
+    def test_python_handler_command_uses_current_python_entrypoint(self) -> None:
+        command = message_handler_command(
+            Path("/tmp/handler.json"),
+            env={HANDLER_IMPLEMENTATION_ENV: "python"},
+            python_executable="/bin/python-test",
+        )
+
+        self.assertEqual(
+            command,
+            [
+                "/bin/python-test",
+                "-m",
+                "app.main_message_handler",
+                "--config",
+                "/tmp/handler.json",
+            ],
+        )
+
+    def test_go_selection_fails_clearly_until_runtime_exists(self) -> None:
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Go handler runtime is not implemented yet",
+        ):
+            message_handler_command(
+                Path("/tmp/handler.json"),
+                env={HANDLER_IMPLEMENTATION_ENV: "go"},
+            )
+
+    def test_unknown_handler_implementation_fails(self) -> None:
+        with self.assertRaisesRegex(ValueError, HANDLER_IMPLEMENTATION_ENV):
+            selected_handler_implementation({HANDLER_IMPLEMENTATION_ENV: "ruby"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_split_mode_e2e.py
+++ b/tests/test_split_mode_e2e.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from app.state import SQLiteStateStore
+from tests.e2e.handler_selector import message_handler_command
 def _is_port_open(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         probe.settimeout(0.2)
@@ -116,13 +117,7 @@ class SplitModeE2ETests(unittest.TestCase):
                     text=True,
                 )
                 handler_proc = subprocess.Popen(
-                    [
-                        sys.executable,
-                        "-m",
-                        "app.main_message_handler",
-                        "--config",
-                        str(handler_config_path),
-                    ],
+                    message_handler_command(handler_config_path),
                     cwd=repo_root,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- add a shared E2E handler selector controlled by CHATTING_E2E_HANDLER_IMPLEMENTATION
- keep python as the default handler implementation for existing E2E tests
- make CHATTING_E2E_HANDLER_IMPLEMENTATION=go fail explicitly until the Go handler runtime exists
- update the porting plan and test docs to show the selector state

## Tests
- uv run python -m unittest tests.test_e2e_handler_selector tests.test_split_mode_e2e tests.e2e.test_email_e2e tests.e2e.test_auxiliary_ingress_e2e
- uv run ruff check tests/test_e2e_handler_selector.py tests/e2e/handler_selector.py tests/test_split_mode_e2e.py tests/e2e/test_email_e2e.py tests/e2e/test_auxiliary_ingress_e2e.py