### PR TITLE
Add Go schedule connector

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -600,6 +600,12 @@ Validation:
 
 ### 11. Schedule Connector
 
+Status: complete. The Go handler now loads strict interval schedule files,
+rejects unknown or invalid job keys, evaluates five-field cron schedules in the
+configured timezone, publishes Python-compatible `cron` task envelopes with
+global/source/task prompt context, and participates in the existing
+Go-handler/Python-worker split-mode schedule smoke path.
+
 Implement interval schedule jobs.
 
 Validation:
@@ -703,5 +709,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add interval schedule connector support.
-2. Add basic Prometheus-style metrics for the Go runtime.
+1. Add basic Prometheus-style metrics for the Go runtime.
+2. Add SMTP dispatch.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -15,6 +15,7 @@ import (
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/auxiliary"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/schedule"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/egress"
 	handlerruntime "github.com/EdwardSalkeld/chatting/go/handler/internal/runtime"
@@ -101,6 +102,24 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		return nil, err
 	}
 	connectors := []handlerruntime.Connector{heartbeat.New(nil)}
+	if config.ScheduleFile != "" {
+		jobs, err := schedule.LoadJobs(config.ScheduleFile)
+		if err != nil {
+			_ = store.Close()
+			return nil, err
+		}
+		connector, err := schedule.New(
+			jobs,
+			config.GlobalPromptContext,
+			config.CronPromptContext,
+			nil,
+		)
+		if err != nil {
+			_ = store.Close()
+			return nil, err
+		}
+		connectors = append(connectors, connector)
+	}
 	auxiliaryAdapter := adapter
 	if config.AuxiliaryIngressEnabled {
 		auxiliaryAddress := config.AuxiliaryIngressBBMBAddress

--- a/go/handler/go.mod
+++ b/go/handler/go.mod
@@ -2,7 +2,10 @@ module github.com/EdwardSalkeld/chatting/go/handler
 
 go 1.25.0
 
-require modernc.org/sqlite v1.50.1
+require (
+	github.com/robfig/cron/v3 v3.0.1
+	modernc.org/sqlite v1.50.1
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go/handler/go.sum
+++ b/go/handler/go.sum
@@ -12,6 +12,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -33,6 +33,8 @@ var allowedKeys = map[string]bool{
 	"metrics_port":            true,
 	"allowed_egress_channels": true,
 	"global_prompt_context":   true,
+	"cron_prompt_context":     true,
+	"schedule_file":           true,
 
 	"auxiliary_ingress_enabled":      true,
 	"auxiliary_ingress_bbmb_address": true,
@@ -50,6 +52,8 @@ type Config struct {
 	MetricsPort           int
 	AllowedEgressChannels []string
 	GlobalPromptContext   []string
+	CronPromptContext     []string
+	ScheduleFile          string
 
 	AuxiliaryIngressEnabled     bool
 	AuxiliaryIngressBBMBAddress string
@@ -68,6 +72,8 @@ func Defaults() Config {
 		MetricsPort:           DefaultMetricsPort,
 		AllowedEgressChannels: []string{"email", "telegram", "telegram_reaction", "log"},
 		GlobalPromptContext:   []string{},
+		CronPromptContext:     []string{},
+		ScheduleFile:          "",
 
 		AuxiliaryIngressEnabled:     false,
 		AuxiliaryIngressBBMBAddress: "",
@@ -183,6 +189,18 @@ func Load(raw []byte) (Config, error) {
 	}
 	if rawValue, ok := payload["global_prompt_context"]; ok && !isNull(rawValue) {
 		config.GlobalPromptContext, err = decodeStringList(rawValue, "global_prompt_context")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["cron_prompt_context"]; ok && !isNull(rawValue) {
+		config.CronPromptContext, err = decodeStringList(rawValue, "cron_prompt_context")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["schedule_file"]; ok && !isNull(rawValue) {
+		config.ScheduleFile, err = decodeNonEmptyString(rawValue, "schedule_file")
 		if err != nil {
 			return Config{}, err
 		}

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -31,6 +31,8 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 		"metrics_port": 9555,
 		"allowed_egress_channels": ["log", "email"],
 		"global_prompt_context": ["Keep replies terse."],
+		"cron_prompt_context": ["This is a scheduled automation task."],
+		"schedule_file": "/tmp/schedule.json",
 		"auxiliary_ingress_enabled": true,
 		"auxiliary_ingress_bbmb_address": "10.0.0.2:9998",
 		"auxiliary_ingress_queues": ["generic-post"],
@@ -66,6 +68,12 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(config.GlobalPromptContext, []string{"Keep replies terse."}) {
 		t.Fatalf("GlobalPromptContext = %#v", config.GlobalPromptContext)
+	}
+	if !reflect.DeepEqual(config.CronPromptContext, []string{"This is a scheduled automation task."}) {
+		t.Fatalf("CronPromptContext = %#v", config.CronPromptContext)
+	}
+	if config.ScheduleFile != "/tmp/schedule.json" {
+		t.Fatalf("ScheduleFile = %q", config.ScheduleFile)
 	}
 	if !config.AuxiliaryIngressEnabled {
 		t.Fatal("AuxiliaryIngressEnabled = false")

--- a/go/handler/internal/connectors/schedule/schedule.go
+++ b/go/handler/internal/connectors/schedule/schedule.go
@@ -1,0 +1,349 @@
+package schedule
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+	_ "time/tzdata"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	"github.com/robfig/cron/v3"
+)
+
+const Source = "cron"
+
+var (
+	allowedJobKeys = map[string]bool{
+		"job_name":             true,
+		"content":              true,
+		"context_refs":         true,
+		"cron":                 true,
+		"prompt_context":       true,
+		"timezone":             true,
+		"reply_channel_type":   true,
+		"reply_channel_target": true,
+	}
+	requiredJobKeys = map[string]bool{
+		"content":  true,
+		"job_name": true,
+	}
+	cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+)
+
+type NowFunc func() time.Time
+
+type Job struct {
+	JobName            string
+	Content            string
+	ContextRefs        []string
+	Cron               string
+	PromptContext      []string
+	TimezoneName       string
+	ReplyChannelType   string
+	ReplyChannelTarget string
+	schedule           cron.Schedule
+	location           *time.Location
+}
+
+type Connector struct {
+	jobs                []Job
+	globalPromptContext []string
+	sourcePromptContext []string
+	now                 NowFunc
+	nextRunAtByJob      map[string]time.Time
+}
+
+func New(jobs []Job, globalPromptContext []string, sourcePromptContext []string, now NowFunc) (*Connector, error) {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	normalized := make([]Job, 0, len(jobs))
+	for _, job := range jobs {
+		prepared, err := prepareJob(job)
+		if err != nil {
+			return nil, err
+		}
+		normalized = append(normalized, prepared)
+	}
+	return &Connector{
+		jobs:                normalized,
+		globalPromptContext: append([]string{}, globalPromptContext...),
+		sourcePromptContext: append([]string{}, sourcePromptContext...),
+		now:                 now,
+		nextRunAtByJob:      map[string]time.Time{},
+	}, nil
+}
+
+func LoadJobs(path string) ([]Job, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("schedule file path must not be empty")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return LoadJobsJSON(raw)
+}
+
+func LoadJobsJSON(raw []byte) ([]Job, error) {
+	var payload []map[string]json.RawMessage
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		return nil, errors.New("schedule file must contain a JSON array")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return nil, errors.New("schedule file must contain a single JSON array")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+
+	jobs := make([]Job, 0, len(payload))
+	for index, rawJob := range payload {
+		unknownKeys := make([]string, 0)
+		for key := range rawJob {
+			if !allowedJobKeys[key] {
+				unknownKeys = append(unknownKeys, key)
+			}
+		}
+		if len(unknownKeys) > 0 {
+			sort.Strings(unknownKeys)
+			return nil, fmt.Errorf("schedule job at index %d contains unknown keys: %s", index, strings.Join(unknownKeys, ", "))
+		}
+		missingKeys := make([]string, 0)
+		for key := range requiredJobKeys {
+			if _, ok := rawJob[key]; !ok {
+				missingKeys = append(missingKeys, key)
+			}
+		}
+		if len(missingKeys) > 0 {
+			sort.Strings(missingKeys)
+			return nil, fmt.Errorf("schedule job at index %d is missing required keys: %s", index, strings.Join(missingKeys, ", "))
+		}
+
+		jobName, err := decodeNonEmptyString(rawJob["job_name"], fmt.Sprintf("schedule job at index %d job_name", index))
+		if err != nil {
+			return nil, err
+		}
+		content, err := decodeNonEmptyString(rawJob["content"], fmt.Sprintf("schedule job at index %d content", index))
+		if err != nil {
+			return nil, err
+		}
+		rawCron, ok := rawJob["cron"]
+		if !ok {
+			return nil, fmt.Errorf("schedule job at index %d cron must be a non-empty string", index)
+		}
+		cronExpression, err := decodeNonEmptyString(rawCron, fmt.Sprintf("schedule job at index %d cron", index))
+		if err != nil {
+			return nil, err
+		}
+		timezoneName := "UTC"
+		if rawTimezone, ok := rawJob["timezone"]; ok && !isNull(rawTimezone) {
+			timezoneName, err = decodeNonEmptyString(rawTimezone, fmt.Sprintf("schedule job at index %d timezone", index))
+			if err != nil {
+				return nil, err
+			}
+		}
+		contextRefs, err := decodeStringListOptional(rawJob, "context_refs", fmt.Sprintf("schedule job at index %d context_refs", index))
+		if err != nil {
+			return nil, err
+		}
+		promptContext, err := decodeStringListOptional(rawJob, "prompt_context", fmt.Sprintf("schedule job at index %d prompt_context", index))
+		if err != nil {
+			return nil, err
+		}
+		replyChannelType, err := decodeOptionalNonEmptyString(rawJob, "reply_channel_type", fmt.Sprintf("schedule job at index %d reply_channel_type", index))
+		if err != nil {
+			return nil, err
+		}
+		replyChannelTarget, err := decodeOptionalNonEmptyString(rawJob, "reply_channel_target", fmt.Sprintf("schedule job at index %d reply_channel_target", index))
+		if err != nil {
+			return nil, err
+		}
+		if (replyChannelType == "") != (replyChannelTarget == "") {
+			return nil, fmt.Errorf("schedule job at index %d reply_channel_type and reply_channel_target must be provided together", index)
+		}
+
+		job, err := prepareJob(Job{
+			JobName:            strings.TrimSpace(jobName),
+			Content:            strings.TrimSpace(content),
+			ContextRefs:        contextRefs,
+			Cron:               strings.TrimSpace(cronExpression),
+			PromptContext:      promptContext,
+			TimezoneName:       strings.TrimSpace(timezoneName),
+			ReplyChannelType:   strings.TrimSpace(replyChannelType),
+			ReplyChannelTarget: strings.TrimSpace(replyChannelTarget),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("schedule job at index %d %w", index, err)
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, nil
+}
+
+func (connector *Connector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	now := connector.now().UTC()
+	envelopes := []contracts.TaskEnvelope{}
+	for _, job := range connector.jobs {
+		nextRunAt, ok := connector.nextRunAtByJob[job.JobName]
+		if !ok {
+			nextRunAt = initialNextRunAt(job, now)
+		}
+		if now.Before(nextRunAt) {
+			connector.nextRunAtByJob[job.JobName] = nextRunAt
+			continue
+		}
+		eventID := "cron:" + job.JobName + ":" + pythonUTCISO(nextRunAt)
+		replyChannel := contracts.ReplyChannel{Type: "log", Target: job.JobName}
+		if job.ReplyChannelType != "" {
+			replyChannel = contracts.ReplyChannel{
+				Type:   job.ReplyChannelType,
+				Target: job.ReplyChannelTarget,
+			}
+		}
+		prompt := &contracts.PromptContext{
+			GlobalInstructions: append([]string{}, connector.globalPromptContext...),
+			SourceInstructions: append([]string{}, connector.sourcePromptContext...),
+			TaskInstructions:   append([]string{}, job.PromptContext...),
+		}
+		envelopes = append(envelopes, contracts.TaskEnvelope{
+			SchemaVersion: contracts.SchemaVersion,
+			ID:            eventID,
+			Source:        Source,
+			ReceivedAt:    contracts.NewTimestamp(now),
+			Actor:         nil,
+			Content:       job.Content,
+			Attachments:   []contracts.AttachmentRef{},
+			ContextRefs:   append([]string{}, job.ContextRefs...),
+			PromptContext: prompt,
+			ReplyChannel:  replyChannel,
+			DedupeKey:     eventID,
+		})
+		connector.nextRunAtByJob[job.JobName] = nextDueTime(job, now)
+	}
+	return envelopes, nil
+}
+
+func prepareJob(job Job) (Job, error) {
+	if strings.TrimSpace(job.JobName) == "" {
+		return Job{}, errors.New("job_name is required")
+	}
+	if strings.TrimSpace(job.Content) == "" {
+		return Job{}, errors.New("content is required")
+	}
+	if strings.TrimSpace(job.Cron) == "" {
+		return Job{}, errors.New("cron must be non-empty when provided")
+	}
+	locationName := strings.TrimSpace(job.TimezoneName)
+	if locationName == "" {
+		locationName = "UTC"
+	}
+	location, err := time.LoadLocation(locationName)
+	if err != nil {
+		return Job{}, fmt.Errorf("invalid timezone: %s", locationName)
+	}
+	parsedSchedule, err := parseCron(job.Cron)
+	if err != nil {
+		return Job{}, err
+	}
+	job.JobName = strings.TrimSpace(job.JobName)
+	job.Content = strings.TrimSpace(job.Content)
+	job.Cron = strings.TrimSpace(job.Cron)
+	job.TimezoneName = locationName
+	job.ContextRefs = append([]string{}, job.ContextRefs...)
+	job.PromptContext = append([]string{}, job.PromptContext...)
+	job.schedule = parsedSchedule
+	job.location = location
+	return job, nil
+}
+
+func parseCron(expression string) (cron.Schedule, error) {
+	if len(strings.Fields(expression)) != 5 {
+		return nil, errors.New("cron must contain exactly 5 fields")
+	}
+	parsed, err := cronParser.Parse(expression)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cron expression: %w", err)
+	}
+	return parsed, nil
+}
+
+func initialNextRunAt(job Job, now time.Time) time.Time {
+	localRef := now.UTC().In(job.location)
+	truncated := localRef.Truncate(time.Minute)
+	if matches(job, truncated) {
+		return truncated.UTC()
+	}
+	return job.schedule.Next(localRef).UTC()
+}
+
+func nextDueTime(job Job, now time.Time) time.Time {
+	return job.schedule.Next(now.UTC().In(job.location)).UTC()
+}
+
+func matches(job Job, candidate time.Time) bool {
+	before := candidate.Add(-time.Minute)
+	return job.schedule.Next(before).Equal(candidate)
+}
+
+func pythonUTCISO(value time.Time) string {
+	return strings.TrimSuffix(value.UTC().Format(time.RFC3339Nano), "Z") + "+00:00"
+}
+
+func decodeNonEmptyString(raw json.RawMessage, name string) (string, error) {
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", fmt.Errorf("%s must be a non-empty string", name)
+	}
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("%s must be a non-empty string", name)
+	}
+	return value, nil
+}
+
+func decodeOptionalNonEmptyString(rawJob map[string]json.RawMessage, key string, name string) (string, error) {
+	raw, ok := rawJob[key]
+	if !ok || isNull(raw) {
+		return "", nil
+	}
+	return decodeNonEmptyString(raw, name)
+}
+
+func decodeStringListOptional(rawJob map[string]json.RawMessage, key string, name string) ([]string, error) {
+	raw, ok := rawJob[key]
+	if !ok || isNull(raw) {
+		return []string{}, nil
+	}
+	var values []string
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("%s must be a list of non-empty strings", name)
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("%s must be a list of non-empty strings", name)
+		}
+	}
+	if values == nil {
+		return []string{}, nil
+	}
+	return values, nil
+}
+
+func isNull(raw json.RawMessage) bool {
+	return strings.TrimSpace(string(raw)) == "null"
+}

--- a/go/handler/internal/connectors/schedule/schedule_test.go
+++ b/go/handler/internal/connectors/schedule/schedule_test.go
@@ -1,0 +1,232 @@
+package schedule
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadJobsJSONAcceptsPythonSupportedKeys(t *testing.T) {
+	jobs, err := LoadJobsJSON([]byte(`[
+		{
+			"job_name": "daily-note",
+			"content": "Write the daily note",
+			"cron": "5 7 * * *",
+			"timezone": "Europe/London",
+			"context_refs": ["repo:/workspace/chatting"],
+			"prompt_context": ["Keep it terse."],
+			"reply_channel_type": "telegram",
+			"reply_channel_target": "8605042448"
+		}
+	]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %#v", jobs)
+	}
+	job := jobs[0]
+	if job.JobName != "daily-note" {
+		t.Fatalf("JobName = %q", job.JobName)
+	}
+	if job.Content != "Write the daily note" {
+		t.Fatalf("Content = %q", job.Content)
+	}
+	if job.TimezoneName != "Europe/London" {
+		t.Fatalf("TimezoneName = %q", job.TimezoneName)
+	}
+	if got := strings.Join(job.ContextRefs, ","); got != "repo:/workspace/chatting" {
+		t.Fatalf("ContextRefs = %#v", job.ContextRefs)
+	}
+	if got := strings.Join(job.PromptContext, ","); got != "Keep it terse." {
+		t.Fatalf("PromptContext = %#v", job.PromptContext)
+	}
+	if job.ReplyChannelType != "telegram" || job.ReplyChannelTarget != "8605042448" {
+		t.Fatalf("reply channel = %#v", job)
+	}
+}
+
+func TestLoadJobsJSONRejectsUnknownKeys(t *testing.T) {
+	_, err := LoadJobsJSON([]byte(`[
+		{
+			"job_name": "daily-note",
+			"content": "Write the daily note",
+			"cron": "5 7 * * *",
+			"surprise": true
+		}
+	]`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "schedule job at index 0 contains unknown keys: surprise") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestLoadJobsJSONRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		message string
+	}{
+		{
+			name:    "missing content",
+			raw:     `[{"job_name": "daily-note", "cron": "5 7 * * *"}]`,
+			message: "schedule job at index 0 is missing required keys: content",
+		},
+		{
+			name:    "blank cron",
+			raw:     `[{"job_name": "daily-note", "content": "Write", "cron": "  "}]`,
+			message: "schedule job at index 0 cron must be a non-empty string",
+		},
+		{
+			name:    "six field cron",
+			raw:     `[{"job_name": "daily-note", "content": "Write", "cron": "0 5 7 * * *"}]`,
+			message: "schedule job at index 0 cron must contain exactly 5 fields",
+		},
+		{
+			name:    "invalid timezone",
+			raw:     `[{"job_name": "daily-note", "content": "Write", "cron": "5 7 * * *", "timezone": "Mars/Base"}]`,
+			message: "schedule job at index 0 invalid timezone: Mars/Base",
+		},
+		{
+			name:    "bad context refs",
+			raw:     `[{"job_name": "daily-note", "content": "Write", "cron": "5 7 * * *", "context_refs": [""]}]`,
+			message: "schedule job at index 0 context_refs must be a list of non-empty strings",
+		},
+		{
+			name:    "partial reply channel",
+			raw:     `[{"job_name": "daily-note", "content": "Write", "cron": "5 7 * * *", "reply_channel_type": "log"}]`,
+			message: "schedule job at index 0 reply_channel_type and reply_channel_target must be provided together",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadJobsJSON([]byte(tt.raw))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.message) {
+				t.Fatalf("error = %v, want %q", err, tt.message)
+			}
+		})
+	}
+}
+
+func TestPollEmitsDueJobWithPromptContextAndRefs(t *testing.T) {
+	now := mustTime(t, "2026-03-09T12:34:56Z")
+	connector, err := New(
+		[]Job{
+			{
+				JobName:       "daily-note",
+				Content:       "Write the daily note",
+				Cron:          "34 12 * * *",
+				ContextRefs:   []string{"repo:/workspace/chatting"},
+				PromptContext: []string{"Keep it terse."},
+			},
+		},
+		[]string{"Global guidance."},
+		[]string{"Scheduled task guidance."},
+		func() time.Time { return now },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	envelope := envelopes[0]
+	if envelope.ID != "cron:daily-note:2026-03-09T12:34:00+00:00" {
+		t.Fatalf("ID = %q", envelope.ID)
+	}
+	if envelope.Source != Source {
+		t.Fatalf("Source = %q", envelope.Source)
+	}
+	if envelope.ReceivedAt.Time != now.UTC() {
+		t.Fatalf("ReceivedAt = %s", envelope.ReceivedAt.Time)
+	}
+	if envelope.Content != "Write the daily note" {
+		t.Fatalf("Content = %q", envelope.Content)
+	}
+	if got := strings.Join(envelope.ContextRefs, ","); got != "repo:/workspace/chatting" {
+		t.Fatalf("ContextRefs = %#v", envelope.ContextRefs)
+	}
+	if envelope.ReplyChannel.Type != "log" || envelope.ReplyChannel.Target != "daily-note" {
+		t.Fatalf("ReplyChannel = %#v", envelope.ReplyChannel)
+	}
+	if envelope.DedupeKey != envelope.ID {
+		t.Fatalf("DedupeKey = %q", envelope.DedupeKey)
+	}
+	if envelope.PromptContext == nil {
+		t.Fatal("PromptContext = nil")
+	}
+	if got := strings.Join(envelope.PromptContext.GlobalInstructions, ","); got != "Global guidance." {
+		t.Fatalf("GlobalInstructions = %#v", envelope.PromptContext.GlobalInstructions)
+	}
+	if got := strings.Join(envelope.PromptContext.SourceInstructions, ","); got != "Scheduled task guidance." {
+		t.Fatalf("SourceInstructions = %#v", envelope.PromptContext.SourceInstructions)
+	}
+	if got := strings.Join(envelope.PromptContext.TaskInstructions, ","); got != "Keep it terse." {
+		t.Fatalf("TaskInstructions = %#v", envelope.PromptContext.TaskInstructions)
+	}
+
+	envelopes, err = connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(envelopes) != 0 {
+		t.Fatalf("second poll envelopes = %#v", envelopes)
+	}
+}
+
+func TestPollUsesConfiguredTimezoneAndReplyChannel(t *testing.T) {
+	connector, err := New(
+		[]Job{
+			{
+				JobName:            "morning",
+				Content:            "Morning note",
+				Cron:               "5 7 * * *",
+				TimezoneName:       "Europe/London",
+				ReplyChannelType:   "telegram",
+				ReplyChannelTarget: "8605042448",
+			},
+		},
+		nil,
+		nil,
+		func() time.Time { return mustTime(t, "2026-07-01T06:05:30Z") },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	if envelopes[0].ID != "cron:morning:2026-07-01T06:05:00+00:00" {
+		t.Fatalf("ID = %q", envelopes[0].ID)
+	}
+	if envelopes[0].ReplyChannel.Type != "telegram" || envelopes[0].ReplyChannel.Target != "8605042448" {
+		t.Fatalf("ReplyChannel = %#v", envelopes[0].ReplyChannel)
+	}
+}
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}


### PR DESCRIPTION
## Summary

- add Go `internal/connectors/schedule` for strict schedule JSON parsing and cron task envelopes
- wire `schedule_file` and `cron_prompt_context` through Go config/runtime startup
- update the Go handler port plan to mark schedule connector complete

## Validation

- `go test ./...`
- `test -z "$(gofmt -l .)"`
- `uv run python -m unittest tests.test_main_github_ingress.MainGitHubIngressTests tests.test_connectors.IntervalScheduleConnectorTests`
- `CHATTING_E2E_HANDLER_IMPLEMENTATION=go uv run python -m unittest tests.test_split_mode_e2e` (skipped locally because `CHATTING_BBMB_SERVER_BIN` is not set)
