### PR TITLE
Add Go handler config loader

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -460,6 +460,11 @@ Validation:
 
 ### 4. Go Config Loader
 
+Status: complete. `internal/config` now loads the minimal handler runtime config
+with Python-compatible defaults for supported keys, strict unknown-key rejection,
+validation for blank strings and invalid numeric/list values, and `--config`/env
+path wiring in the Go handler binary.
+
 Implement `internal/config` for the minimal handler runtime config:
 - `bbmb_address`
 - `db_path`
@@ -659,7 +664,6 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Implement the minimal Go handler config loader.
-2. Add SQLite dedupe and task ledger state.
-3. Add SQLite egress staging and dispatch state.
-4. Build the Go egress engine before tackling the more complex connectors.
+1. Add SQLite dedupe and task ledger state.
+2. Add SQLite egress staging and dispatch state.
+3. Build the Go egress engine before tackling the more complex connectors.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -3,20 +3,51 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"strings"
+
+	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
 )
 
 const version = "go-handler-bootstrap"
 
 func main() {
-	showVersion := flag.Bool("version", false, "print version and exit")
-	flag.Parse()
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, currentEnv()))
+}
 
-	if *showVersion {
-		fmt.Println(version)
-		return
+func run(args []string, stdout io.Writer, stderr io.Writer, environ map[string]string) int {
+	flags := flag.NewFlagSet("chatting-handler", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	showVersion := flags.Bool("version", false, "print version and exit")
+	configPath := flags.String("config", "", "Path to JSON config file.")
+	if err := flags.Parse(args); err != nil {
+		return 2
 	}
 
-	fmt.Fprintln(os.Stderr, "chatting Go handler bootstrap: runtime not implemented yet")
-	os.Exit(2)
+	if *showVersion {
+		fmt.Fprintln(stdout, version)
+		return 0
+	}
+
+	config, err := handlerconfig.LoadFromEnv(*configPath, environ)
+	if err != nil {
+		fmt.Fprintf(stderr, "config error: %v\n", err)
+		return 2
+	}
+	_ = config
+
+	fmt.Fprintln(stderr, "chatting Go handler bootstrap: runtime not implemented yet")
+	return 2
+}
+
+func currentEnv() map[string]string {
+	result := make(map[string]string)
+	for _, entry := range os.Environ() {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			result[key] = value
+		}
+	}
+	return result
 }

--- a/go/handler/cmd/chatting-handler/main_test.go
+++ b/go/handler/cmd/chatting-handler/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+)
+
+func TestRunPrintsVersion(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	status := run([]string{"--version"}, &stdout, &stderr, nil)
+
+	if status != 0 {
+		t.Fatalf("status = %d", status)
+	}
+	if strings.TrimSpace(stdout.String()) != version {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunParsesConfigFlagBeforeBootstrapExit(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "handler.json")
+	if err := os.WriteFile(configPath, []byte(`{"db_path": "/tmp/handler.db"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	status := run([]string{"--config", configPath}, &stdout, &stderr, nil)
+
+	if status != 2 {
+		t.Fatalf("status = %d", status)
+	}
+	if !strings.Contains(stderr.String(), "runtime not implemented yet") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "config error") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunRejectsInvalidConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "handler.json")
+	if err := os.WriteFile(configPath, []byte(`{"db_path": ""}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	status := run([]string{"--config", configPath}, &stdout, &stderr, nil)
+
+	if status != 2 {
+		t.Fatalf("status = %d", status)
+	}
+	if !strings.Contains(stderr.String(), "config error: config db_path must be a non-empty string") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "runtime not implemented yet") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunUsesConfigPathFromEnvironment(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "handler.json")
+	if err := os.WriteFile(configPath, []byte(`{"db_path": "/tmp/handler.db"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	status := run(
+		nil,
+		&stdout,
+		&stderr,
+		map[string]string{handlerconfig.MessageHandlerConfigPathEnvVar: configPath},
+	)
+
+	if status != 2 {
+		t.Fatalf("status = %d", status)
+	}
+	if !strings.Contains(stderr.String(), "runtime not implemented yet") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -1,0 +1,225 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	MessageHandlerConfigPathEnvVar = "CHATTING_MESSAGE_HANDLER_CONFIG_PATH"
+	DefaultBBMBAddress             = "127.0.0.1:9876"
+	DefaultPollIntervalSeconds     = 30.0
+	DefaultPollTimeoutSeconds      = 2
+	DefaultMetricsHost             = "127.0.0.1"
+	DefaultMetricsPort             = 9464
+)
+
+var allowedKeys = map[string]bool{
+	"bbmb_address":            true,
+	"db_path":                 true,
+	"max_loops":               true,
+	"poll_interval_seconds":   true,
+	"poll_timeout_seconds":    true,
+	"metrics_host":            true,
+	"metrics_port":            true,
+	"allowed_egress_channels": true,
+}
+
+type Config struct {
+	BBMBAddress           string
+	DBPath                string
+	MaxLoops              int
+	PollIntervalSeconds   float64
+	PollTimeoutSeconds    int
+	MetricsHost           string
+	MetricsPort           int
+	AllowedEgressChannels []string
+}
+
+func Defaults() Config {
+	return Config{
+		BBMBAddress:           DefaultBBMBAddress,
+		DBPath:                filepath.Join(os.TempDir(), "chatting-message-handler-state.db"),
+		MaxLoops:              0,
+		PollIntervalSeconds:   DefaultPollIntervalSeconds,
+		PollTimeoutSeconds:    DefaultPollTimeoutSeconds,
+		MetricsHost:           DefaultMetricsHost,
+		MetricsPort:           DefaultMetricsPort,
+		AllowedEgressChannels: []string{"email", "telegram", "telegram_reaction", "log"},
+	}
+}
+
+func LoadFile(path string) (Config, error) {
+	if strings.TrimSpace(path) == "" {
+		return Config{}, errors.New("config path must not be empty")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	return Load(raw)
+}
+
+func LoadFromEnv(configPath string, environ map[string]string) (Config, error) {
+	path := configPath
+	if path == "" && environ != nil {
+		if raw, ok := environ[MessageHandlerConfigPathEnvVar]; ok {
+			if strings.TrimSpace(raw) == "" {
+				return Config{}, fmt.Errorf("%s must not be empty", MessageHandlerConfigPathEnvVar)
+			}
+			path = raw
+		}
+	}
+	if path == "" {
+		return Defaults(), nil
+	}
+	return LoadFile(path)
+}
+
+func Load(raw []byte) (Config, error) {
+	var payload map[string]json.RawMessage
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		return Config{}, err
+	}
+	if payload == nil {
+		return Config{}, errors.New("config file must contain a JSON object")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return Config{}, errors.New("config file must contain a single JSON object")
+	} else if !errors.Is(err, io.EOF) {
+		return Config{}, err
+	}
+
+	unknownKeys := make([]string, 0)
+	for key := range payload {
+		if !allowedKeys[key] {
+			unknownKeys = append(unknownKeys, key)
+		}
+	}
+	if len(unknownKeys) > 0 {
+		sort.Strings(unknownKeys)
+		return Config{}, errors.New("config contains unknown keys: " + strings.Join(unknownKeys, ", "))
+	}
+
+	config := Defaults()
+	var err error
+	if rawValue, ok := payload["bbmb_address"]; ok && !isNull(rawValue) {
+		config.BBMBAddress, err = decodeNonEmptyString(rawValue, "bbmb_address")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["db_path"]; ok && !isNull(rawValue) {
+		config.DBPath, err = decodeNonEmptyString(rawValue, "db_path")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["max_loops"]; ok && !isNull(rawValue) {
+		config.MaxLoops, err = decodePositiveInt(rawValue, "max_loops")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["poll_interval_seconds"]; ok && !isNull(rawValue) {
+		config.PollIntervalSeconds, err = decodePositiveFloat(rawValue, "poll_interval_seconds")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["poll_timeout_seconds"]; ok && !isNull(rawValue) {
+		config.PollTimeoutSeconds, err = decodePositiveInt(rawValue, "poll_timeout_seconds")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["metrics_host"]; ok && !isNull(rawValue) {
+		config.MetricsHost, err = decodeNonEmptyString(rawValue, "metrics_host")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["metrics_port"]; ok && !isNull(rawValue) {
+		config.MetricsPort, err = decodePositiveInt(rawValue, "metrics_port")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["allowed_egress_channels"]; ok && !isNull(rawValue) {
+		config.AllowedEgressChannels, err = decodeAllowedEgressChannels(rawValue)
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	return config, nil
+}
+
+func isNull(raw json.RawMessage) bool {
+	return strings.TrimSpace(string(raw)) == "null"
+}
+
+func decodeNonEmptyString(raw json.RawMessage, name string) (string, error) {
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", fmt.Errorf("config %s must be a non-empty string", name)
+	}
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("config %s must be a non-empty string", name)
+	}
+	return value, nil
+}
+
+func decodePositiveInt(raw json.RawMessage, name string) (int, error) {
+	var value json.Number
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return 0, fmt.Errorf("config %s must be a positive integer", name)
+	}
+	parsed, err := strconv.ParseInt(value.String(), 10, 0)
+	if err != nil || parsed <= 0 {
+		return 0, fmt.Errorf("config %s must be a positive integer", name)
+	}
+	return int(parsed), nil
+}
+
+func decodePositiveFloat(raw json.RawMessage, name string) (float64, error) {
+	var value json.Number
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return 0, fmt.Errorf("config %s must be numeric", name)
+	}
+	parsed, err := strconv.ParseFloat(value.String(), 64)
+	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, fmt.Errorf("config %s must be numeric", name)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("config %s must be positive", name)
+	}
+	return parsed, nil
+}
+
+func decodeAllowedEgressChannels(raw json.RawMessage) ([]string, error) {
+	var values []string
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, errors.New("config allowed_egress_channels must be a list of strings")
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return nil, errors.New("allowed_egress_channel entries must not be empty")
+		}
+	}
+	if len(values) == 0 {
+		return Defaults().AllowedEgressChannels, nil
+	}
+	return values, nil
+}

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLoadAppliesDefaults(t *testing.T) {
+	config, err := Load([]byte(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := Defaults()
+	if !reflect.DeepEqual(config, expected) {
+		t.Fatalf("config = %#v, want %#v", config, expected)
+	}
+}
+
+func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
+	config, err := Load([]byte(`{
+		"bbmb_address": "10.0.0.1:9999",
+		"db_path": "/tmp/handler.db",
+		"max_loops": 20,
+		"poll_interval_seconds": 0.5,
+		"poll_timeout_seconds": 3,
+		"metrics_host": "0.0.0.0",
+		"metrics_port": 9555,
+		"allowed_egress_channels": ["log", "email"]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.BBMBAddress != "10.0.0.1:9999" {
+		t.Fatalf("BBMBAddress = %q", config.BBMBAddress)
+	}
+	if config.DBPath != "/tmp/handler.db" {
+		t.Fatalf("DBPath = %q", config.DBPath)
+	}
+	if config.MaxLoops != 20 {
+		t.Fatalf("MaxLoops = %d", config.MaxLoops)
+	}
+	if config.PollIntervalSeconds != 0.5 {
+		t.Fatalf("PollIntervalSeconds = %f", config.PollIntervalSeconds)
+	}
+	if config.PollTimeoutSeconds != 3 {
+		t.Fatalf("PollTimeoutSeconds = %d", config.PollTimeoutSeconds)
+	}
+	if config.MetricsHost != "0.0.0.0" {
+		t.Fatalf("MetricsHost = %q", config.MetricsHost)
+	}
+	if config.MetricsPort != 9555 {
+		t.Fatalf("MetricsPort = %d", config.MetricsPort)
+	}
+	if !reflect.DeepEqual(config.AllowedEgressChannels, []string{"log", "email"}) {
+		t.Fatalf("AllowedEgressChannels = %#v", config.AllowedEgressChannels)
+	}
+}
+
+func TestLoadRejectsUnknownKeys(t *testing.T) {
+	_, err := Load([]byte(`{"db_path": "/tmp/handler.db", "surprise": true}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "config contains unknown keys: surprise") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestLoadTreatsNullAsMissing(t *testing.T) {
+	config, err := Load([]byte(`{
+		"bbmb_address": null,
+		"db_path": null,
+		"allowed_egress_channels": null
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := Defaults()
+	if config.BBMBAddress != expected.BBMBAddress || config.DBPath != expected.DBPath {
+		t.Fatalf("config = %#v, want defaults %#v", config, expected)
+	}
+	if !reflect.DeepEqual(config.AllowedEgressChannels, expected.AllowedEgressChannels) {
+		t.Fatalf("AllowedEgressChannels = %#v", config.AllowedEgressChannels)
+	}
+}
+
+func TestLoadRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		message string
+	}{
+		{
+			name:    "blank string",
+			raw:     `{"db_path": "  "}`,
+			message: "config db_path must be a non-empty string",
+		},
+		{
+			name:    "wrong string type",
+			raw:     `{"bbmb_address": 12}`,
+			message: "config bbmb_address must be a non-empty string",
+		},
+		{
+			name:    "zero max loops",
+			raw:     `{"max_loops": 0}`,
+			message: "config max_loops must be a positive integer",
+		},
+		{
+			name:    "fractional timeout",
+			raw:     `{"poll_timeout_seconds": 1.2}`,
+			message: "config poll_timeout_seconds must be a positive integer",
+		},
+		{
+			name:    "negative interval",
+			raw:     `{"poll_interval_seconds": -0.5}`,
+			message: "config poll_interval_seconds must be positive",
+		},
+		{
+			name:    "bool interval",
+			raw:     `{"poll_interval_seconds": true}`,
+			message: "config poll_interval_seconds must be numeric",
+		},
+		{
+			name:    "bad allowed channels",
+			raw:     `{"allowed_egress_channels": ["log", ""]}`,
+			message: "allowed_egress_channel entries must not be empty",
+		},
+		{
+			name:    "non-string allowed channels",
+			raw:     `{"allowed_egress_channels": ["log", 5]}`,
+			message: "config allowed_egress_channels must be a list of strings",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Load([]byte(tt.raw))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.message) {
+				t.Fatalf("error = %v, want %q", err, tt.message)
+			}
+		})
+	}
+}
+
+func TestLoadFileAndEnvPath(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "handler.json")
+	if err := os.WriteFile(configPath, []byte(`{"db_path": "/tmp/from-file.db"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := LoadFromEnv("", map[string]string{MessageHandlerConfigPathEnvVar: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.DBPath != "/tmp/from-file.db" {
+		t.Fatalf("DBPath = %q", config.DBPath)
+	}
+
+	_, err = LoadFromEnv("", map[string]string{MessageHandlerConfigPathEnvVar: " "})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), MessageHandlerConfigPathEnvVar+" must not be empty") {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add `internal/config` for the minimal Go handler runtime settings
- validate unknown keys, blank strings, numeric/list types, and Python-compatible defaults
- wire `--config` and `CHATTING_MESSAGE_HANDLER_CONFIG_PATH` into the Go handler bootstrap
- mark the config loader slice complete in the porting plan

## Tests

- `cd go/handler && go test ./...`
- `uv run ruff check app tests`
