### PR TITLE
Add Go egress engine

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -520,6 +520,13 @@ Validation:
 
 ### 7. Go Egress Engine
 
+Status: complete. `internal/egress` now decodes and validates
+`chatting.egress.v2` payloads, rejects unknown/completed/disallowed egress,
+dedupes dispatched event IDs, dispatches unsequenced incremental events, stages
+sequenced events, flushes them in order, and applies sequenced completion events.
+Tests cover the decision branches with fake state/dispatchers and exercise
+ordered staging plus replay dedupe against SQLite-backed state.
+
 Implement `internal/egress` with a fake dispatcher:
 - parse `chatting.egress.v2`
 - reject invalid payloads
@@ -676,6 +683,6 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add SQLite egress staging and dispatch state.
-2. Build the Go egress engine before tackling the more complex connectors.
-3. Wire the runtime skeleton once egress state and core egress behavior exist.
+1. Wire the handler runtime skeleton around config, BBMB, SQLite state, and the egress loop.
+2. Add the internal heartbeat connector and heartbeat egress recognition.
+3. Add auxiliary ingress queue consumption for the first Go-handler/Python-worker E2E path.

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -1,0 +1,233 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+type TaskRecord struct {
+	TaskID      string
+	EnvelopeID  string
+	TraceID     string
+	TaskMessage contracts.TaskQueueMessage
+}
+
+type StagedRecord struct {
+	TaskID        string
+	EventID       string
+	Sequence      int
+	EgressMessage contracts.EgressQueueMessage
+}
+
+type State interface {
+	GetTask(ctx context.Context, taskID string) (*TaskRecord, error)
+	IsTaskCompleted(ctx context.Context, taskID string, envelopeID string) (bool, error)
+	MarkTaskCompleted(ctx context.Context, taskID string, envelopeID string, traceID string) error
+	HasDispatchedEventID(ctx context.Context, taskID string, eventID string) (bool, error)
+	MarkDispatchedEventID(ctx context.Context, taskID string, eventID string) error
+	StageEgressEvent(ctx context.Context, message contracts.EgressQueueMessage) error
+	ExpectedSequence(ctx context.Context, taskID string) (int, error)
+	GetStagedEventBySequence(ctx context.Context, taskID string, sequence int) (*StagedRecord, error)
+	MarkStagedEventDispatched(ctx context.Context, taskID string, eventID string, sequence int) error
+}
+
+type Dispatcher interface {
+	Dispatch(ctx context.Context, message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (*contracts.OutboundMessage, error)
+}
+
+type DispatcherFunc func(ctx context.Context, message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (*contracts.OutboundMessage, error)
+
+func (fn DispatcherFunc) Dispatch(ctx context.Context, message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (*contracts.OutboundMessage, error) {
+	return fn(ctx, message, envelope)
+}
+
+type Engine struct {
+	state           State
+	dispatcher      Dispatcher
+	allowedChannels map[string]bool
+}
+
+type Option func(*Engine)
+
+func WithAllowedChannels(channels []string) Option {
+	return func(engine *Engine) {
+		engine.allowedChannels = make(map[string]bool, len(channels))
+		for _, channel := range channels {
+			engine.allowedChannels[channel] = true
+		}
+	}
+}
+
+func New(state State, dispatcher Dispatcher, options ...Option) (*Engine, error) {
+	if state == nil {
+		return nil, errors.New("state is required")
+	}
+	if dispatcher == nil {
+		return nil, errors.New("dispatcher is required")
+	}
+	engine := &Engine{
+		state:           state,
+		dispatcher:      dispatcher,
+		allowedChannels: map[string]bool{},
+	}
+	for _, option := range options {
+		option(engine)
+	}
+	return engine, nil
+}
+
+type Result struct {
+	Status string
+	Reason string
+}
+
+const (
+	StatusDispatched = "dispatched"
+	StatusStaged     = "staged"
+	StatusCompleted  = "completed"
+	StatusDropped    = "dropped"
+	StatusDeduped    = "deduped"
+)
+
+func (engine *Engine) HandleRaw(ctx context.Context, raw []byte) (Result, error) {
+	message, err := contracts.DecodeEgressQueueMessage(raw)
+	if err != nil {
+		return Result{Status: StatusDropped, Reason: "invalid_payload"}, nil
+	}
+	return engine.Handle(ctx, message)
+}
+
+func (engine *Engine) Handle(ctx context.Context, message contracts.EgressQueueMessage) (Result, error) {
+	if err := message.Validate(); err != nil {
+		return Result{Status: StatusDropped, Reason: "invalid_payload"}, nil
+	}
+
+	completed, err := engine.state.IsTaskCompleted(ctx, message.TaskID, message.EnvelopeID)
+	if err != nil {
+		return Result{}, err
+	}
+	if completed {
+		return Result{Status: StatusDropped, Reason: "completed_task"}, nil
+	}
+
+	task, err := engine.state.GetTask(ctx, message.TaskID)
+	if err != nil {
+		return Result{}, err
+	}
+	if task == nil || task.EnvelopeID != message.EnvelopeID {
+		return Result{Status: StatusDropped, Reason: "unknown_task"}, nil
+	}
+
+	if !engine.channelAllowed(message) {
+		return Result{Status: StatusDropped, Reason: "disallowed_channel"}, nil
+	}
+
+	dispatched, err := engine.state.HasDispatchedEventID(ctx, message.TaskID, message.EventID)
+	if err != nil {
+		return Result{}, err
+	}
+	if dispatched {
+		return Result{Status: StatusDeduped}, nil
+	}
+
+	if message.Sequence == nil {
+		if message.EventKind == "completion" {
+			return Result{Status: StatusDropped, Reason: "invalid_payload"}, nil
+		}
+		if err := engine.dispatchAndMark(ctx, task, message); err != nil {
+			return Result{}, err
+		}
+		return Result{Status: StatusDispatched}, nil
+	}
+
+	if err := engine.state.StageEgressEvent(ctx, message); err != nil {
+		return Result{}, err
+	}
+	result, err := engine.Flush(ctx, message.TaskID)
+	if err != nil {
+		return Result{}, err
+	}
+	if result.Status == "" {
+		return Result{Status: StatusStaged}, nil
+	}
+	return result, nil
+}
+
+func (engine *Engine) Flush(ctx context.Context, taskID string) (Result, error) {
+	task, err := engine.state.GetTask(ctx, taskID)
+	if err != nil {
+		return Result{}, err
+	}
+	if task == nil {
+		return Result{}, nil
+	}
+
+	var last Result
+	for {
+		expected, err := engine.state.ExpectedSequence(ctx, taskID)
+		if err != nil {
+			return Result{}, err
+		}
+		staged, err := engine.state.GetStagedEventBySequence(ctx, taskID, expected)
+		if err != nil {
+			return Result{}, err
+		}
+		if staged == nil {
+			return last, nil
+		}
+
+		dispatched, err := engine.state.HasDispatchedEventID(ctx, taskID, staged.EventID)
+		if err != nil {
+			return Result{}, err
+		}
+		if dispatched {
+			if err := engine.state.MarkStagedEventDispatched(ctx, taskID, staged.EventID, staged.Sequence); err != nil {
+				return Result{}, err
+			}
+			last = Result{Status: StatusDeduped}
+			continue
+		}
+
+		message := staged.EgressMessage
+		if message.EventKind == "completion" {
+			if err := engine.state.MarkStagedEventDispatched(ctx, taskID, staged.EventID, staged.Sequence); err != nil {
+				return Result{}, err
+			}
+			if err := engine.state.MarkDispatchedEventID(ctx, taskID, staged.EventID); err != nil {
+				return Result{}, err
+			}
+			if err := engine.state.MarkTaskCompleted(ctx, message.TaskID, message.EnvelopeID, message.TraceID); err != nil {
+				return Result{}, err
+			}
+			return Result{Status: StatusCompleted}, nil
+		}
+
+		if !engine.channelAllowed(message) {
+			return Result{}, fmt.Errorf("staged event %s has disallowed channel %q", staged.EventID, message.Message.Channel)
+		}
+		if err := engine.dispatchAndMark(ctx, task, message); err != nil {
+			return Result{}, err
+		}
+		if err := engine.state.MarkStagedEventDispatched(ctx, taskID, staged.EventID, staged.Sequence); err != nil {
+			return Result{}, err
+		}
+		last = Result{Status: StatusDispatched}
+	}
+}
+
+func (engine *Engine) dispatchAndMark(ctx context.Context, task *TaskRecord, message contracts.EgressQueueMessage) error {
+	if _, err := engine.dispatcher.Dispatch(ctx, message.Message, task.TaskMessage.Envelope); err != nil {
+		return err
+	}
+	return engine.state.MarkDispatchedEventID(ctx, message.TaskID, message.EventID)
+}
+
+func (engine *Engine) channelAllowed(message contracts.EgressQueueMessage) bool {
+	if message.EventKind == "completion" {
+		return true
+	}
+	return engine.allowedChannels[message.Message.Channel]
+}

--- a/go/handler/internal/egress/egress_test.go
+++ b/go/handler/internal/egress/egress_test.go
@@ -1,0 +1,418 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
+)
+
+func TestHandleRawDropsInvalidPayload(t *testing.T) {
+	engine := newTestEngine(t, newFakeState(), nil)
+
+	result, err := engine.HandleRaw(context.Background(), []byte(`{"message_type":"chatting.egress.v1"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDropped || result.Reason != "invalid_payload" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestHandleDropsUnknownTask(t *testing.T) {
+	engine := newTestEngine(t, newFakeState(), nil)
+
+	result, err := engine.Handle(context.Background(), testEgressMessage(t, testTaskMessage(t), nil, "evt:1", "incremental"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDropped || result.Reason != "unknown_task" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestHandleDropsCompletedTask(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.completed[task.TaskID] = task.Envelope.ID
+	engine := newTestEngine(t, state, nil)
+
+	result, err := engine.Handle(context.Background(), testEgressMessage(t, task, nil, "evt:1", "incremental"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDropped || result.Reason != "completed_task" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestHandleDropsDisallowedChannel(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	engine := newTestEngine(t, state, nil)
+	message := testEgressMessage(t, task, nil, "evt:1", "incremental")
+	message.Message.Channel = "telegram"
+
+	result, err := engine.Handle(context.Background(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDropped || result.Reason != "disallowed_channel" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestHandleDispatchesUnsequencedIncrementalAndDedupesReplay(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngine(t, state, dispatcher)
+	message := testEgressMessage(t, task, nil, "evt:incremental:1", "incremental")
+
+	result, err := engine.Handle(context.Background(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDispatched {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(dispatcher.messages) != 1 {
+		t.Fatalf("dispatch count = %d", len(dispatcher.messages))
+	}
+
+	result, err = engine.Handle(context.Background(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDeduped {
+		t.Fatalf("replay result = %#v", result)
+	}
+	if len(dispatcher.messages) != 1 {
+		t.Fatalf("replay dispatch count = %d", len(dispatcher.messages))
+	}
+}
+
+func TestHandleStagesAndFlushesSequencedEventsInOrder(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngine(t, state, dispatcher)
+	second := testEgressMessage(t, task, intPtr(1), "evt:1", "message")
+	second.Message.Body = stringPtr("second")
+	first := testEgressMessage(t, task, intPtr(0), "evt:0", "message")
+	first.Message.Body = stringPtr("first")
+
+	result, err := engine.Handle(context.Background(), second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusStaged {
+		t.Fatalf("out-of-order result = %#v", result)
+	}
+	if len(dispatcher.messages) != 0 {
+		t.Fatalf("out-of-order dispatch count = %d", len(dispatcher.messages))
+	}
+
+	result, err = engine.Handle(context.Background(), first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDispatched {
+		t.Fatalf("flush result = %#v", result)
+	}
+	if got := dispatcher.bodies(); got != "first|second" {
+		t.Fatalf("dispatch order = %q", got)
+	}
+}
+
+func TestHandleAppliesCompletionAfterEarlierSequencedMessages(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngine(t, state, dispatcher)
+	first := testEgressMessage(t, task, intPtr(0), "evt:0", "message")
+	completion := testEgressMessage(t, task, intPtr(1), "evt:completion", "completion")
+
+	result, err := engine.Handle(context.Background(), completion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusStaged {
+		t.Fatalf("completion staged result = %#v", result)
+	}
+	result, err = engine.Handle(context.Background(), first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusCompleted {
+		t.Fatalf("completion flush result = %#v", result)
+	}
+	if len(dispatcher.messages) != 1 {
+		t.Fatalf("dispatch count = %d", len(dispatcher.messages))
+	}
+	if state.completed[task.TaskID] != task.Envelope.ID {
+		t.Fatalf("completed envelope = %q", state.completed[task.TaskID])
+	}
+}
+
+func TestHandleReturnsDispatchErrorWithoutMarkingEvent(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	engine := newTestEngine(t, state, &recordingDispatcher{err: errors.New("send failed")})
+
+	_, err := engine.Handle(context.Background(), testEgressMessage(t, task, nil, "evt:incremental:1", "incremental"))
+	if err == nil {
+		t.Fatal("expected dispatch error")
+	}
+	if state.dispatched[task.TaskID]["evt:incremental:1"] {
+		t.Fatal("failed dispatch was marked dispatched")
+	}
+}
+
+func TestSQLiteBackedEnginePersistsStagingAndDedupe(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlitestate.Open(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	task := testTaskMessage(t)
+	if err := store.RecordTask(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngineWithState(t, NewSQLiteState(store), dispatcher)
+	second := testEgressMessage(t, task, intPtr(1), "evt:1", "message")
+	second.Message.Body = stringPtr("second")
+	first := testEgressMessage(t, task, intPtr(0), "evt:0", "message")
+	first.Message.Body = stringPtr("first")
+
+	result, err := engine.Handle(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusStaged {
+		t.Fatalf("out-of-order result = %#v", result)
+	}
+	result, err = engine.Handle(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDispatched {
+		t.Fatalf("flush result = %#v", result)
+	}
+	if got := dispatcher.bodies(); got != "first|second" {
+		t.Fatalf("dispatch order = %q", got)
+	}
+
+	replayResult, err := engine.Handle(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayResult.Status != StatusDeduped {
+		t.Fatalf("replay result = %#v", replayResult)
+	}
+	if got := dispatcher.bodies(); got != "first|second" {
+		t.Fatalf("replay dispatch order = %q", got)
+	}
+}
+
+type fakeState struct {
+	tasks      map[string]TaskRecord
+	completed  map[string]string
+	dispatched map[string]map[string]bool
+	staged     map[string]map[int]StagedRecord
+	expected   map[string]int
+}
+
+func newFakeState() *fakeState {
+	return &fakeState{
+		tasks:      map[string]TaskRecord{},
+		completed:  map[string]string{},
+		dispatched: map[string]map[string]bool{},
+		staged:     map[string]map[int]StagedRecord{},
+		expected:   map[string]int{},
+	}
+}
+
+func (state *fakeState) addTask(task contracts.TaskQueueMessage) {
+	state.tasks[task.TaskID] = TaskRecord{
+		TaskID:      task.TaskID,
+		EnvelopeID:  task.Envelope.ID,
+		TraceID:     task.TraceID,
+		TaskMessage: task,
+	}
+}
+
+func (state *fakeState) GetTask(_ context.Context, taskID string) (*TaskRecord, error) {
+	record, ok := state.tasks[taskID]
+	if !ok {
+		return nil, nil
+	}
+	return &record, nil
+}
+
+func (state *fakeState) IsTaskCompleted(_ context.Context, taskID string, envelopeID string) (bool, error) {
+	return state.completed[taskID] == envelopeID, nil
+}
+
+func (state *fakeState) MarkTaskCompleted(_ context.Context, taskID string, envelopeID string, _ string) error {
+	state.completed[taskID] = envelopeID
+	delete(state.tasks, taskID)
+	delete(state.staged, taskID)
+	delete(state.expected, taskID)
+	return nil
+}
+
+func (state *fakeState) HasDispatchedEventID(_ context.Context, taskID string, eventID string) (bool, error) {
+	return state.dispatched[taskID][eventID], nil
+}
+
+func (state *fakeState) MarkDispatchedEventID(_ context.Context, taskID string, eventID string) error {
+	if state.dispatched[taskID] == nil {
+		state.dispatched[taskID] = map[string]bool{}
+	}
+	state.dispatched[taskID][eventID] = true
+	return nil
+}
+
+func (state *fakeState) StageEgressEvent(_ context.Context, message contracts.EgressQueueMessage) error {
+	if state.staged[message.TaskID] == nil {
+		state.staged[message.TaskID] = map[int]StagedRecord{}
+	}
+	state.staged[message.TaskID][*message.Sequence] = StagedRecord{
+		TaskID:        message.TaskID,
+		EventID:       message.EventID,
+		Sequence:      *message.Sequence,
+		EgressMessage: message,
+	}
+	return nil
+}
+
+func (state *fakeState) ExpectedSequence(_ context.Context, taskID string) (int, error) {
+	return state.expected[taskID], nil
+}
+
+func (state *fakeState) GetStagedEventBySequence(_ context.Context, taskID string, sequence int) (*StagedRecord, error) {
+	record, ok := state.staged[taskID][sequence]
+	if !ok {
+		return nil, nil
+	}
+	return &record, nil
+}
+
+func (state *fakeState) MarkStagedEventDispatched(_ context.Context, taskID string, _ string, sequence int) error {
+	delete(state.staged[taskID], sequence)
+	if state.expected[taskID] <= sequence {
+		state.expected[taskID] = sequence + 1
+	}
+	return nil
+}
+
+type recordingDispatcher struct {
+	messages []contracts.OutboundMessage
+	err      error
+}
+
+func (dispatcher *recordingDispatcher) Dispatch(_ context.Context, message contracts.OutboundMessage, _ contracts.TaskEnvelope) (*contracts.OutboundMessage, error) {
+	if dispatcher.err != nil {
+		return nil, dispatcher.err
+	}
+	dispatcher.messages = append(dispatcher.messages, message)
+	return &message, nil
+}
+
+func (dispatcher *recordingDispatcher) bodies() string {
+	result := ""
+	for index, message := range dispatcher.messages {
+		if index > 0 {
+			result += "|"
+		}
+		if message.Body != nil {
+			result += *message.Body
+		}
+	}
+	return result
+}
+
+func newTestEngine(t *testing.T, state *fakeState, dispatcher *recordingDispatcher) *Engine {
+	t.Helper()
+	if dispatcher == nil {
+		dispatcher = &recordingDispatcher{}
+	}
+	return newTestEngineWithState(t, state, dispatcher)
+}
+
+func newTestEngineWithState(t *testing.T, state State, dispatcher *recordingDispatcher) *Engine {
+	t.Helper()
+	engine, err := New(state, dispatcher, WithAllowedChannels([]string{"email"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return engine
+}
+
+func testTaskMessage(t *testing.T) contracts.TaskQueueMessage {
+	t.Helper()
+	actor := "alice@example.com"
+	return contracts.NewTaskQueueMessage(contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            "email:1",
+		Source:        "email",
+		ReceivedAt:    contracts.NewTimestamp(mustTime(t, "2026-03-06T11:00:00Z")),
+		Actor:         &actor,
+		Content:       "hello from egress tests",
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   "email",
+			Target: "alice@example.com",
+		},
+		DedupeKey: "email:1",
+	}, "trace:email:1", mustTime(t, "2026-03-06T11:00:01Z"))
+}
+
+func testEgressMessage(t *testing.T, task contracts.TaskQueueMessage, sequence *int, eventID string, eventKind string) contracts.EgressQueueMessage {
+	t.Helper()
+	body := "hello"
+	return contracts.EgressQueueMessage{
+		SchemaVersion: contracts.SchemaVersion,
+		MessageType:   contracts.EgressMessageTypeV2,
+		TaskID:        task.TaskID,
+		EnvelopeID:    task.Envelope.ID,
+		TraceID:       task.TraceID,
+		EventID:       eventID,
+		EventKind:     eventKind,
+		EmittedAt:     contracts.NewTimestamp(mustTime(t, "2026-03-06T12:00:00Z")),
+		Message: contracts.OutboundMessage{
+			Channel: "email",
+			Target:  "alice@example.com",
+			Body:    &body,
+		},
+		Sequence: sequence,
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func mustTime(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/go/handler/internal/egress/sqlite_state.go
+++ b/go/handler/internal/egress/sqlite_state.go
@@ -1,0 +1,70 @@
+package egress
+
+import (
+	"context"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
+)
+
+type SQLiteState struct {
+	store *sqlitestate.Store
+}
+
+func NewSQLiteState(store *sqlitestate.Store) *SQLiteState {
+	return &SQLiteState{store: store}
+}
+
+func (state *SQLiteState) GetTask(ctx context.Context, taskID string) (*TaskRecord, error) {
+	record, err := state.store.GetTask(ctx, taskID)
+	if err != nil || record == nil {
+		return nil, err
+	}
+	return &TaskRecord{
+		TaskID:      record.TaskID,
+		EnvelopeID:  record.EnvelopeID,
+		TraceID:     record.TraceID,
+		TaskMessage: record.TaskMessage,
+	}, nil
+}
+
+func (state *SQLiteState) IsTaskCompleted(ctx context.Context, taskID string, envelopeID string) (bool, error) {
+	return state.store.IsTaskCompleted(ctx, taskID, envelopeID)
+}
+
+func (state *SQLiteState) MarkTaskCompleted(ctx context.Context, taskID string, envelopeID string, traceID string) error {
+	return state.store.MarkTaskCompleted(ctx, taskID, envelopeID, traceID)
+}
+
+func (state *SQLiteState) HasDispatchedEventID(ctx context.Context, taskID string, eventID string) (bool, error) {
+	return state.store.HasDispatchedEventID(ctx, taskID, eventID)
+}
+
+func (state *SQLiteState) MarkDispatchedEventID(ctx context.Context, taskID string, eventID string) error {
+	return state.store.MarkDispatchedEventID(ctx, taskID, eventID)
+}
+
+func (state *SQLiteState) StageEgressEvent(ctx context.Context, message contracts.EgressQueueMessage) error {
+	return state.store.StageEgressEvent(ctx, message)
+}
+
+func (state *SQLiteState) ExpectedSequence(ctx context.Context, taskID string) (int, error) {
+	return state.store.ExpectedSequence(ctx, taskID)
+}
+
+func (state *SQLiteState) GetStagedEventBySequence(ctx context.Context, taskID string, sequence int) (*StagedRecord, error) {
+	record, err := state.store.GetStagedEventBySequence(ctx, taskID, sequence)
+	if err != nil || record == nil {
+		return nil, err
+	}
+	return &StagedRecord{
+		TaskID:        record.TaskID,
+		EventID:       record.EventID,
+		Sequence:      record.Sequence,
+		EgressMessage: record.EgressMessage,
+	}, nil
+}
+
+func (state *SQLiteState) MarkStagedEventDispatched(ctx context.Context, taskID string, eventID string, sequence int) error {
+	return state.store.MarkStagedEventDispatched(ctx, taskID, eventID, sequence)
+}


### PR DESCRIPTION
## Summary

- add `internal/egress` for Go handler egress validation, event-id dedupe, dispatch, staging, ordered flush, and completion
- add a SQLite state adapter for the egress engine
- mark the Go egress engine slice complete in `docs/porting/handler-go.md` and move immediate next steps to the runtime skeleton

## Validation

- `cd go/handler && go test ./...`
- `uv run ruff check app tests`
