### PR TITLE
Add Go handler runtime skeleton

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -544,6 +544,12 @@ Validation:
 
 ### 8. Handler Runtime Skeleton
 
+Status: complete. The Go handler command now wires config, BBMB, SQLite state,
+the strict egress engine, queue setup, bounded loop execution, cancellation, and
+egress pickup/ack draining. Real outbound dispatch remains deliberately
+unimplemented until the dispatch-specific PRs, so this slice starts and drains
+runtime plumbing without claiming connector or side-effect parity.
+
 Wire:
 - config loader
 - BBMB client
@@ -683,6 +689,6 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Wire the handler runtime skeleton around config, BBMB, SQLite state, and the egress loop.
-2. Add the internal heartbeat connector and heartbeat egress recognition.
-3. Add auxiliary ingress queue consumption for the first Go-handler/Python-worker E2E path.
+1. Add the internal heartbeat connector and heartbeat egress recognition.
+2. Add auxiliary ingress queue consumption for the first Go-handler/Python-worker E2E path.
+3. Add interval schedule connector support.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -1,22 +1,43 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/egress"
+	handlerruntime "github.com/EdwardSalkeld/chatting/go/handler/internal/runtime"
+	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
 )
 
 const version = "go-handler-bootstrap"
 
+type runner interface {
+	Run(ctx context.Context) error
+}
+
+type runnerFactory func(ctx context.Context, config handlerconfig.Config) (runner, error)
+
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, currentEnv()))
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	os.Exit(runWithFactory(ctx, os.Args[1:], os.Stdout, os.Stderr, currentEnv(), newRuntimeRunner))
 }
 
 func run(args []string, stdout io.Writer, stderr io.Writer, environ map[string]string) int {
+	return runWithFactory(context.Background(), args, stdout, stderr, environ, newRuntimeRunner)
+}
+
+func runWithFactory(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, environ map[string]string, newRunner runnerFactory) int {
 	flags := flag.NewFlagSet("chatting-handler", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	showVersion := flags.Bool("version", false, "print version and exit")
@@ -35,10 +56,17 @@ func run(args []string, stdout io.Writer, stderr io.Writer, environ map[string]s
 		fmt.Fprintf(stderr, "config error: %v\n", err)
 		return 2
 	}
-	_ = config
 
-	fmt.Fprintln(stderr, "chatting Go handler bootstrap: runtime not implemented yet")
-	return 2
+	runner, err := newRunner(ctx, config)
+	if err != nil {
+		fmt.Fprintf(stderr, "runtime setup error: %v\n", err)
+		return 2
+	}
+	if err := runner.Run(ctx); err != nil {
+		fmt.Fprintf(stderr, "runtime error: %v\n", err)
+		return 1
+	}
+	return 0
 }
 
 func currentEnv() map[string]string {
@@ -50,4 +78,59 @@ func currentEnv() map[string]string {
 		}
 	}
 	return result
+}
+
+func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner, error) {
+	adapter, err := bbmb.NewAdapter(config.BBMBAddress)
+	if err != nil {
+		return nil, err
+	}
+	store, err := sqlitestate.Open(ctx, config.DBPath)
+	if err != nil {
+		return nil, err
+	}
+	engine, err := egress.New(
+		egress.NewSQLiteState(store),
+		unsupportedDispatcher{},
+		egress.WithAllowedChannels(config.AllowedEgressChannels),
+	)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+	runner, err := handlerruntime.NewRunner(config, adapter, egressHandlerFunc(func(ctx context.Context, raw []byte) error {
+		_, err := engine.HandleRaw(ctx, raw)
+		return err
+	}))
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+	return &closingRunner{runner: runner, closer: store}, nil
+}
+
+type egressHandlerFunc func(context.Context, []byte) error
+
+func (fn egressHandlerFunc) HandleRaw(ctx context.Context, raw []byte) error {
+	return fn(ctx, raw)
+}
+
+type unsupportedDispatcher struct{}
+
+func (unsupportedDispatcher) Dispatch(ctx context.Context, message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (*contracts.OutboundMessage, error) {
+	return nil, errors.New("dispatch is not implemented in the Go handler yet")
+}
+
+type closer interface {
+	Close() error
+}
+
+type closingRunner struct {
+	runner runner
+	closer closer
+}
+
+func (runner *closingRunner) Run(ctx context.Context) error {
+	defer runner.closer.Close()
+	return runner.runner.Run(ctx)
 }

--- a/go/handler/cmd/chatting-handler/main_test.go
+++ b/go/handler/cmd/chatting-handler/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,22 +32,26 @@ func TestRunPrintsVersion(t *testing.T) {
 func TestRunParsesConfigFlagBeforeBootstrapExit(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "handler.json")
-	if err := os.WriteFile(configPath, []byte(`{"db_path": "/tmp/handler.db"}`), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte(`{"db_path": "/tmp/handler.db", "max_loops": 1}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	factory := &fakeRunnerFactory{}
 
-	status := run([]string{"--config", configPath}, &stdout, &stderr, nil)
+	status := runWithFactory(context.Background(), []string{"--config", configPath}, &stdout, &stderr, nil, factory.newRunner)
 
-	if status != 2 {
+	if status != 0 {
 		t.Fatalf("status = %d", status)
 	}
-	if !strings.Contains(stderr.String(), "runtime not implemented yet") {
+	if stderr.String() != "" {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
-	if strings.Contains(stderr.String(), "config error") {
-		t.Fatalf("stderr = %q", stderr.String())
+	if !factory.called {
+		t.Fatal("runner factory was not called")
+	}
+	if factory.config.DBPath != "/tmp/handler.db" {
+		t.Fatalf("db path = %q", factory.config.DBPath)
 	}
 }
 
@@ -74,23 +80,83 @@ func TestRunRejectsInvalidConfig(t *testing.T) {
 func TestRunUsesConfigPathFromEnvironment(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "handler.json")
-	if err := os.WriteFile(configPath, []byte(`{"db_path": "/tmp/handler.db"}`), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte(`{"db_path": "/tmp/handler.db", "max_loops": 1}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	factory := &fakeRunnerFactory{}
 
-	status := run(
+	status := runWithFactory(
+		context.Background(),
 		nil,
 		&stdout,
 		&stderr,
 		map[string]string{handlerconfig.MessageHandlerConfigPathEnvVar: configPath},
+		factory.newRunner,
 	)
+
+	if status != 0 {
+		t.Fatalf("status = %d", status)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunReportsRuntimeSetupError(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	factory := &fakeRunnerFactory{err: errors.New("boom")}
+
+	status := runWithFactory(context.Background(), nil, &stdout, &stderr, nil, factory.newRunner)
 
 	if status != 2 {
 		t.Fatalf("status = %d", status)
 	}
-	if !strings.Contains(stderr.String(), "runtime not implemented yet") {
+	if !strings.Contains(stderr.String(), "runtime setup error: boom") {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
+}
+
+func TestRunReportsRuntimeError(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	factory := &fakeRunnerFactory{runner: &fakeRunner{err: errors.New("failed")}}
+
+	status := runWithFactory(context.Background(), nil, &stdout, &stderr, nil, factory.newRunner)
+
+	if status != 1 {
+		t.Fatalf("status = %d", status)
+	}
+	if !strings.Contains(stderr.String(), "runtime error: failed") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+type fakeRunnerFactory struct {
+	called bool
+	config handlerconfig.Config
+	runner runner
+	err    error
+}
+
+func (factory *fakeRunnerFactory) newRunner(ctx context.Context, config handlerconfig.Config) (runner, error) {
+	factory.called = true
+	factory.config = config
+	if factory.err != nil {
+		return nil, factory.err
+	}
+	if factory.runner != nil {
+		return factory.runner, nil
+	}
+	return &fakeRunner{}, nil
+}
+
+type fakeRunner struct {
+	err error
+}
+
+func (runner *fakeRunner) Run(ctx context.Context) error {
+	return runner.err
 }

--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -1,0 +1,126 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
+	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+)
+
+const (
+	TaskQueueName           = "chatting.tasks.v1"
+	EgressQueueName         = "chatting.egress.v1"
+	egressPickupWaitSeconds = 5
+	egressDrainWaitSeconds  = 0
+)
+
+type Broker interface {
+	EnsureQueue(ctx context.Context, queueName string) error
+	PickupJSON(ctx context.Context, queueName string, timeoutSeconds int, waitSeconds int) (*bbmb.PickedMessage, error)
+	Ack(ctx context.Context, queueName string, guid string) error
+}
+
+type EgressHandler interface {
+	HandleRaw(ctx context.Context, raw []byte) error
+}
+
+type Runner struct {
+	config handlerconfig.Config
+	broker Broker
+	egress EgressHandler
+	sleep  func(context.Context, time.Duration) error
+}
+
+func NewRunner(config handlerconfig.Config, broker Broker, egress EgressHandler) (*Runner, error) {
+	if broker == nil {
+		return nil, errors.New("broker is required")
+	}
+	if egress == nil {
+		return nil, errors.New("egress handler is required")
+	}
+	return &Runner{
+		config: config,
+		broker: broker,
+		egress: egress,
+		sleep:  sleep,
+	}, nil
+}
+
+func (runner *Runner) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := runner.broker.EnsureQueue(ctx, TaskQueueName); err != nil {
+		return err
+	}
+	if err := runner.broker.EnsureQueue(ctx, EgressQueueName); err != nil {
+		return err
+	}
+
+	loopCount := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		loopCount++
+		if _, err := runner.DrainEgress(ctx); err != nil {
+			return err
+		}
+		if runner.config.MaxLoops > 0 && loopCount >= runner.config.MaxLoops {
+			return nil
+		}
+		if err := runner.sleep(ctx, durationFromSeconds(runner.config.PollIntervalSeconds)); err != nil {
+			return nil
+		}
+	}
+}
+
+func (runner *Runner) DrainEgress(ctx context.Context) (int, error) {
+	drained := 0
+	waitSeconds := egressPickupWaitSeconds
+	for {
+		picked, err := runner.broker.PickupJSON(
+			ctx,
+			EgressQueueName,
+			runner.config.PollTimeoutSeconds,
+			waitSeconds,
+		)
+		if err != nil {
+			return drained, err
+		}
+		if picked == nil {
+			return drained, nil
+		}
+		raw, err := json.Marshal(picked.Payload)
+		if err != nil {
+			return drained, fmt.Errorf("marshal egress payload guid=%s: %w", picked.GUID, err)
+		}
+		if err := runner.egress.HandleRaw(ctx, raw); err != nil {
+			return drained, err
+		}
+		if err := runner.broker.Ack(ctx, EgressQueueName, picked.GUID); err != nil {
+			return drained, err
+		}
+		drained++
+		waitSeconds = egressDrainWaitSeconds
+	}
+}
+
+func sleep(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func durationFromSeconds(seconds float64) time.Duration {
+	return time.Duration(seconds * float64(time.Second))
+}

--- a/go/handler/internal/runtime/runtime_test.go
+++ b/go/handler/internal/runtime/runtime_test.go
@@ -1,0 +1,181 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
+	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+)
+
+func TestRunEnsuresQueuesAndExitsAfterMaxLoops(t *testing.T) {
+	broker := &fakeBroker{}
+	handler := &fakeEgressHandler{}
+	config := handlerconfig.Defaults()
+	config.MaxLoops = 1
+	config.PollIntervalSeconds = 100
+	runner, err := NewRunner(config, broker, handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runner.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := broker.ensured, []string{TaskQueueName, EgressQueueName}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ensured = %#v, want %#v", got, want)
+	}
+	if len(broker.pickups) != 1 {
+		t.Fatalf("pickup calls = %#v", broker.pickups)
+	}
+	if len(handler.rawPayloads) != 0 {
+		t.Fatalf("handled payloads = %#v", handler.rawPayloads)
+	}
+}
+
+func TestDrainEgressHandlesAndAcksUntilEmpty(t *testing.T) {
+	broker := &fakeBroker{
+		picked: []*bbmb.PickedMessage{
+			{GUID: "guid-1", Payload: map[string]any{"message_type": "chatting.egress.v2", "task_id": "task:1"}},
+			{GUID: "guid-2", Payload: map[string]any{"message_type": "chatting.egress.v2", "task_id": "task:2"}},
+		},
+	}
+	handler := &fakeEgressHandler{}
+	config := handlerconfig.Defaults()
+	config.PollTimeoutSeconds = 7
+	runner, err := NewRunner(config, broker, handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	drained, err := runner.DrainEgress(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if drained != 2 {
+		t.Fatalf("drained = %d", drained)
+	}
+	if got, want := broker.pickups, []pickupCall{
+		{queue: EgressQueueName, timeoutSeconds: 7, waitSeconds: egressPickupWaitSeconds},
+		{queue: EgressQueueName, timeoutSeconds: 7, waitSeconds: egressDrainWaitSeconds},
+		{queue: EgressQueueName, timeoutSeconds: 7, waitSeconds: egressDrainWaitSeconds},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pickups = %#v, want %#v", got, want)
+	}
+	if got, want := broker.acks, []ackCall{
+		{queue: EgressQueueName, guid: "guid-1"},
+		{queue: EgressQueueName, guid: "guid-2"},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("acks = %#v, want %#v", got, want)
+	}
+	if len(handler.rawPayloads) != 2 {
+		t.Fatalf("handled payloads = %#v", handler.rawPayloads)
+	}
+	for index, raw := range handler.rawPayloads {
+		var decoded map[string]any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("payload %d is invalid JSON: %v", index, err)
+		}
+	}
+}
+
+func TestDrainEgressDoesNotAckWhenHandlerFails(t *testing.T) {
+	expected := errors.New("egress failed")
+	broker := &fakeBroker{
+		picked: []*bbmb.PickedMessage{{GUID: "guid-1", Payload: map[string]any{"message_type": "chatting.egress.v2"}}},
+	}
+	handler := &fakeEgressHandler{err: expected}
+	runner, err := NewRunner(handlerconfig.Defaults(), broker, handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	drained, err := runner.DrainEgress(context.Background())
+	if !errors.Is(err, expected) {
+		t.Fatalf("err = %v, want %v", err, expected)
+	}
+	if drained != 0 {
+		t.Fatalf("drained = %d", drained)
+	}
+	if len(broker.acks) != 0 {
+		t.Fatalf("acks = %#v", broker.acks)
+	}
+}
+
+func TestRunReturnsWhenContextIsCancelledDuringSleep(t *testing.T) {
+	broker := &fakeBroker{}
+	handler := &fakeEgressHandler{}
+	config := handlerconfig.Defaults()
+	config.MaxLoops = 0
+	runner, err := NewRunner(config, broker, handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runner.sleep = func(context.Context, time.Duration) error {
+		cancel()
+		return context.Canceled
+	}
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type pickupCall struct {
+	queue          string
+	timeoutSeconds int
+	waitSeconds    int
+}
+
+type ackCall struct {
+	queue string
+	guid  string
+}
+
+type fakeBroker struct {
+	ensured []string
+	picked  []*bbmb.PickedMessage
+	pickups []pickupCall
+	acks    []ackCall
+}
+
+func (broker *fakeBroker) EnsureQueue(ctx context.Context, queueName string) error {
+	broker.ensured = append(broker.ensured, queueName)
+	return nil
+}
+
+func (broker *fakeBroker) PickupJSON(ctx context.Context, queueName string, timeoutSeconds int, waitSeconds int) (*bbmb.PickedMessage, error) {
+	broker.pickups = append(broker.pickups, pickupCall{
+		queue:          queueName,
+		timeoutSeconds: timeoutSeconds,
+		waitSeconds:    waitSeconds,
+	})
+	if len(broker.picked) == 0 {
+		return nil, nil
+	}
+	picked := broker.picked[0]
+	broker.picked = broker.picked[1:]
+	return picked, nil
+}
+
+func (broker *fakeBroker) Ack(ctx context.Context, queueName string, guid string) error {
+	broker.acks = append(broker.acks, ackCall{queue: queueName, guid: guid})
+	return nil
+}
+
+type fakeEgressHandler struct {
+	rawPayloads [][]byte
+	err         error
+}
+
+func (handler *fakeEgressHandler) HandleRaw(ctx context.Context, raw []byte) error {
+	handler.rawPayloads = append(handler.rawPayloads, raw)
+	return handler.err
+}

--- a/tests/e2e/handler_selector.py
+++ b/tests/e2e/handler_selector.py
@@ -44,6 +44,6 @@ def message_handler_command(
         ]
     raise NotImplementedError(
         f"{HANDLER_IMPLEMENTATION_ENV}=go was selected, but the Go handler "
-        "runtime is not implemented yet. This is intentional and must not "
-        "fall back to the Python handler."
+        "drop-in E2E path is not implemented yet. This is intentional and "
+        "must not fall back to the Python handler."
     )

--- a/tests/test_e2e_handler_selector.py
+++ b/tests/test_e2e_handler_selector.py
@@ -30,10 +30,10 @@ class E2EHandlerSelectorTests(unittest.TestCase):
             ],
         )
 
-    def test_go_selection_fails_clearly_until_runtime_exists(self) -> None:
+    def test_go_selection_fails_clearly_until_e2e_path_exists(self) -> None:
         with self.assertRaisesRegex(
             NotImplementedError,
-            "Go handler runtime is not implemented yet",
+            "Go handler drop-in E2E path is not implemented yet",
         ):
             message_handler_command(
                 Path("/tmp/handler.json"),


### PR DESCRIPTION
## Summary

- add `go/handler/internal/runtime` to ensure BBMB queues, run bounded handler loops, drain egress messages, invoke the egress handler, and ack processed messages
- wire `cmd/chatting-handler` to config, BBMB, SQLite state, the strict egress engine, and SIGINT/SIGTERM cancellation
- update the Go port plan and E2E selector wording now that runtime plumbing exists but the Go drop-in E2E path is still pending ingress connectors

## Validation

- `cd go/handler && go test ./...`
- `uv run ruff check app tests`
- `uv run python -m unittest tests.test_e2e_handler_selector`
