### PR TITLE
Add Go auxiliary ingress connector

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -583,6 +583,13 @@ Validation:
 
 ### 10. Auxiliary Ingress Queue Connector
 
+Status: complete. The Go handler now supports configured auxiliary ingress BBMB
+queues, drains `chatting.auxiliary_ingress.v1` payloads into Python-compatible
+webhook task envelopes, records and publishes them through the shared runtime
+path, and acks source messages only after publication or when already deduped.
+The E2E handler selector can now launch the Go handler for the auxiliary
+Go-handler/Python-worker path.
+
 Implement the handler-side consumer for `chatting.auxiliary_ingress.v1`.
 
 Validation:
@@ -696,5 +703,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add auxiliary ingress queue consumption for the first Go-handler/Python-worker E2E path.
-2. Add interval schedule connector support.
+1. Add interval schedule connector support.
+2. Add basic Prometheus-style metrics for the Go runtime.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/auxiliary"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/egress"
@@ -99,10 +100,43 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		_ = store.Close()
 		return nil, err
 	}
+	connectors := []handlerruntime.Connector{heartbeat.New(nil)}
+	auxiliaryAdapter := adapter
+	if config.AuxiliaryIngressEnabled {
+		auxiliaryAddress := config.AuxiliaryIngressBBMBAddress
+		if auxiliaryAddress == "" {
+			auxiliaryAddress = config.BBMBAddress
+		}
+		if auxiliaryAddress != config.BBMBAddress {
+			auxiliaryAdapter, err = bbmb.NewAdapter(auxiliaryAddress)
+			if err != nil {
+				_ = store.Close()
+				return nil, err
+			}
+		}
+		prompt := contracts.PromptContext{GlobalInstructions: config.GlobalPromptContext}
+		for _, queueName := range config.AuxiliaryIngressQueues {
+			if err := auxiliaryAdapter.EnsureQueue(ctx, queueName); err != nil {
+				_ = store.Close()
+				return nil, err
+			}
+			connector, err := auxiliary.New(
+				auxiliaryAdapter,
+				queueName,
+				config.AuxiliaryIngressContextRefs,
+				prompt,
+			)
+			if err != nil {
+				_ = store.Close()
+				return nil, err
+			}
+			connectors = append(connectors, connector)
+		}
+	}
 	runner, err := handlerruntime.NewRunner(config, adapter, egressHandlerFunc(func(ctx context.Context, raw []byte) error {
 		_, err := engine.HandleRaw(ctx, raw)
 		return err
-	}), handlerruntime.WithIngress(store, heartbeat.New(nil)))
+	}), handlerruntime.WithIngress(store, connectors...))
 	if err != nil {
 		_ = store.Close()
 		return nil, err

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -32,6 +32,12 @@ var allowedKeys = map[string]bool{
 	"metrics_host":            true,
 	"metrics_port":            true,
 	"allowed_egress_channels": true,
+	"global_prompt_context":   true,
+
+	"auxiliary_ingress_enabled":      true,
+	"auxiliary_ingress_bbmb_address": true,
+	"auxiliary_ingress_queues":       true,
+	"auxiliary_ingress_context_refs": true,
 }
 
 type Config struct {
@@ -43,6 +49,12 @@ type Config struct {
 	MetricsHost           string
 	MetricsPort           int
 	AllowedEgressChannels []string
+	GlobalPromptContext   []string
+
+	AuxiliaryIngressEnabled     bool
+	AuxiliaryIngressBBMBAddress string
+	AuxiliaryIngressQueues      []string
+	AuxiliaryIngressContextRefs []string
 }
 
 func Defaults() Config {
@@ -55,6 +67,12 @@ func Defaults() Config {
 		MetricsHost:           DefaultMetricsHost,
 		MetricsPort:           DefaultMetricsPort,
 		AllowedEgressChannels: []string{"email", "telegram", "telegram_reaction", "log"},
+		GlobalPromptContext:   []string{},
+
+		AuxiliaryIngressEnabled:     false,
+		AuxiliaryIngressBBMBAddress: "",
+		AuxiliaryIngressQueues:      []string{},
+		AuxiliaryIngressContextRefs: []string{},
 	}
 }
 
@@ -163,6 +181,39 @@ func Load(raw []byte) (Config, error) {
 			return Config{}, err
 		}
 	}
+	if rawValue, ok := payload["global_prompt_context"]; ok && !isNull(rawValue) {
+		config.GlobalPromptContext, err = decodeStringList(rawValue, "global_prompt_context")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["auxiliary_ingress_enabled"]; ok && !isNull(rawValue) {
+		config.AuxiliaryIngressEnabled, err = decodeBool(rawValue, "auxiliary_ingress_enabled")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["auxiliary_ingress_bbmb_address"]; ok && !isNull(rawValue) {
+		config.AuxiliaryIngressBBMBAddress, err = decodeNonEmptyString(rawValue, "auxiliary_ingress_bbmb_address")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["auxiliary_ingress_queues"]; ok && !isNull(rawValue) {
+		config.AuxiliaryIngressQueues, err = decodeStringList(rawValue, "auxiliary_ingress_queues")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["auxiliary_ingress_context_refs"]; ok && !isNull(rawValue) {
+		config.AuxiliaryIngressContextRefs, err = decodeStringList(rawValue, "auxiliary_ingress_context_refs")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if config.AuxiliaryIngressEnabled && len(config.AuxiliaryIngressQueues) == 0 {
+		return Config{}, errors.New("auxiliary ingress requires auxiliary_ingress_queues")
+	}
 	return config, nil
 }
 
@@ -209,17 +260,43 @@ func decodePositiveFloat(raw json.RawMessage, name string) (float64, error) {
 }
 
 func decodeAllowedEgressChannels(raw json.RawMessage) ([]string, error) {
-	var values []string
-	if err := json.Unmarshal(raw, &values); err != nil {
-		return nil, errors.New("config allowed_egress_channels must be a list of strings")
-	}
-	for _, value := range values {
-		if strings.TrimSpace(value) == "" {
-			return nil, errors.New("allowed_egress_channel entries must not be empty")
-		}
+	values, err := decodeStringList(raw, "allowed_egress_channels")
+	if err != nil {
+		return nil, err
 	}
 	if len(values) == 0 {
 		return Defaults().AllowedEgressChannels, nil
 	}
 	return values, nil
+}
+
+func decodeStringList(raw json.RawMessage, name string) ([]string, error) {
+	var values []string
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("config %s must be a list of strings", name)
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("%s entries must not be empty", singularListName(name))
+		}
+	}
+	if values == nil {
+		return []string{}, nil
+	}
+	return values, nil
+}
+
+func singularListName(name string) string {
+	if name == "allowed_egress_channels" {
+		return "allowed_egress_channel"
+	}
+	return name
+}
+
+func decodeBool(raw json.RawMessage, name string) (bool, error) {
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false, fmt.Errorf("config %s must be a boolean", name)
+	}
+	return value, nil
 }

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -29,7 +29,12 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 		"poll_timeout_seconds": 3,
 		"metrics_host": "0.0.0.0",
 		"metrics_port": 9555,
-		"allowed_egress_channels": ["log", "email"]
+		"allowed_egress_channels": ["log", "email"],
+		"global_prompt_context": ["Keep replies terse."],
+		"auxiliary_ingress_enabled": true,
+		"auxiliary_ingress_bbmb_address": "10.0.0.2:9998",
+		"auxiliary_ingress_queues": ["generic-post"],
+		"auxiliary_ingress_context_refs": ["repo:/workspace/chatting"]
 	}`))
 	if err != nil {
 		t.Fatal(err)
@@ -58,6 +63,21 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(config.AllowedEgressChannels, []string{"log", "email"}) {
 		t.Fatalf("AllowedEgressChannels = %#v", config.AllowedEgressChannels)
+	}
+	if !reflect.DeepEqual(config.GlobalPromptContext, []string{"Keep replies terse."}) {
+		t.Fatalf("GlobalPromptContext = %#v", config.GlobalPromptContext)
+	}
+	if !config.AuxiliaryIngressEnabled {
+		t.Fatal("AuxiliaryIngressEnabled = false")
+	}
+	if config.AuxiliaryIngressBBMBAddress != "10.0.0.2:9998" {
+		t.Fatalf("AuxiliaryIngressBBMBAddress = %q", config.AuxiliaryIngressBBMBAddress)
+	}
+	if !reflect.DeepEqual(config.AuxiliaryIngressQueues, []string{"generic-post"}) {
+		t.Fatalf("AuxiliaryIngressQueues = %#v", config.AuxiliaryIngressQueues)
+	}
+	if !reflect.DeepEqual(config.AuxiliaryIngressContextRefs, []string{"repo:/workspace/chatting"}) {
+		t.Fatalf("AuxiliaryIngressContextRefs = %#v", config.AuxiliaryIngressContextRefs)
 	}
 }
 
@@ -135,6 +155,21 @@ func TestLoadRejectsInvalidValues(t *testing.T) {
 			name:    "non-string allowed channels",
 			raw:     `{"allowed_egress_channels": ["log", 5]}`,
 			message: "config allowed_egress_channels must be a list of strings",
+		},
+		{
+			name:    "non-bool auxiliary enabled",
+			raw:     `{"auxiliary_ingress_enabled": "yes"}`,
+			message: "config auxiliary_ingress_enabled must be a boolean",
+		},
+		{
+			name:    "enabled auxiliary without queues",
+			raw:     `{"auxiliary_ingress_enabled": true}`,
+			message: "auxiliary ingress requires auxiliary_ingress_queues",
+		},
+		{
+			name:    "blank auxiliary queue",
+			raw:     `{"auxiliary_ingress_queues": ["generic-post", ""]}`,
+			message: "auxiliary_ingress_queues entries must not be empty",
 		},
 	}
 

--- a/go/handler/internal/connectors/auxiliary/auxiliary.go
+++ b/go/handler/internal/connectors/auxiliary/auxiliary.go
@@ -1,0 +1,142 @@
+package auxiliary
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+const (
+	Source           = "webhook"
+	ReplyChannelType = "webhook"
+)
+
+type Broker interface {
+	PickupJSON(ctx context.Context, queueName string, timeoutSeconds int, waitSeconds int) (*bbmb.PickedMessage, error)
+	Ack(ctx context.Context, queueName string, guid string) error
+}
+
+type Connector struct {
+	broker      Broker
+	queueName   string
+	replyTarget string
+	contextRefs []string
+	prompt      *contracts.PromptContext
+
+	pendingByEnvelopeID map[string]string
+	pendingEnvelopes    map[string]contracts.TaskEnvelope
+}
+
+func New(broker Broker, queueName string, contextRefs []string, prompt contracts.PromptContext) (*Connector, error) {
+	if broker == nil {
+		return nil, errors.New("broker is required")
+	}
+	if queueName == "" {
+		return nil, errors.New("queue name is required")
+	}
+	var promptContext *contracts.PromptContext
+	if prompt.HasContent() {
+		promptCopy := prompt
+		promptContext = &promptCopy
+	}
+	return &Connector{
+		broker:              broker,
+		queueName:           queueName,
+		replyTarget:         queueName,
+		contextRefs:         append([]string{}, contextRefs...),
+		prompt:              promptContext,
+		pendingByEnvelopeID: map[string]string{},
+		pendingEnvelopes:    map[string]contracts.TaskEnvelope{},
+	}, nil
+}
+
+func (connector *Connector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	envelopes := make([]contracts.TaskEnvelope, 0, len(connector.pendingEnvelopes))
+	for _, envelope := range connector.pendingEnvelopes {
+		envelopes = append(envelopes, envelope)
+	}
+	for {
+		picked, err := connector.broker.PickupJSON(ctx, connector.queueName, 0, 0)
+		if err != nil {
+			return envelopes, err
+		}
+		if picked == nil {
+			return envelopes, nil
+		}
+		raw, err := json.Marshal(picked.Payload)
+		if err != nil {
+			return envelopes, err
+		}
+		message, err := contracts.DecodeAuxiliaryIngressQueueMessage(raw)
+		if err != nil {
+			return envelopes, err
+		}
+		envelope, err := connector.envelopeFromMessage(message)
+		if err != nil {
+			return envelopes, err
+		}
+		if _, exists := connector.pendingEnvelopes[envelope.ID]; exists {
+			continue
+		}
+		connector.pendingByEnvelopeID[envelope.ID] = picked.GUID
+		connector.pendingEnvelopes[envelope.ID] = envelope
+		envelopes = append(envelopes, envelope)
+	}
+}
+
+func (connector *Connector) AckEnvelope(ctx context.Context, envelopeID string) error {
+	guid, ok := connector.pendingByEnvelopeID[envelopeID]
+	delete(connector.pendingByEnvelopeID, envelopeID)
+	delete(connector.pendingEnvelopes, envelopeID)
+	if !ok {
+		return nil
+	}
+	return connector.broker.Ack(ctx, connector.queueName, guid)
+}
+
+func (connector *Connector) envelopeFromMessage(message contracts.AuxiliaryIngressQueueMessage) (contracts.TaskEnvelope, error) {
+	content, err := renderBodyContent(message.Body)
+	if err != nil {
+		return contracts.TaskEnvelope{}, err
+	}
+	envelopeID := "webhook:" + message.EventID
+	return contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            envelopeID,
+		Source:        Source,
+		ReceivedAt:    message.ReceivedAt,
+		Actor:         nil,
+		Content:       content,
+		Attachments:   []contracts.AttachmentRef{},
+		ContextRefs:   append([]string{}, connector.contextRefs...),
+		PromptContext: connector.prompt,
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   ReplyChannelType,
+			Target: connector.replyTarget,
+		},
+		DedupeKey: envelopeID,
+	}, nil
+}
+
+func renderBodyContent(body any) (string, error) {
+	switch body.(type) {
+	case map[string]any, []any:
+		raw, err := json.MarshalIndent(body, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(raw), nil
+	default:
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return "", err
+		}
+		return string(raw), nil
+	}
+}

--- a/go/handler/internal/connectors/auxiliary/auxiliary_test.go
+++ b/go/handler/internal/connectors/auxiliary/auxiliary_test.go
@@ -1,0 +1,141 @@
+package auxiliary
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+func TestPollDrainsAuxiliaryIngressQueueIntoWebhookEnvelope(t *testing.T) {
+	broker := &fakeBroker{
+		picked: []*bbmb.PickedMessage{
+			{
+				GUID: "guid-1",
+				Payload: map[string]any{
+					"schema_version": "1.0",
+					"message_type":   "chatting.auxiliary_ingress.v1",
+					"event_id":       "aux:1",
+					"received_at":    "2026-04-01T12:00:00Z",
+					"body": map[string]any{
+						"hello":  "world",
+						"nested": []any{float64(1), float64(2)},
+					},
+				},
+			},
+		},
+	}
+	connector, err := New(
+		broker,
+		"chatting.auxiliary-ingress.v1",
+		[]string{"repo:/workspace/chatting"},
+		contracts.PromptContext{GlobalInstructions: []string{"Keep it terse."}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	envelope := envelopes[0]
+	if envelope.ID != "webhook:aux:1" {
+		t.Fatalf("ID = %q", envelope.ID)
+	}
+	if envelope.Source != Source {
+		t.Fatalf("Source = %q", envelope.Source)
+	}
+	if envelope.ReplyChannel.Type != ReplyChannelType || envelope.ReplyChannel.Target != "chatting.auxiliary-ingress.v1" {
+		t.Fatalf("ReplyChannel = %#v", envelope.ReplyChannel)
+	}
+	if !reflect.DeepEqual(envelope.ContextRefs, []string{"repo:/workspace/chatting"}) {
+		t.Fatalf("ContextRefs = %#v", envelope.ContextRefs)
+	}
+	if envelope.PromptContext == nil || !reflect.DeepEqual(envelope.PromptContext.GlobalInstructions, []string{"Keep it terse."}) {
+		t.Fatalf("PromptContext = %#v", envelope.PromptContext)
+	}
+	expectedContent := "{\n  \"hello\": \"world\",\n  \"nested\": [\n    1,\n    2\n  ]\n}"
+	if envelope.Content != expectedContent {
+		t.Fatalf("Content = %q, want %q", envelope.Content, expectedContent)
+	}
+	if len(broker.acks) != 0 {
+		t.Fatalf("acks before AckEnvelope = %#v", broker.acks)
+	}
+
+	if err := connector.AckEnvelope(context.Background(), envelope.ID); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := broker.acks, []ackCall{{queue: "chatting.auxiliary-ingress.v1", guid: "guid-1"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("acks = %#v, want %#v", got, want)
+	}
+}
+
+func TestPollKeepsPendingEnvelopeUntilAcked(t *testing.T) {
+	broker := &fakeBroker{
+		picked: []*bbmb.PickedMessage{
+			{
+				GUID: "guid-1",
+				Payload: map[string]any{
+					"schema_version": "1.0",
+					"message_type":   "chatting.auxiliary_ingress.v1",
+					"event_id":       "aux:1",
+					"received_at":    "2026-04-01T12:00:00Z",
+					"body":           "hello",
+				},
+			},
+		},
+	}
+	connector, err := New(broker, "aux", nil, contracts.PromptContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("first = %#v, second = %#v", first, second)
+	}
+	if second[0].ID != first[0].ID {
+		t.Fatalf("pending ID = %q, want %q", second[0].ID, first[0].ID)
+	}
+}
+
+type fakeBroker struct {
+	picked []*bbmb.PickedMessage
+	acks   []ackCall
+}
+
+type ackCall struct {
+	queue string
+	guid  string
+}
+
+func (broker *fakeBroker) PickupJSON(ctx context.Context, queueName string, timeoutSeconds int, waitSeconds int) (*bbmb.PickedMessage, error) {
+	if timeoutSeconds != 0 || waitSeconds != 0 {
+		panic("auxiliary connector must use nonblocking pickup")
+	}
+	if len(broker.picked) == 0 {
+		return nil, nil
+	}
+	picked := broker.picked[0]
+	broker.picked = broker.picked[1:]
+	return picked, nil
+}
+
+func (broker *fakeBroker) Ack(ctx context.Context, queueName string, guid string) error {
+	broker.acks = append(broker.acks, ackCall{queue: queueName, guid: guid})
+	return nil
+}

--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -40,6 +40,11 @@ type Connector interface {
 	Poll(ctx context.Context) ([]contracts.TaskEnvelope, error)
 }
 
+type AckingConnector interface {
+	Connector
+	AckEnvelope(ctx context.Context, envelopeID string) error
+}
+
 type Runner struct {
 	config       handlerconfig.Config
 	broker       Broker
@@ -143,6 +148,9 @@ func (runner *Runner) PublishIngress(ctx context.Context) (int, error) {
 				return published, err
 			}
 			if seen {
+				if err := ackEnvelope(ctx, connector, envelope.ID); err != nil {
+					return published, err
+				}
 				continue
 			}
 			taskMessage := contracts.NewTaskQueueMessage(
@@ -163,10 +171,21 @@ func (runner *Runner) PublishIngress(ctx context.Context) (int, error) {
 			if err := runner.ingressState.MarkSeen(ctx, envelope.Source, envelope.DedupeKey); err != nil {
 				return published, err
 			}
+			if err := ackEnvelope(ctx, connector, envelope.ID); err != nil {
+				return published, err
+			}
 			published++
 		}
 	}
 	return published, nil
+}
+
+func ackEnvelope(ctx context.Context, connector Connector, envelopeID string) error {
+	acking, ok := connector.(AckingConnector)
+	if !ok {
+		return nil
+	}
+	return acking.AckEnvelope(ctx, envelopeID)
 }
 
 func (runner *Runner) DrainEgress(ctx context.Context) (int, error) {

--- a/go/handler/internal/runtime/runtime_test.go
+++ b/go/handler/internal/runtime/runtime_test.go
@@ -195,6 +195,66 @@ func TestPublishIngressSkipsSeenEnvelope(t *testing.T) {
 	}
 }
 
+func TestPublishIngressAcksAckingConnectorAfterPublish(t *testing.T) {
+	broker := &fakeBroker{}
+	state := newFakeIngressState()
+	envelope := heartbeat.BuildEnvelope(1, mustTime(t, "2026-03-09T12:00:00Z"))
+	connector := &fakeAckingConnector{envelopes: []contracts.TaskEnvelope{envelope}}
+	runner, err := NewRunner(
+		handlerconfig.Defaults(),
+		broker,
+		&fakeEgressHandler{},
+		WithIngress(state, connector),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	published, err := runner.PublishIngress(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if published != 1 {
+		t.Fatalf("published = %d", published)
+	}
+	if got, want := connector.acked, []string{envelope.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("acked = %#v, want %#v", got, want)
+	}
+}
+
+func TestPublishIngressAcksSeenEnvelopeFromAckingConnector(t *testing.T) {
+	broker := &fakeBroker{}
+	state := newFakeIngressState()
+	envelope := heartbeat.BuildEnvelope(1, mustTime(t, "2026-03-09T12:00:00Z"))
+	state.seen[envelope.Source] = map[string]bool{envelope.DedupeKey: true}
+	connector := &fakeAckingConnector{envelopes: []contracts.TaskEnvelope{envelope}}
+	runner, err := NewRunner(
+		handlerconfig.Defaults(),
+		broker,
+		&fakeEgressHandler{},
+		WithIngress(state, connector),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	published, err := runner.PublishIngress(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if published != 0 {
+		t.Fatalf("published = %d", published)
+	}
+	if len(broker.published) != 0 {
+		t.Fatalf("broker published = %#v", broker.published)
+	}
+	if got, want := connector.acked, []string{envelope.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("acked = %#v, want %#v", got, want)
+	}
+}
+
 func TestRunReturnsWhenContextIsCancelledDuringSleep(t *testing.T) {
 	broker := &fakeBroker{}
 	handler := &fakeEgressHandler{}
@@ -314,4 +374,18 @@ func mustTime(t *testing.T, raw string) time.Time {
 		t.Fatal(err)
 	}
 	return parsed
+}
+
+type fakeAckingConnector struct {
+	envelopes []contracts.TaskEnvelope
+	acked     []string
+}
+
+func (connector *fakeAckingConnector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	return connector.envelopes, nil
+}
+
+func (connector *fakeAckingConnector) AckEnvelope(ctx context.Context, envelopeID string) error {
+	connector.acked = append(connector.acked, envelopeID)
+	return nil
 }

--- a/tests/e2e/handler_selector.py
+++ b/tests/e2e/handler_selector.py
@@ -42,8 +42,10 @@ def message_handler_command(
             "--config",
             str(config_path),
         ]
-    raise NotImplementedError(
-        f"{HANDLER_IMPLEMENTATION_ENV}=go was selected, but the Go handler "
-        "drop-in E2E path is not implemented yet. This is intentional and "
-        "must not fall back to the Python handler."
-    )
+    return [
+        "sh",
+        "-c",
+        'cd go/handler && exec go run ./cmd/chatting-handler --config "$1"',
+        "chatting-handler",
+        str(config_path),
+    ]

--- a/tests/test_e2e_handler_selector.py
+++ b/tests/test_e2e_handler_selector.py
@@ -30,15 +30,22 @@ class E2EHandlerSelectorTests(unittest.TestCase):
             ],
         )
 
-    def test_go_selection_fails_clearly_until_e2e_path_exists(self) -> None:
-        with self.assertRaisesRegex(
-            NotImplementedError,
-            "Go handler drop-in E2E path is not implemented yet",
-        ):
-            message_handler_command(
-                Path("/tmp/handler.json"),
-                env={HANDLER_IMPLEMENTATION_ENV: "go"},
-            )
+    def test_go_handler_command_uses_go_entrypoint(self) -> None:
+        command = message_handler_command(
+            Path("/tmp/handler.json"),
+            env={HANDLER_IMPLEMENTATION_ENV: "go"},
+        )
+
+        self.assertEqual(
+            command,
+            [
+                "sh",
+                "-c",
+                'cd go/handler && exec go run ./cmd/chatting-handler --config "$1"',
+                "chatting-handler",
+                "/tmp/handler.json",
+            ],
+        )
 
     def test_unknown_handler_implementation_fails(self) -> None:
         with self.assertRaisesRegex(ValueError, HANDLER_IMPLEMENTATION_ENV):


### PR DESCRIPTION
## Summary
- add the Go auxiliary ingress connector for `chatting.auxiliary_ingress.v1` queue consumption
- wire auxiliary config keys and queue setup into the Go handler runtime
- let E2E selection launch the Go handler and mark the porting plan slice complete

## Validation
- `cd go/handler && go test ./...`
- `uv run python -m unittest tests.test_e2e_handler_selector tests.test_contract_fixtures`
- `CHATTING_E2E_HANDLER_IMPLEMENTATION=go CHATTING_BBMB_SERVER_BIN=/tmp/chatting-bbmb-server uv run python -m unittest tests.e2e.test_auxiliary_ingress_e2e`
