### PR TITLE
Add Go handler metrics endpoint

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -616,6 +616,12 @@ Validation:
 
 ### 12. Metrics Endpoint
 
+Status: complete. The Go handler now starts a Prometheus-style `/metrics`
+server from the existing `metrics_host`/`metrics_port` config, tracks runtime
+loop and ingress-publish counters, records egress result counters from the
+egress engine, and renders the current Python metric names with zeroed
+placeholders for connectors not ported yet.
+
 Implement basic Prometheus-style handler metrics.
 
 Validation:
@@ -709,5 +715,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add basic Prometheus-style metrics for the Go runtime.
-2. Add SMTP dispatch.
+1. Add SMTP dispatch.
+2. Add IMAP ingress.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
@@ -18,6 +19,7 @@ import (
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/schedule"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/egress"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/metrics"
 	handlerruntime "github.com/EdwardSalkeld/chatting/go/handler/internal/runtime"
 	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
 )
@@ -152,15 +154,25 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 			connectors = append(connectors, connector)
 		}
 	}
-	runner, err := handlerruntime.NewRunner(config, adapter, egressHandlerFunc(func(ctx context.Context, raw []byte) error {
-		_, err := engine.HandleRaw(ctx, raw)
-		return err
-	}), handlerruntime.WithIngress(store, connectors...))
+	metricRecorder := metrics.New(time.Time{}, nil)
+	metricsServer, err := metrics.StartServer(metricRecorder, config.MetricsHost, config.MetricsPort)
 	if err != nil {
 		_ = store.Close()
 		return nil, err
 	}
-	return &closingRunner{runner: runner, closer: store}, nil
+	runner, err := handlerruntime.NewRunner(config, adapter, egressHandlerFunc(func(ctx context.Context, raw []byte) error {
+		result, err := engine.HandleRaw(ctx, raw)
+		if err == nil {
+			metricRecorder.RecordEgressResult(result.Status, result.Reason)
+		}
+		return err
+	}), handlerruntime.WithIngress(store, connectors...), handlerruntime.WithMetrics(metricRecorder))
+	if err != nil {
+		_ = metricsServer.Close()
+		_ = store.Close()
+		return nil, err
+	}
+	return &closingRunner{runner: runner, closers: []closer{metricsServer, store}}, nil
 }
 
 type egressHandlerFunc func(context.Context, []byte) error
@@ -183,11 +195,15 @@ type closer interface {
 }
 
 type closingRunner struct {
-	runner runner
-	closer closer
+	runner  runner
+	closers []closer
 }
 
 func (runner *closingRunner) Run(ctx context.Context) error {
-	defer runner.closer.Close()
+	defer func() {
+		for _, closer := range runner.closers {
+			_ = closer.Close()
+		}
+	}()
 	return runner.runner.Run(ctx)
 }

--- a/go/handler/internal/metrics/metrics.go
+++ b/go/handler/internal/metrics/metrics.go
@@ -1,0 +1,285 @@
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Clock interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now().UTC()
+}
+
+func (realClock) Since(start time.Time) time.Duration {
+	return time.Since(start)
+}
+
+type Recorder struct {
+	mu                sync.Mutex
+	clock             Clock
+	startedAt         time.Time
+	loopsTotal        int64
+	ingressPublished  int64
+	egressLoopsTotal  int64
+	egressReceived    int64
+	egressDispatched  int64
+	egressDeduped     int64
+	egressDropped     int64
+	egressDroppedBy   map[string]int64
+	egressIncremental int64
+	egressMessage     int64
+	egressCompletion  int64
+	lastLoopAt        time.Time
+	lastEgressLoopAt  time.Time
+}
+
+func New(startedAt time.Time, clock Clock) *Recorder {
+	if clock == nil {
+		clock = realClock{}
+	}
+	if startedAt.IsZero() {
+		startedAt = clock.Now()
+	}
+	return &Recorder{
+		clock:           clock,
+		startedAt:       startedAt.UTC(),
+		egressDroppedBy: map[string]int64{},
+	}
+}
+
+func (recorder *Recorder) RecordLoop(ingressPublished int, completedAt time.Time) {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	recorder.loopsTotal++
+	recorder.ingressPublished += int64(ingressPublished)
+	recorder.lastLoopAt = normalizeTime(completedAt)
+}
+
+func (recorder *Recorder) RecordEgressLoop(completedAt time.Time) {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	recorder.egressLoopsTotal++
+	recorder.lastEgressLoopAt = normalizeTime(completedAt)
+}
+
+func (recorder *Recorder) RecordEgressResult(status string, reason string) {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	recorder.egressReceived++
+	switch status {
+	case "dispatched":
+		recorder.egressDispatched++
+		recorder.egressIncremental++
+		recorder.egressMessage++
+	case "completed":
+		recorder.egressDispatched++
+		recorder.egressIncremental++
+		recorder.egressCompletion++
+	case "deduped":
+		recorder.egressDeduped++
+	case "dropped":
+		recorder.egressDropped++
+		if reason != "" {
+			recorder.egressDroppedBy[reason]++
+		}
+	}
+}
+
+func (recorder *Recorder) Snapshot() map[string]float64 {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	dedupeRate := 0.0
+	if recorder.egressReceived > 0 {
+		dedupeRate = (float64(recorder.egressDeduped) / float64(recorder.egressReceived)) * 100
+	}
+
+	return map[string]float64{
+		"uptime_seconds":                                    recorder.clock.Since(recorder.startedAt).Seconds(),
+		"process_start_time_seconds":                        float64(recorder.startedAt.UnixNano()) / float64(time.Second),
+		"loops_total":                                       float64(recorder.loopsTotal),
+		"ingress_published_total":                           float64(recorder.ingressPublished),
+		"github_scanned_events_total":                       0,
+		"github_new_events_total":                           0,
+		"github_published_total":                            0,
+		"telegram_attachment_cleanup_deleted_total":         0,
+		"telegram_attachment_cleanup_missing_total":         0,
+		"telegram_attachment_cleanup_failed_total":          0,
+		"telegram_attachment_cleanup_reclaimed_bytes_total": 0,
+		"last_loop_completed_timestamp_seconds":             unixTimestamp(recorder.lastLoopAt),
+		"egress_loops_total":                                float64(recorder.egressLoopsTotal),
+		"last_egress_loop_completed_timestamp_seconds":      unixTimestamp(recorder.lastEgressLoopAt),
+		"received_total":                                    float64(recorder.egressReceived),
+		"dispatched_total":                                  float64(recorder.egressDispatched),
+		"deduped_total":                                     float64(recorder.egressDeduped),
+		"dedupe_hit_rate_pct":                               dedupeRate,
+		"dropped_total":                                     float64(recorder.egressDropped),
+		"dropped_unknown_task_total":                        float64(recorder.egressDroppedBy["unknown_task"]),
+		"dropped_completed_task_total":                      float64(recorder.egressDroppedBy["completed_task"]),
+		"dropped_disallowed_channel_total":                  float64(recorder.egressDroppedBy["disallowed_channel"]),
+		"dropped_missing_event_id_total":                    float64(recorder.egressDroppedBy["missing_event_id"]),
+		"incremental_dispatched_total":                      float64(recorder.egressIncremental),
+		"message_dispatched_total":                          float64(recorder.egressMessage),
+		"completion_applied_total":                          float64(recorder.egressCompletion),
+		"dispatch_latency_ms_avg":                           0,
+		"dispatch_latency_ms_max":                           0,
+	}
+}
+
+func RenderPrometheus(snapshot map[string]float64) string {
+	var builder strings.Builder
+	for _, definition := range definitions {
+		builder.WriteString("# HELP ")
+		builder.WriteString(definition.name)
+		builder.WriteByte(' ')
+		builder.WriteString(definition.help)
+		builder.WriteByte('\n')
+		builder.WriteString("# TYPE ")
+		builder.WriteString(definition.name)
+		builder.WriteByte(' ')
+		builder.WriteString(definition.kind)
+		builder.WriteByte('\n')
+		builder.WriteString(definition.name)
+		builder.WriteByte(' ')
+		builder.WriteString(formatValue(snapshot[definition.key]))
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}
+
+type Server struct {
+	server *http.Server
+	done   chan struct{}
+	addr   string
+}
+
+func StartServer(recorder *Recorder, host string, port int) (*Server, error) {
+	if recorder == nil {
+		return nil, fmt.Errorf("metrics recorder is required")
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics", func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet {
+			writer.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		payload := []byte(RenderPrometheus(recorder.Snapshot()))
+		writer.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		writer.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write(payload)
+	})
+	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	})
+
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		return nil, err
+	}
+	server := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			return
+		}
+	}()
+	return &Server{server: server, done: done, addr: listener.Addr().String()}, nil
+}
+
+func (server *Server) Addr() string {
+	if server == nil {
+		return ""
+	}
+	return server.addr
+}
+
+func (server *Server) Close() error {
+	if server == nil || server.server == nil {
+		return nil
+	}
+	err := server.server.Close()
+	<-server.done
+	return err
+}
+
+func normalizeTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Time{}
+	}
+	return value.UTC()
+}
+
+func unixTimestamp(value time.Time) float64 {
+	if value.IsZero() {
+		return 0
+	}
+	return float64(value.UnixNano()) / float64(time.Second)
+}
+
+func formatValue(value float64) string {
+	if value == float64(int64(value)) {
+		return strconv.FormatInt(int64(value), 10)
+	}
+	return strconv.FormatFloat(value, 'f', 6, 64)
+}
+
+type metricDefinition struct {
+	name string
+	kind string
+	help string
+	key  string
+}
+
+var definitions = []metricDefinition{
+	{"chatting_message_handler_uptime_seconds", "gauge", "Seconds since the message handler process started.", "uptime_seconds"},
+	{"chatting_message_handler_process_start_time_seconds", "gauge", "Unix timestamp when the message handler process started.", "process_start_time_seconds"},
+	{"chatting_message_handler_loops_total", "counter", "Completed message handler loops.", "loops_total"},
+	{"chatting_message_handler_ingress_published_total", "counter", "Tasks published to the worker ingress queue.", "ingress_published_total"},
+	{"chatting_message_handler_github_scanned_events_total", "counter", "GitHub assignment events scanned by the handler.", "github_scanned_events_total"},
+	{"chatting_message_handler_github_new_events_total", "counter", "New GitHub assignment events discovered after checkpointing.", "github_new_events_total"},
+	{"chatting_message_handler_github_published_total", "counter", "GitHub assignment events published as tasks.", "github_published_total"},
+	{"chatting_message_handler_telegram_attachment_cleanup_deleted_total", "counter", "Telegram attachment files deleted by handler-managed cleanup.", "telegram_attachment_cleanup_deleted_total"},
+	{"chatting_message_handler_telegram_attachment_cleanup_missing_total", "counter", "Tracked Telegram attachment files already missing from disk during cleanup.", "telegram_attachment_cleanup_missing_total"},
+	{"chatting_message_handler_telegram_attachment_cleanup_failed_total", "counter", "Telegram attachment cleanup attempts that failed.", "telegram_attachment_cleanup_failed_total"},
+	{"chatting_message_handler_telegram_attachment_cleanup_reclaimed_bytes_total", "counter", "Bytes reclaimed by Telegram attachment cleanup.", "telegram_attachment_cleanup_reclaimed_bytes_total"},
+	{"chatting_message_handler_last_loop_completed_timestamp_seconds", "gauge", "Unix timestamp of the most recently completed loop.", "last_loop_completed_timestamp_seconds"},
+	{"chatting_message_handler_egress_loops_total", "counter", "Completed egress polling loops.", "egress_loops_total"},
+	{"chatting_message_handler_last_egress_loop_completed_timestamp_seconds", "gauge", "Unix timestamp of the most recently completed egress loop.", "last_egress_loop_completed_timestamp_seconds"},
+	{"chatting_message_handler_egress_received_total", "counter", "Egress messages received from the broker.", "received_total"},
+	{"chatting_message_handler_egress_dispatched_total", "counter", "Egress events applied by the message-handler.", "dispatched_total"},
+	{"chatting_message_handler_egress_deduped_total", "counter", "Egress messages skipped due to deduplication.", "deduped_total"},
+	{"chatting_message_handler_egress_dedupe_hit_rate_pct", "gauge", "Percentage of handled egress events skipped by dedupe.", "dedupe_hit_rate_pct"},
+	{"chatting_message_handler_egress_dropped_total", "counter", "Egress messages dropped before dispatch.", "dropped_total"},
+	{"chatting_message_handler_egress_dropped_unknown_task_total", "counter", "Egress messages dropped because the task ledger entry was missing.", "dropped_unknown_task_total"},
+	{"chatting_message_handler_egress_dropped_completed_task_total", "counter", "Egress messages dropped because the task was already completed.", "dropped_completed_task_total"},
+	{"chatting_message_handler_egress_dropped_disallowed_channel_total", "counter", "Egress messages dropped because the channel is not allowed.", "dropped_disallowed_channel_total"},
+	{"chatting_message_handler_egress_dropped_missing_event_id_total", "counter", "Egress messages dropped because they had no event id.", "dropped_missing_event_id_total"},
+	{"chatting_message_handler_egress_incremental_dispatched_total", "counter", "Incremental egress events dispatched in order.", "incremental_dispatched_total"},
+	{"chatting_message_handler_egress_message_dispatched_total", "counter", "Task-scoped visible egress messages dispatched in order.", "message_dispatched_total"},
+	{"chatting_message_handler_egress_completion_applied_total", "counter", "Internal completion events applied in order.", "completion_applied_total"},
+	{"chatting_message_handler_egress_dispatch_latency_ms_avg", "gauge", "Average egress dispatch latency in milliseconds.", "dispatch_latency_ms_avg"},
+	{"chatting_message_handler_egress_dispatch_latency_ms_max", "gauge", "Maximum egress dispatch latency in milliseconds.", "dispatch_latency_ms_max"},
+}
+
+func MetricNames() []string {
+	names := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		names = append(names, definition.name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/go/handler/internal/metrics/metrics_test.go
+++ b/go/handler/internal/metrics/metrics_test.go
@@ -1,0 +1,119 @@
+package metrics
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRecorderSnapshotAndPrometheusRendering(t *testing.T) {
+	clock := &fakeClock{
+		now: mustTime(t, "2026-03-09T12:00:10Z"),
+	}
+	recorder := New(mustTime(t, "2026-03-09T12:00:00Z"), clock)
+
+	recorder.RecordLoop(2, mustTime(t, "2026-03-09T12:00:04Z"))
+	recorder.RecordEgressLoop(mustTime(t, "2026-03-09T12:00:05Z"))
+	recorder.RecordEgressResult("dispatched", "")
+	recorder.RecordEgressResult("completed", "")
+	recorder.RecordEgressResult("deduped", "")
+	recorder.RecordEgressResult("dropped", "unknown_task")
+
+	snapshot := recorder.Snapshot()
+	if snapshot["loops_total"] != 1 {
+		t.Fatalf("loops_total = %v", snapshot["loops_total"])
+	}
+	if snapshot["ingress_published_total"] != 2 {
+		t.Fatalf("ingress_published_total = %v", snapshot["ingress_published_total"])
+	}
+	if snapshot["received_total"] != 4 {
+		t.Fatalf("received_total = %v", snapshot["received_total"])
+	}
+	if snapshot["dispatched_total"] != 2 {
+		t.Fatalf("dispatched_total = %v", snapshot["dispatched_total"])
+	}
+	if snapshot["deduped_total"] != 1 {
+		t.Fatalf("deduped_total = %v", snapshot["deduped_total"])
+	}
+	if snapshot["dropped_unknown_task_total"] != 1 {
+		t.Fatalf("dropped_unknown_task_total = %v", snapshot["dropped_unknown_task_total"])
+	}
+	if snapshot["dedupe_hit_rate_pct"] != 25 {
+		t.Fatalf("dedupe_hit_rate_pct = %v", snapshot["dedupe_hit_rate_pct"])
+	}
+
+	rendered := RenderPrometheus(snapshot)
+	for _, expected := range []string{
+		"# TYPE chatting_message_handler_loops_total counter",
+		"chatting_message_handler_ingress_published_total 2",
+		"chatting_message_handler_egress_received_total 4",
+		"chatting_message_handler_egress_dedupe_hit_rate_pct 25",
+		"chatting_message_handler_egress_dropped_unknown_task_total 1",
+	} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("rendered metrics missing %q:\n%s", expected, rendered)
+		}
+	}
+}
+
+func TestMetricsServerServesMetricsAnd404sOtherPaths(t *testing.T) {
+	recorder := New(mustTime(t, "2026-03-09T12:00:00Z"), &fakeClock{now: mustTime(t, "2026-03-09T12:00:01Z")})
+	recorder.RecordLoop(1, mustTime(t, "2026-03-09T12:00:01Z"))
+
+	server, err := StartServer(recorder, "127.0.0.1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	response, err := http.Get("http://" + server.Addr() + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s", response.StatusCode, string(body))
+	}
+	if contentType := response.Header.Get("Content-Type"); contentType != "text/plain; version=0.0.4; charset=utf-8" {
+		t.Fatalf("content type = %q", contentType)
+	}
+	if !strings.Contains(string(body), "chatting_message_handler_loops_total 1") {
+		t.Fatalf("body = %s", string(body))
+	}
+
+	notFound, err := http.Get("http://" + server.Addr() + "/nope")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer notFound.Body.Close()
+	if notFound.StatusCode != http.StatusNotFound {
+		t.Fatalf("not found status = %d", notFound.StatusCode)
+	}
+}
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (clock *fakeClock) Now() time.Time {
+	return clock.now
+}
+
+func (clock *fakeClock) Since(start time.Time) time.Duration {
+	return clock.now.Sub(start)
+}
+
+func mustTime(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -10,6 +10,7 @@ import (
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/metrics"
 )
 
 const (
@@ -51,6 +52,7 @@ type Runner struct {
 	egress       EgressHandler
 	ingressState IngressState
 	connectors   []Connector
+	metrics      *metrics.Recorder
 	now          func() time.Time
 	sleep        func(context.Context, time.Duration) error
 }
@@ -69,6 +71,12 @@ func WithNow(now func() time.Time) Option {
 		if now != nil {
 			runner.now = now
 		}
+	}
+}
+
+func WithMetrics(recorder *metrics.Recorder) Option {
+	return func(runner *Runner) {
+		runner.metrics = recorder
 	}
 }
 
@@ -117,11 +125,15 @@ func (runner *Runner) Run(ctx context.Context) error {
 			return nil
 		}
 		loopCount++
-		if _, err := runner.PublishIngress(ctx); err != nil {
+		published, err := runner.PublishIngress(ctx)
+		if err != nil {
 			return err
 		}
 		if _, err := runner.DrainEgress(ctx); err != nil {
 			return err
+		}
+		if runner.metrics != nil {
+			runner.metrics.RecordLoop(published, runner.now())
 		}
 		if runner.config.MaxLoops > 0 && loopCount >= runner.config.MaxLoops {
 			return nil
@@ -202,6 +214,9 @@ func (runner *Runner) DrainEgress(ctx context.Context) (int, error) {
 			return drained, err
 		}
 		if picked == nil {
+			if runner.metrics != nil {
+				runner.metrics.RecordEgressLoop(runner.now())
+			}
 			return drained, nil
 		}
 		raw, err := json.Marshal(picked.Payload)

--- a/go/handler/internal/runtime/runtime_test.go
+++ b/go/handler/internal/runtime/runtime_test.go
@@ -12,6 +12,7 @@ import (
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/metrics"
 )
 
 func TestRunEnsuresQueuesAndExitsAfterMaxLoops(t *testing.T) {
@@ -275,6 +276,46 @@ func TestRunReturnsWhenContextIsCancelledDuringSleep(t *testing.T) {
 	}
 }
 
+func TestRunRecordsLoopAndEgressMetrics(t *testing.T) {
+	broker := &fakeBroker{
+		picked: []*bbmb.PickedMessage{
+			{GUID: "guid-1", Payload: map[string]any{"message_type": "chatting.egress.v2", "task_id": "task:1"}},
+		},
+	}
+	handler := &fakeEgressHandler{}
+	recorder := metrics.New(mustTime(t, "2026-03-09T12:00:00Z"), &fakeMetricsClock{now: mustTime(t, "2026-03-09T12:00:03Z")})
+	config := handlerconfig.Defaults()
+	config.MaxLoops = 1
+	config.PollIntervalSeconds = 100
+	runner, err := NewRunner(
+		config,
+		broker,
+		handler,
+		WithMetrics(recorder),
+		WithNow(func() time.Time {
+			return mustTime(t, "2026-03-09T12:00:02Z")
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runner.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := recorder.Snapshot()
+	if snapshot["loops_total"] != 1 {
+		t.Fatalf("loops_total = %v", snapshot["loops_total"])
+	}
+	if snapshot["egress_loops_total"] != 1 {
+		t.Fatalf("egress_loops_total = %v", snapshot["egress_loops_total"])
+	}
+	if snapshot["last_loop_completed_timestamp_seconds"] != float64(mustTime(t, "2026-03-09T12:00:02Z").Unix()) {
+		t.Fatalf("last_loop_completed_timestamp_seconds = %v", snapshot["last_loop_completed_timestamp_seconds"])
+	}
+}
+
 type pickupCall struct {
 	queue          string
 	timeoutSeconds int
@@ -388,4 +429,16 @@ func (connector *fakeAckingConnector) Poll(ctx context.Context) ([]contracts.Tas
 func (connector *fakeAckingConnector) AckEnvelope(ctx context.Context, envelopeID string) error {
 	connector.acked = append(connector.acked, envelopeID)
 	return nil
+}
+
+type fakeMetricsClock struct {
+	now time.Time
+}
+
+func (clock *fakeMetricsClock) Now() time.Time {
+	return clock.now
+}
+
+func (clock *fakeMetricsClock) Since(start time.Time) time.Duration {
+	return clock.now.Sub(start)
 }


### PR DESCRIPTION
## Summary

- add a Go handler metrics recorder and Prometheus text renderer using the existing Python metric names
- start the Go /metrics HTTP endpoint from metrics_host/metrics_port during runtime bootstrap
- wire runtime loop/ingress counters and egress engine result counters into the recorder
- update the Go porting plan so SMTP dispatch is next

## Tests

- go test ./... (from go/handler)
- gofmt -l .
- uv run python -m unittest tests.test_message_handler_runtime tests.test_main_github_ingress
- CHATTING_E2E_HANDLER_IMPLEMENTATION=go uv run python -m unittest tests.e2e.test_auxiliary_ingress_e2e -v (skipped locally: CHATTING_BBMB_SERVER_BIN is not set)
