### PR TITLE
Add Go SQLite egress state

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -501,6 +501,12 @@ Validation:
 
 ### 6. SQLite Egress State
 
+Status: complete. `internal/state/sqlite` now creates Python-compatible
+`dispatched_event_ids`, `staged_egress_events`, and `egress_sequence_state`
+tables, supports event-id dispatch dedupe, stages sequenced egress payloads,
+fetches events by expected sequence, advances sequence state only when staged
+events are marked dispatched, and clears staged/sequence state on completion.
+
 Implement handler state for:
 - `dispatched_event_ids`
 - `staged_egress_events`

--- a/go/handler/internal/state/sqlite/sqlite.go
+++ b/go/handler/internal/state/sqlite/sqlite.go
@@ -34,6 +34,14 @@ type CompletedTaskRecord struct {
 	CompletedAt time.Time
 }
 
+type StagedEgressRecord struct {
+	TaskID        string
+	EventID       string
+	Sequence      int
+	EgressMessage contracts.EgressQueueMessage
+	CreatedAt     time.Time
+}
+
 func Open(ctx context.Context, dbPath string) (*Store, error) {
 	if strings.TrimSpace(dbPath) == "" {
 		return nil, errors.New("db_path is required")
@@ -80,6 +88,24 @@ func (store *Store) initialize(ctx context.Context) error {
 			envelope_id TEXT NOT NULL,
 			trace_id TEXT NOT NULL,
 			completed_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS dispatched_event_ids (
+			task_id TEXT NOT NULL,
+			event_id TEXT NOT NULL,
+			dispatched_at TEXT NOT NULL,
+			PRIMARY KEY (task_id, event_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS egress_sequence_state (
+			task_id TEXT PRIMARY KEY,
+			next_sequence INTEGER NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS staged_egress_events (
+			task_id TEXT NOT NULL,
+			event_id TEXT NOT NULL,
+			sequence INTEGER NOT NULL,
+			payload_json TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (task_id, event_id)
 		)`,
 	}
 	for _, statement := range statements {
@@ -241,6 +267,12 @@ func (store *Store) MarkTaskCompleted(ctx context.Context, taskID string, envelo
 	if _, err := tx.ExecContext(ctx, `DELETE FROM task_ledger WHERE task_id = ?`, taskID); err != nil {
 		return err
 	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM egress_sequence_state WHERE task_id = ?`, taskID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM staged_egress_events WHERE task_id = ?`, taskID); err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 
@@ -277,6 +309,193 @@ func (store *Store) IsTaskCompleted(ctx context.Context, taskID string, envelope
 		return false, err
 	}
 	return record.EnvelopeID == envelopeID, nil
+}
+
+func (store *Store) MarkDispatchedEventID(ctx context.Context, taskID string, eventID string) error {
+	if strings.TrimSpace(taskID) == "" {
+		return errors.New("task_id is required")
+	}
+	if strings.TrimSpace(eventID) == "" {
+		return errors.New("event_id is required")
+	}
+	_, err := store.db.ExecContext(
+		ctx,
+		`INSERT OR IGNORE INTO dispatched_event_ids (task_id, event_id, dispatched_at)
+		VALUES (?, ?, ?)`,
+		taskID,
+		eventID,
+		formatTimestamp(time.Now()),
+	)
+	return err
+}
+
+func (store *Store) HasDispatchedEventID(ctx context.Context, taskID string, eventID string) (bool, error) {
+	if strings.TrimSpace(taskID) == "" {
+		return false, errors.New("task_id is required")
+	}
+	if strings.TrimSpace(eventID) == "" {
+		return false, errors.New("event_id is required")
+	}
+	var found int
+	err := store.db.QueryRowContext(
+		ctx,
+		`SELECT 1 FROM dispatched_event_ids WHERE task_id = ? AND event_id = ?`,
+		taskID,
+		eventID,
+	).Scan(&found)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (store *Store) StageEgressEvent(ctx context.Context, egressMessage contracts.EgressQueueMessage) error {
+	if err := egressMessage.Validate(); err != nil {
+		return err
+	}
+	if egressMessage.Sequence == nil {
+		return errors.New("sequence is required")
+	}
+	payload, err := json.Marshal(egressMessage)
+	if err != nil {
+		return err
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollbackUnlessCommitted(tx)
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT OR IGNORE INTO staged_egress_events (
+			task_id,
+			event_id,
+			sequence,
+			payload_json,
+			created_at
+		)
+		VALUES (?, ?, ?, ?, ?)`,
+		egressMessage.TaskID,
+		egressMessage.EventID,
+		*egressMessage.Sequence,
+		string(payload),
+		formatTimestamp(time.Now()),
+	); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT OR IGNORE INTO egress_sequence_state (task_id, next_sequence)
+		VALUES (?, 0)`,
+		egressMessage.TaskID,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (store *Store) ExpectedSequence(ctx context.Context, taskID string) (int, error) {
+	if strings.TrimSpace(taskID) == "" {
+		return 0, errors.New("task_id is required")
+	}
+	var nextSequence int
+	err := store.db.QueryRowContext(
+		ctx,
+		`SELECT next_sequence FROM egress_sequence_state WHERE task_id = ?`,
+		taskID,
+	).Scan(&nextSequence)
+	if err == nil {
+		return nextSequence, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	return 0, err
+}
+
+func (store *Store) GetStagedEventBySequence(ctx context.Context, taskID string, sequence int) (*StagedEgressRecord, error) {
+	if strings.TrimSpace(taskID) == "" {
+		return nil, errors.New("task_id is required")
+	}
+	if sequence < 0 {
+		return nil, errors.New("sequence must be non-negative")
+	}
+	var payload string
+	var createdAt string
+	record := StagedEgressRecord{}
+	err := store.db.QueryRowContext(
+		ctx,
+		`SELECT task_id, event_id, sequence, payload_json, created_at
+		FROM staged_egress_events
+		WHERE task_id = ? AND sequence = ?`,
+		taskID,
+		sequence,
+	).Scan(&record.TaskID, &record.EventID, &record.Sequence, &payload, &createdAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	egressMessage, err := contracts.DecodeEgressQueueMessage([]byte(payload))
+	if err != nil {
+		return nil, err
+	}
+	parsedCreatedAt, err := parseTimestamp(createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse staged_egress_events.created_at: %w", err)
+	}
+	record.EgressMessage = egressMessage
+	record.CreatedAt = parsedCreatedAt
+	return &record, nil
+}
+
+func (store *Store) MarkStagedEventDispatched(ctx context.Context, taskID string, eventID string, sequence int) error {
+	if strings.TrimSpace(taskID) == "" {
+		return errors.New("task_id is required")
+	}
+	if strings.TrimSpace(eventID) == "" {
+		return errors.New("event_id is required")
+	}
+	if sequence < 0 {
+		return errors.New("sequence must be non-negative")
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollbackUnlessCommitted(tx)
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`DELETE FROM staged_egress_events
+		WHERE task_id = ? AND event_id = ? AND sequence = ?`,
+		taskID,
+		eventID,
+		sequence,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO egress_sequence_state (task_id, next_sequence)
+		VALUES (?, ?)
+		ON CONFLICT(task_id) DO UPDATE SET
+			next_sequence = CASE
+				WHEN egress_sequence_state.next_sequence <= excluded.next_sequence
+				THEN excluded.next_sequence
+				ELSE egress_sequence_state.next_sequence
+			END`,
+		taskID,
+		sequence+1,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func rollbackUnlessCommitted(tx *sql.Tx) {

--- a/go/handler/internal/state/sqlite/sqlite_test.go
+++ b/go/handler/internal/state/sqlite/sqlite_test.go
@@ -134,6 +134,132 @@ func TestRecordTaskClearsPreviousCompletion(t *testing.T) {
 	}
 }
 
+func TestDispatchedEventIDCheckpointRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	dispatched, err := store.HasDispatchedEventID(ctx, "task:email:1", "evt:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dispatched {
+		t.Fatal("new event id was already dispatched")
+	}
+	if err := store.MarkDispatchedEventID(ctx, "task:email:1", "evt:1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkDispatchedEventID(ctx, "task:email:1", "evt:1"); err != nil {
+		t.Fatal(err)
+	}
+
+	dispatched, err = store.HasDispatchedEventID(ctx, "task:email:1", "evt:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dispatched {
+		t.Fatal("event id was not marked dispatched")
+	}
+	otherTaskDispatched, err := store.HasDispatchedEventID(ctx, "task:email:other", "evt:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherTaskDispatched {
+		t.Fatal("event id checkpoint leaked across tasks")
+	}
+}
+
+func TestStagedEgressEventsAdvanceSequenceWhenMarkedDispatched(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	taskMessage := testTaskMessage(t)
+	second := testEgressMessage(t, taskMessage, 1, "evt:task:email:1:1", "second", "message")
+	first := testEgressMessage(t, taskMessage, 0, "evt:task:email:1:0", "first", "message")
+
+	if err := store.StageEgressEvent(ctx, second); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := store.ExpectedSequence(ctx, taskMessage.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected != 0 {
+		t.Fatalf("expected sequence after staging second = %d", expected)
+	}
+	stagedSecond, err := store.GetStagedEventBySequence(ctx, taskMessage.TaskID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stagedSecond == nil {
+		t.Fatal("second event was not staged")
+	}
+	if gotBody := derefString(stagedSecond.EgressMessage.Message.Body); gotBody != "second" {
+		t.Fatalf("staged second body = %q", gotBody)
+	}
+	if err := store.StageEgressEvent(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkStagedEventDispatched(ctx, first.TaskID, first.EventID, *first.Sequence); err != nil {
+		t.Fatal(err)
+	}
+
+	expected, err = store.ExpectedSequence(ctx, taskMessage.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected != 1 {
+		t.Fatalf("expected sequence after dispatching first = %d", expected)
+	}
+	stagedFirst, err := store.GetStagedEventBySequence(ctx, taskMessage.TaskID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stagedFirst != nil {
+		t.Fatalf("first event remained staged: %#v", stagedFirst)
+	}
+	if err := store.MarkStagedEventDispatched(ctx, second.TaskID, second.EventID, *second.Sequence); err != nil {
+		t.Fatal(err)
+	}
+	expected, err = store.ExpectedSequence(ctx, taskMessage.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected != 2 {
+		t.Fatalf("expected sequence after dispatching second = %d", expected)
+	}
+}
+
+func TestCompletionEventsCanBeStagedAndCompletionClearsEgressState(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	taskMessage := testTaskMessage(t)
+	completion := testEgressMessage(t, taskMessage, 0, "evt:task:email:1:completion", "done", "completion")
+
+	if err := store.RecordTask(ctx, taskMessage); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.StageEgressEvent(ctx, completion); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkTaskCompleted(ctx, taskMessage.TaskID, taskMessage.Envelope.ID, taskMessage.TraceID); err != nil {
+		t.Fatal(err)
+	}
+
+	staged, err := store.GetStagedEventBySequence(ctx, taskMessage.TaskID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if staged != nil {
+		t.Fatalf("completion did not clear staged event: %#v", staged)
+	}
+	expected, err := store.ExpectedSequence(ctx, taskMessage.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected != 0 {
+		t.Fatalf("completion did not clear sequence state, got %d", expected)
+	}
+}
+
 func openTestStore(t *testing.T) *Store {
 	t.Helper()
 	return openStoreAt(t, filepath.Join(t.TempDir(), "state.db"))
@@ -180,6 +306,40 @@ func testTaskMessage(t *testing.T) contracts.TaskQueueMessage {
 		},
 		DedupeKey: "email:1",
 	}, "trace:email:1", mustTime(t, "2026-03-06T11:00:01Z"))
+}
+
+func testEgressMessage(
+	t *testing.T,
+	taskMessage contracts.TaskQueueMessage,
+	sequence int,
+	eventID string,
+	body string,
+	eventKind string,
+) contracts.EgressQueueMessage {
+	t.Helper()
+	return contracts.EgressQueueMessage{
+		SchemaVersion: contracts.SchemaVersion,
+		MessageType:   contracts.EgressMessageTypeV2,
+		TaskID:        taskMessage.TaskID,
+		EnvelopeID:    taskMessage.Envelope.ID,
+		TraceID:       taskMessage.TraceID,
+		EventID:       eventID,
+		EventKind:     eventKind,
+		EmittedAt:     contracts.NewTimestamp(mustTime(t, "2026-03-06T12:00:00Z")),
+		Message: contracts.OutboundMessage{
+			Channel: "email",
+			Target:  "alice@example.com",
+			Body:    &body,
+		},
+		Sequence: &sequence,
+	}
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 func assertTaskLedgerSchemaAndPayload(t *testing.T, dbPath string, taskMessage contracts.TaskQueueMessage) {


### PR DESCRIPTION
## Summary
- add Go SQLite tables and methods for dispatched egress event-id dedupe
- add sequenced egress staging/fetch/dispatch advancement state
- clear staged egress and sequence state when tasks are completed
- update the Go handler port plan to mark SQLite egress state complete

## Validation
- cd go/handler && go test ./...
- gofmt -l go/handler
- uv run ruff check app tests
