### PR TITLE
Add Go handler heartbeat connector

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -566,6 +566,13 @@ Validation:
 
 ### 9. Internal Heartbeat Connector
 
+Status: complete. The Go handler now wires an always-on internal heartbeat
+connector into the runtime loop, records heartbeat tasks in SQLite before
+publishing them to `chatting.tasks.v1`, and recognizes the internal
+`log/heartbeat` pong as an allowlist exception. Tests cover heartbeat envelope
+shape, runtime publication/dedupe behavior, and egress acceptance when `log` is
+not otherwise allowlisted.
+
 Implement the heartbeat task source and heartbeat egress recognition.
 
 Validation:
@@ -689,6 +696,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add the internal heartbeat connector and heartbeat egress recognition.
-2. Add auxiliary ingress queue consumption for the first Go-handler/Python-worker E2E path.
-3. Add interval schedule connector support.
+1. Add auxiliary ingress queue consumption for the first Go-handler/Python-worker E2E path.
+2. Add interval schedule connector support.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/egress"
 	handlerruntime "github.com/EdwardSalkeld/chatting/go/handler/internal/runtime"
@@ -101,7 +102,7 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 	runner, err := handlerruntime.NewRunner(config, adapter, egressHandlerFunc(func(ctx context.Context, raw []byte) error {
 		_, err := engine.HandleRaw(ctx, raw)
 		return err
-	}))
+	}), handlerruntime.WithIngress(store, heartbeat.New(nil)))
 	if err != nil {
 		_ = store.Close()
 		return nil, err
@@ -118,6 +119,9 @@ func (fn egressHandlerFunc) HandleRaw(ctx context.Context, raw []byte) error {
 type unsupportedDispatcher struct{}
 
 func (unsupportedDispatcher) Dispatch(ctx context.Context, message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (*contracts.OutboundMessage, error) {
+	if heartbeat.IsLogPong(message, envelope) {
+		return &message, nil
+	}
 	return nil, errors.New("dispatch is not implemented in the Go handler yet")
 }
 

--- a/go/handler/cmd/chatting-handler/main_test.go
+++ b/go/handler/cmd/chatting-handler/main_test.go
@@ -8,8 +8,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 )
 
 func TestRunPrintsVersion(t *testing.T) {
@@ -134,6 +137,27 @@ func TestRunReportsRuntimeError(t *testing.T) {
 	}
 }
 
+func TestUnsupportedDispatcherAcceptsInternalHeartbeatLogPong(t *testing.T) {
+	body := `{"kind":"heartbeat_pong"}`
+	message := contracts.OutboundMessage{
+		Channel: "log",
+		Target:  "heartbeat",
+		Body:    &body,
+	}
+
+	dispatched, err := unsupportedDispatcher{}.Dispatch(
+		context.Background(),
+		message,
+		heartbeat.BuildEnvelope(1, mustTime(t, "2026-03-09T12:00:00Z")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dispatched == nil || dispatched.Channel != "log" || dispatched.Target != "heartbeat" {
+		t.Fatalf("dispatched = %#v", dispatched)
+	}
+}
+
 type fakeRunnerFactory struct {
 	called bool
 	config handlerconfig.Config
@@ -159,4 +183,13 @@ type fakeRunner struct {
 
 func (runner *fakeRunner) Run(ctx context.Context) error {
 	return runner.err
+}
+
+func mustTime(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
 }

--- a/go/handler/internal/connectors/heartbeat/heartbeat.go
+++ b/go/handler/internal/connectors/heartbeat/heartbeat.go
@@ -1,0 +1,77 @@
+package heartbeat
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+const (
+	InternalSource           = "internal"
+	InternalReplyChannelType = "internal"
+	InternalHeartbeatTarget  = "heartbeat"
+)
+
+type NowFunc func() time.Time
+
+type Connector struct {
+	now      NowFunc
+	sequence int
+}
+
+func New(now NowFunc) *Connector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Connector{now: now}
+}
+
+func (connector *Connector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	connector.sequence++
+	return []contracts.TaskEnvelope{
+		BuildEnvelope(connector.sequence, connector.now()),
+	}, nil
+}
+
+func BuildEnvelope(sequence int, now time.Time) contracts.TaskEnvelope {
+	currentTime := now.UTC()
+	heartbeatID := "internal-heartbeat:" + pythonUTCISO(currentTime) + ":" + strconv.Itoa(sequence)
+	actor := "message-handler"
+	return contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            heartbeatID,
+		Source:        InternalSource,
+		ReceivedAt:    contracts.NewTimestamp(currentTime),
+		Actor:         &actor,
+		Content:       "internal heartbeat ping",
+		Attachments:   []contracts.AttachmentRef{},
+		ContextRefs:   []string{},
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   InternalReplyChannelType,
+			Target: InternalHeartbeatTarget,
+		},
+		DedupeKey: heartbeatID,
+	}
+}
+
+func IsEnvelope(envelope contracts.TaskEnvelope) bool {
+	return envelope.Source == InternalSource &&
+		envelope.ReplyChannel.Type == InternalReplyChannelType &&
+		envelope.ReplyChannel.Target == InternalHeartbeatTarget
+}
+
+func IsLogPong(message contracts.OutboundMessage, envelope contracts.TaskEnvelope) bool {
+	return IsEnvelope(envelope) &&
+		message.Channel == "log" &&
+		message.Target == InternalHeartbeatTarget
+}
+
+func pythonUTCISO(value time.Time) string {
+	return strings.TrimSuffix(value.Format(time.RFC3339Nano), "Z") + "+00:00"
+}

--- a/go/handler/internal/connectors/heartbeat/heartbeat_test.go
+++ b/go/handler/internal/connectors/heartbeat/heartbeat_test.go
@@ -1,0 +1,74 @@
+package heartbeat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+func TestPollEmitsInternalHeartbeatWithUniqueIDs(t *testing.T) {
+	now := mustTime(t, "2026-03-09T12:00:00Z")
+	connector := New(func() time.Time { return now })
+
+	first, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("poll results = %#v %#v", first, second)
+	}
+	if first[0].Source != "internal" {
+		t.Fatalf("source = %q", first[0].Source)
+	}
+	if first[0].Actor == nil || *first[0].Actor != "message-handler" {
+		t.Fatalf("actor = %#v", first[0].Actor)
+	}
+	if first[0].ReplyChannel.Type != "internal" || first[0].ReplyChannel.Target != "heartbeat" {
+		t.Fatalf("reply channel = %#v", first[0].ReplyChannel)
+	}
+	if first[0].ID == second[0].ID {
+		t.Fatalf("heartbeat IDs should be unique: %q", first[0].ID)
+	}
+	if first[0].DedupeKey != first[0].ID || second[0].DedupeKey != second[0].ID {
+		t.Fatalf("dedupe keys = %q %q", first[0].DedupeKey, second[0].DedupeKey)
+	}
+	if first[0].ID != "internal-heartbeat:2026-03-09T12:00:00+00:00:1" {
+		t.Fatalf("first ID = %q", first[0].ID)
+	}
+}
+
+func TestIsLogPongRecognizesOnlyInternalHeartbeatLogTarget(t *testing.T) {
+	envelope := BuildEnvelope(1, mustTime(t, "2026-03-09T12:00:00Z"))
+	body := "{}"
+
+	if !IsLogPong(testMessage("log", "heartbeat", body), envelope) {
+		t.Fatal("expected heartbeat log pong")
+	}
+	if IsLogPong(testMessage("log", "ops", body), envelope) {
+		t.Fatal("ops log should not be a heartbeat pong")
+	}
+	envelope.ReplyChannel.Type = "log"
+	if IsLogPong(testMessage("log", "heartbeat", body), envelope) {
+		t.Fatal("non-internal reply channel should not be a heartbeat pong")
+	}
+}
+
+func testMessage(channel string, target string, body string) contracts.OutboundMessage {
+	return contracts.OutboundMessage{Channel: channel, Target: target, Body: &body}
+}
+
+func mustTime(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 )
 
@@ -121,7 +122,7 @@ func (engine *Engine) Handle(ctx context.Context, message contracts.EgressQueueM
 		return Result{Status: StatusDropped, Reason: "unknown_task"}, nil
 	}
 
-	if !engine.channelAllowed(message) {
+	if !engine.channelAllowed(message, task) {
 		return Result{Status: StatusDropped, Reason: "disallowed_channel"}, nil
 	}
 
@@ -205,7 +206,7 @@ func (engine *Engine) Flush(ctx context.Context, taskID string) (Result, error) 
 			return Result{Status: StatusCompleted}, nil
 		}
 
-		if !engine.channelAllowed(message) {
+		if !engine.channelAllowed(message, task) {
 			return Result{}, fmt.Errorf("staged event %s has disallowed channel %q", staged.EventID, message.Message.Channel)
 		}
 		if err := engine.dispatchAndMark(ctx, task, message); err != nil {
@@ -225,8 +226,11 @@ func (engine *Engine) dispatchAndMark(ctx context.Context, task *TaskRecord, mes
 	return engine.state.MarkDispatchedEventID(ctx, message.TaskID, message.EventID)
 }
 
-func (engine *Engine) channelAllowed(message contracts.EgressQueueMessage) bool {
+func (engine *Engine) channelAllowed(message contracts.EgressQueueMessage, task *TaskRecord) bool {
 	if message.EventKind == "completion" {
+		return true
+	}
+	if task != nil && heartbeat.IsLogPong(message.Message, task.TaskMessage.Envelope) {
 		return true
 	}
 	return engine.allowedChannels[message.Message.Channel]

--- a/go/handler/internal/egress/egress_test.go
+++ b/go/handler/internal/egress/egress_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
 )
@@ -64,6 +65,33 @@ func TestHandleDropsDisallowedChannel(t *testing.T) {
 	}
 	if result.Status != StatusDropped || result.Reason != "disallowed_channel" {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestHandleAllowsInternalHeartbeatLogPongWhenLogDisallowed(t *testing.T) {
+	task := contracts.NewTaskQueueMessage(
+		heartbeat.BuildEnvelope(1, mustTime(t, "2026-03-09T12:00:00Z")),
+		"trace:internal-heartbeat:1",
+		mustTime(t, "2026-03-09T12:00:01Z"),
+	)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngine(t, state, dispatcher)
+	message := testEgressMessage(t, task, intPtr(0), "evt:heartbeat:0", "message")
+	message.Message.Channel = "log"
+	message.Message.Target = "heartbeat"
+	message.Message.Body = stringPtr(`{"kind":"heartbeat_pong"}`)
+
+	result, err := engine.Handle(context.Background(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDispatched {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(dispatcher.messages) != 1 {
+		t.Fatalf("dispatch count = %d", len(dispatcher.messages))
 	}
 }
 

--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 )
 
 const (
@@ -20,6 +21,7 @@ const (
 
 type Broker interface {
 	EnsureQueue(ctx context.Context, queueName string) error
+	PublishJSON(ctx context.Context, queueName string, payload map[string]any) (string, error)
 	PickupJSON(ctx context.Context, queueName string, timeoutSeconds int, waitSeconds int) (*bbmb.PickedMessage, error)
 	Ack(ctx context.Context, queueName string, guid string) error
 }
@@ -28,26 +30,69 @@ type EgressHandler interface {
 	HandleRaw(ctx context.Context, raw []byte) error
 }
 
-type Runner struct {
-	config handlerconfig.Config
-	broker Broker
-	egress EgressHandler
-	sleep  func(context.Context, time.Duration) error
+type IngressState interface {
+	Seen(ctx context.Context, source string, dedupeKey string) (bool, error)
+	MarkSeen(ctx context.Context, source string, dedupeKey string) error
+	RecordTask(ctx context.Context, taskMessage contracts.TaskQueueMessage) error
 }
 
-func NewRunner(config handlerconfig.Config, broker Broker, egress EgressHandler) (*Runner, error) {
+type Connector interface {
+	Poll(ctx context.Context) ([]contracts.TaskEnvelope, error)
+}
+
+type Runner struct {
+	config       handlerconfig.Config
+	broker       Broker
+	egress       EgressHandler
+	ingressState IngressState
+	connectors   []Connector
+	now          func() time.Time
+	sleep        func(context.Context, time.Duration) error
+}
+
+type Option func(*Runner)
+
+func WithIngress(state IngressState, connectors ...Connector) Option {
+	return func(runner *Runner) {
+		runner.ingressState = state
+		runner.connectors = append(runner.connectors, connectors...)
+	}
+}
+
+func WithNow(now func() time.Time) Option {
+	return func(runner *Runner) {
+		if now != nil {
+			runner.now = now
+		}
+	}
+}
+
+func NewRunner(config handlerconfig.Config, broker Broker, egress EgressHandler, options ...Option) (*Runner, error) {
 	if broker == nil {
 		return nil, errors.New("broker is required")
 	}
 	if egress == nil {
 		return nil, errors.New("egress handler is required")
 	}
-	return &Runner{
+	runner := &Runner{
 		config: config,
 		broker: broker,
 		egress: egress,
+		now:    func() time.Time { return time.Now().UTC() },
 		sleep:  sleep,
-	}, nil
+	}
+	for _, option := range options {
+		option(runner)
+	}
+	if len(runner.connectors) > 0 && runner.ingressState == nil {
+		return nil, errors.New("ingress state is required when connectors are configured")
+	}
+	for _, connector := range runner.connectors {
+		if connector == nil {
+			return nil, errors.New("connector is required")
+		}
+	}
+	return runner, nil
 }
 
 func (runner *Runner) Run(ctx context.Context) error {
@@ -67,6 +112,9 @@ func (runner *Runner) Run(ctx context.Context) error {
 			return nil
 		}
 		loopCount++
+		if _, err := runner.PublishIngress(ctx); err != nil {
+			return err
+		}
 		if _, err := runner.DrainEgress(ctx); err != nil {
 			return err
 		}
@@ -77,6 +125,48 @@ func (runner *Runner) Run(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+func (runner *Runner) PublishIngress(ctx context.Context) (int, error) {
+	if len(runner.connectors) == 0 {
+		return 0, nil
+	}
+	published := 0
+	for _, connector := range runner.connectors {
+		envelopes, err := connector.Poll(ctx)
+		if err != nil {
+			return published, err
+		}
+		for _, envelope := range envelopes {
+			seen, err := runner.ingressState.Seen(ctx, envelope.Source, envelope.DedupeKey)
+			if err != nil {
+				return published, err
+			}
+			if seen {
+				continue
+			}
+			taskMessage := contracts.NewTaskQueueMessage(
+				envelope,
+				"trace:"+envelope.ID,
+				runner.now(),
+			)
+			if err := runner.ingressState.RecordTask(ctx, taskMessage); err != nil {
+				return published, err
+			}
+			payload, err := taskMessageMap(taskMessage)
+			if err != nil {
+				return published, err
+			}
+			if _, err := runner.broker.PublishJSON(ctx, TaskQueueName, payload); err != nil {
+				return published, err
+			}
+			if err := runner.ingressState.MarkSeen(ctx, envelope.Source, envelope.DedupeKey); err != nil {
+				return published, err
+			}
+			published++
+		}
+	}
+	return published, nil
 }
 
 func (runner *Runner) DrainEgress(ctx context.Context) (int, error) {
@@ -108,6 +198,18 @@ func (runner *Runner) DrainEgress(ctx context.Context) (int, error) {
 		drained++
 		waitSeconds = egressDrainWaitSeconds
 	}
+}
+
+func taskMessageMap(taskMessage contracts.TaskQueueMessage) (map[string]any, error) {
+	encoded, err := json.Marshal(taskMessage)
+	if err != nil {
+		return nil, err
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
 }
 
 func sleep(ctx context.Context, duration time.Duration) error {

--- a/go/handler/internal/runtime/runtime_test.go
+++ b/go/handler/internal/runtime/runtime_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 )
 
 func TestRunEnsuresQueuesAndExitsAfterMaxLoops(t *testing.T) {
@@ -108,6 +110,91 @@ func TestDrainEgressDoesNotAckWhenHandlerFails(t *testing.T) {
 	}
 }
 
+func TestRunPublishesInternalHeartbeatTask(t *testing.T) {
+	broker := &fakeBroker{}
+	state := newFakeIngressState()
+	handler := &fakeEgressHandler{}
+	config := handlerconfig.Defaults()
+	config.MaxLoops = 1
+	runner, err := NewRunner(
+		config,
+		broker,
+		handler,
+		WithIngress(state, heartbeat.New(func() time.Time {
+			return mustTime(t, "2026-03-09T12:00:00Z")
+		})),
+		WithNow(func() time.Time {
+			return mustTime(t, "2026-03-09T12:00:01Z")
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runner.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(broker.published) != 1 {
+		t.Fatalf("published = %#v", broker.published)
+	}
+	published := broker.published[0]
+	if published.queue != TaskQueueName {
+		t.Fatalf("publish queue = %q", published.queue)
+	}
+	raw, err := json.Marshal(published.payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMessage, err := contracts.DecodeTaskQueueMessage(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if taskMessage.Envelope.Source != "internal" {
+		t.Fatalf("source = %q", taskMessage.Envelope.Source)
+	}
+	if taskMessage.Envelope.ReplyChannel.Type != "internal" || taskMessage.Envelope.ReplyChannel.Target != "heartbeat" {
+		t.Fatalf("reply channel = %#v", taskMessage.Envelope.ReplyChannel)
+	}
+	if _, ok := state.tasks[taskMessage.TaskID]; !ok {
+		t.Fatalf("task was not recorded: %#v", state.tasks)
+	}
+	if !state.seen[taskMessage.Envelope.Source][taskMessage.Envelope.DedupeKey] {
+		t.Fatalf("dedupe key was not marked seen: %#v", state.seen)
+	}
+}
+
+func TestPublishIngressSkipsSeenEnvelope(t *testing.T) {
+	broker := &fakeBroker{}
+	state := newFakeIngressState()
+	connector := heartbeat.New(func() time.Time {
+		return mustTime(t, "2026-03-09T12:00:00Z")
+	})
+	envelope := heartbeat.BuildEnvelope(1, mustTime(t, "2026-03-09T12:00:00Z"))
+	state.seen[envelope.Source] = map[string]bool{envelope.DedupeKey: true}
+	runner, err := NewRunner(
+		handlerconfig.Defaults(),
+		broker,
+		&fakeEgressHandler{},
+		WithIngress(state, connector),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	published, err := runner.PublishIngress(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if published != 0 {
+		t.Fatalf("published = %d", published)
+	}
+	if len(broker.published) != 0 {
+		t.Fatalf("broker published = %#v", broker.published)
+	}
+}
+
 func TestRunReturnsWhenContextIsCancelledDuringSleep(t *testing.T) {
 	broker := &fakeBroker{}
 	handler := &fakeEgressHandler{}
@@ -139,16 +226,27 @@ type ackCall struct {
 	guid  string
 }
 
+type publishCall struct {
+	queue   string
+	payload map[string]any
+}
+
 type fakeBroker struct {
-	ensured []string
-	picked  []*bbmb.PickedMessage
-	pickups []pickupCall
-	acks    []ackCall
+	ensured   []string
+	published []publishCall
+	picked    []*bbmb.PickedMessage
+	pickups   []pickupCall
+	acks      []ackCall
 }
 
 func (broker *fakeBroker) EnsureQueue(ctx context.Context, queueName string) error {
 	broker.ensured = append(broker.ensured, queueName)
 	return nil
+}
+
+func (broker *fakeBroker) PublishJSON(ctx context.Context, queueName string, payload map[string]any) (string, error) {
+	broker.published = append(broker.published, publishCall{queue: queueName, payload: payload})
+	return "guid-published", nil
 }
 
 func (broker *fakeBroker) PickupJSON(ctx context.Context, queueName string, timeoutSeconds int, waitSeconds int) (*bbmb.PickedMessage, error) {
@@ -178,4 +276,42 @@ type fakeEgressHandler struct {
 func (handler *fakeEgressHandler) HandleRaw(ctx context.Context, raw []byte) error {
 	handler.rawPayloads = append(handler.rawPayloads, raw)
 	return handler.err
+}
+
+type fakeIngressState struct {
+	seen  map[string]map[string]bool
+	tasks map[string]contracts.TaskQueueMessage
+}
+
+func newFakeIngressState() *fakeIngressState {
+	return &fakeIngressState{
+		seen:  map[string]map[string]bool{},
+		tasks: map[string]contracts.TaskQueueMessage{},
+	}
+}
+
+func (state *fakeIngressState) Seen(ctx context.Context, source string, dedupeKey string) (bool, error) {
+	return state.seen[source][dedupeKey], nil
+}
+
+func (state *fakeIngressState) MarkSeen(ctx context.Context, source string, dedupeKey string) error {
+	if state.seen[source] == nil {
+		state.seen[source] = map[string]bool{}
+	}
+	state.seen[source][dedupeKey] = true
+	return nil
+}
+
+func (state *fakeIngressState) RecordTask(ctx context.Context, taskMessage contracts.TaskQueueMessage) error {
+	state.tasks[taskMessage.TaskID] = taskMessage
+	return nil
+}
+
+func mustTime(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
 }


### PR DESCRIPTION
## Summary
- add the Go internal heartbeat connector and wire it into the handler runtime loop
- record/publish heartbeat tasks through the shared ingress runtime path
- allow the internal `log/heartbeat` pong even when `log` is not in the normal egress allowlist
- update the Go handler port plan so the next slice starts at auxiliary ingress

## Validation
- `cd go/handler && go test ./...`
- `uv run ruff check app tests`
