### PR TITLE
Add Go handler SMTP dispatch

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -631,6 +631,11 @@ Validation:
 
 ### 13. SMTP Dispatch
 
+Status: complete. The Go handler now accepts the Python handler SMTP config keys,
+wires an SMTP-backed email sender into the egress dispatcher, preserves reply
+subject/body formatting for email-originated tasks, and treats unconfigured email
+dispatch as a dropped/no-op dispatch like the Python applier.
+
 Implement email dispatch.
 
 Validation:

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -18,6 +17,7 @@ import (
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/schedule"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/dispatch"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/egress"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/metrics"
 	handlerruntime "github.com/EdwardSalkeld/chatting/go/handler/internal/runtime"
@@ -94,9 +94,14 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 	if err != nil {
 		return nil, err
 	}
+	dispatcher, err := buildDispatcher(config)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
 	engine, err := egress.New(
 		egress.NewSQLiteState(store),
-		unsupportedDispatcher{},
+		dispatcher,
 		egress.WithAllowedChannels(config.AllowedEgressChannels),
 	)
 	if err != nil {
@@ -175,6 +180,33 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 	return &closingRunner{runner: runner, closers: []closer{metricsServer, store}}, nil
 }
 
+func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, error) {
+	if config.SMTPHost == "" {
+		return dispatch.Dispatcher{}, nil
+	}
+	password := ""
+	if config.SMTPUsername != "" {
+		password = os.Getenv(config.SMTPPasswordEnv)
+		if password == "" {
+			return nil, fmt.Errorf("missing SMTP password env var: %s", config.SMTPPasswordEnv)
+		}
+	}
+	sender, err := dispatch.NewSMTPEmailSender(dispatch.SMTPConfig{
+		Host:        config.SMTPHost,
+		Port:        config.SMTPPort,
+		FromAddress: config.SMTPFrom,
+		Username:    config.SMTPUsername,
+		Password:    password,
+		UseSSL:      config.SMTPUseSSL,
+		StartTLS:    config.SMTPStartTLS,
+		Timeout:     10 * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dispatch.Dispatcher{EmailSender: sender}, nil
+}
+
 type egressHandlerFunc func(context.Context, []byte) error
 
 func (fn egressHandlerFunc) HandleRaw(ctx context.Context, raw []byte) error {
@@ -184,10 +216,7 @@ func (fn egressHandlerFunc) HandleRaw(ctx context.Context, raw []byte) error {
 type unsupportedDispatcher struct{}
 
 func (unsupportedDispatcher) Dispatch(ctx context.Context, message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (*contracts.OutboundMessage, error) {
-	if heartbeat.IsLogPong(message, envelope) {
-		return &message, nil
-	}
-	return nil, errors.New("dispatch is not implemented in the Go handler yet")
+	return dispatch.Dispatcher{}.Dispatch(ctx, message, envelope)
 }
 
 type closer interface {

--- a/go/handler/cmd/chatting-handler/main_test.go
+++ b/go/handler/cmd/chatting-handler/main_test.go
@@ -158,6 +158,23 @@ func TestUnsupportedDispatcherAcceptsInternalHeartbeatLogPong(t *testing.T) {
 	}
 }
 
+func TestBuildDispatcherRequiresSMTPPasswordEnvWhenUsernameConfigured(t *testing.T) {
+	t.Setenv("MISSING_SMTP_PASSWORD", "")
+	_, err := buildDispatcher(handlerconfig.Config{
+		SMTPHost:        "smtp.example.com",
+		SMTPPort:        587,
+		SMTPUsername:    "bot@example.com",
+		SMTPPasswordEnv: "MISSING_SMTP_PASSWORD",
+		SMTPFrom:        "bot@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "missing SMTP password env var: MISSING_SMTP_PASSWORD") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 type fakeRunnerFactory struct {
 	called bool
 	config handlerconfig.Config

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -35,6 +35,13 @@ var allowedKeys = map[string]bool{
 	"global_prompt_context":   true,
 	"cron_prompt_context":     true,
 	"schedule_file":           true,
+	"smtp_host":               true,
+	"smtp_port":               true,
+	"smtp_username":           true,
+	"smtp_password_env":       true,
+	"smtp_from":               true,
+	"smtp_starttls":           true,
+	"smtp_use_ssl":            true,
 
 	"auxiliary_ingress_enabled":      true,
 	"auxiliary_ingress_bbmb_address": true,
@@ -54,6 +61,13 @@ type Config struct {
 	GlobalPromptContext   []string
 	CronPromptContext     []string
 	ScheduleFile          string
+	SMTPHost              string
+	SMTPPort              int
+	SMTPUsername          string
+	SMTPPasswordEnv       string
+	SMTPFrom              string
+	SMTPStartTLS          bool
+	SMTPUseSSL            bool
 
 	AuxiliaryIngressEnabled     bool
 	AuxiliaryIngressBBMBAddress string
@@ -74,6 +88,13 @@ func Defaults() Config {
 		GlobalPromptContext:   []string{},
 		CronPromptContext:     []string{},
 		ScheduleFile:          "",
+		SMTPHost:              "",
+		SMTPPort:              465,
+		SMTPUsername:          "",
+		SMTPPasswordEnv:       "CHATTING_SMTP_PASSWORD",
+		SMTPFrom:              "",
+		SMTPStartTLS:          false,
+		SMTPUseSSL:            true,
 
 		AuxiliaryIngressEnabled:     false,
 		AuxiliaryIngressBBMBAddress: "",
@@ -205,6 +226,51 @@ func Load(raw []byte) (Config, error) {
 			return Config{}, err
 		}
 	}
+	if rawValue, ok := payload["smtp_host"]; ok && !isNull(rawValue) {
+		config.SMTPHost, err = decodeNonEmptyString(rawValue, "smtp_host")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["smtp_port"]; ok && !isNull(rawValue) {
+		config.SMTPPort, err = decodePositiveInt(rawValue, "smtp_port")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["smtp_username"]; ok && !isNull(rawValue) {
+		config.SMTPUsername, err = decodeNonEmptyString(rawValue, "smtp_username")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["smtp_password_env"]; ok && !isNull(rawValue) {
+		config.SMTPPasswordEnv, err = decodeNonEmptyString(rawValue, "smtp_password_env")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["smtp_from"]; ok && !isNull(rawValue) {
+		config.SMTPFrom, err = decodeNonEmptyString(rawValue, "smtp_from")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["smtp_starttls"]; ok && !isNull(rawValue) {
+		config.SMTPStartTLS, err = decodeBool(rawValue, "smtp_starttls")
+		if err != nil {
+			return Config{}, err
+		}
+		if _, ok := payload["smtp_use_ssl"]; !ok {
+			config.SMTPUseSSL = !config.SMTPStartTLS
+		}
+	}
+	if rawValue, ok := payload["smtp_use_ssl"]; ok && !isNull(rawValue) {
+		config.SMTPUseSSL, err = decodeBool(rawValue, "smtp_use_ssl")
+		if err != nil {
+			return Config{}, err
+		}
+	}
 	if rawValue, ok := payload["auxiliary_ingress_enabled"]; ok && !isNull(rawValue) {
 		config.AuxiliaryIngressEnabled, err = decodeBool(rawValue, "auxiliary_ingress_enabled")
 		if err != nil {
@@ -231,6 +297,17 @@ func Load(raw []byte) (Config, error) {
 	}
 	if config.AuxiliaryIngressEnabled && len(config.AuxiliaryIngressQueues) == 0 {
 		return Config{}, errors.New("auxiliary ingress requires auxiliary_ingress_queues")
+	}
+	if config.SMTPHost != "" {
+		if config.SMTPFrom == "" {
+			config.SMTPFrom = config.SMTPUsername
+		}
+		if config.SMTPFrom == "" {
+			return Config{}, errors.New("smtp_from or smtp_username is required when smtp_host is set")
+		}
+		if config.SMTPUsername != "" && config.SMTPPasswordEnv == "" {
+			return Config{}, errors.New("smtp_password_env is required when smtp_username is set")
+		}
 	}
 	return config, nil
 }

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -33,6 +33,13 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 		"global_prompt_context": ["Keep replies terse."],
 		"cron_prompt_context": ["This is a scheduled automation task."],
 		"schedule_file": "/tmp/schedule.json",
+		"smtp_host": "smtp.example.com",
+		"smtp_port": 587,
+		"smtp_username": "bot@example.com",
+		"smtp_password_env": "SMTP_PASSWORD",
+		"smtp_from": "replies@example.com",
+		"smtp_starttls": true,
+		"smtp_use_ssl": false,
 		"auxiliary_ingress_enabled": true,
 		"auxiliary_ingress_bbmb_address": "10.0.0.2:9998",
 		"auxiliary_ingress_queues": ["generic-post"],
@@ -74,6 +81,27 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 	}
 	if config.ScheduleFile != "/tmp/schedule.json" {
 		t.Fatalf("ScheduleFile = %q", config.ScheduleFile)
+	}
+	if config.SMTPHost != "smtp.example.com" {
+		t.Fatalf("SMTPHost = %q", config.SMTPHost)
+	}
+	if config.SMTPPort != 587 {
+		t.Fatalf("SMTPPort = %d", config.SMTPPort)
+	}
+	if config.SMTPUsername != "bot@example.com" {
+		t.Fatalf("SMTPUsername = %q", config.SMTPUsername)
+	}
+	if config.SMTPPasswordEnv != "SMTP_PASSWORD" {
+		t.Fatalf("SMTPPasswordEnv = %q", config.SMTPPasswordEnv)
+	}
+	if config.SMTPFrom != "replies@example.com" {
+		t.Fatalf("SMTPFrom = %q", config.SMTPFrom)
+	}
+	if !config.SMTPStartTLS {
+		t.Fatal("SMTPStartTLS = false")
+	}
+	if config.SMTPUseSSL {
+		t.Fatal("SMTPUseSSL = true")
 	}
 	if !config.AuxiliaryIngressEnabled {
 		t.Fatal("AuxiliaryIngressEnabled = false")
@@ -168,6 +196,21 @@ func TestLoadRejectsInvalidValues(t *testing.T) {
 			name:    "non-bool auxiliary enabled",
 			raw:     `{"auxiliary_ingress_enabled": "yes"}`,
 			message: "config auxiliary_ingress_enabled must be a boolean",
+		},
+		{
+			name:    "smtp without sender",
+			raw:     `{"smtp_host": "smtp.example.com"}`,
+			message: "smtp_from or smtp_username is required when smtp_host is set",
+		},
+		{
+			name:    "smtp bad port",
+			raw:     `{"smtp_host": "smtp.example.com", "smtp_from": "bot@example.com", "smtp_port": 0}`,
+			message: "config smtp_port must be a positive integer",
+		},
+		{
+			name:    "smtp starttls wrong type",
+			raw:     `{"smtp_starttls": "yes"}`,
+			message: "config smtp_starttls must be a boolean",
 		},
 		{
 			name:    "enabled auxiliary without queues",

--- a/go/handler/internal/dispatch/dispatch.go
+++ b/go/handler/internal/dispatch/dispatch.go
@@ -1,0 +1,129 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+type EmailSender interface {
+	Send(ctx context.Context, target string, body string, subject *string) error
+}
+
+type Dispatcher struct {
+	EmailSender EmailSender
+}
+
+type MessageDispatchError struct {
+	ReasonCode string
+}
+
+func (err MessageDispatchError) Error() string {
+	return err.ReasonCode
+}
+
+func (dispatcher Dispatcher) Dispatch(ctx context.Context, message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (*contracts.OutboundMessage, error) {
+	channel, target := resolveDispatchChannelAndTarget(message, envelope)
+	normalized := message
+	normalized.Channel = channel
+	normalized.Target = target
+
+	switch channel {
+	case "log", "drop":
+		return &normalized, nil
+	case "email":
+		if dispatcher.EmailSender == nil {
+			return nil, nil
+		}
+		subject, body, err := formatEmailReply(message, envelope)
+		if err != nil {
+			return nil, err
+		}
+		if err := dispatcher.EmailSender.Send(ctx, target, body, subject); err != nil {
+			return nil, MessageDispatchError{ReasonCode: "email_dispatch_failed"}
+		}
+		return &normalized, nil
+	default:
+		if heartbeat.IsLogPong(normalized, envelope) {
+			return &normalized, nil
+		}
+		return nil, errors.New("dispatch is not implemented in the Go handler yet")
+	}
+}
+
+func resolveDispatchChannelAndTarget(message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (string, string) {
+	if message.Channel != "final" {
+		return message.Channel, message.Target
+	}
+	return envelope.ReplyChannel.Type, envelope.ReplyChannel.Target
+}
+
+func formatEmailReply(message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (*string, string, error) {
+	if message.Body == nil {
+		return nil, "", errors.New("email body is required")
+	}
+	cleanedBody := stripLeadingSubjectLine(*message.Body)
+	if envelope.Source != "email" {
+		return nil, cleanedBody, nil
+	}
+
+	originalSubject, originalBody := parseEmailEnvelopeContent(envelope.Content)
+	replySubject := toReplySubject(originalSubject)
+	if originalBody == "" {
+		return &replySubject, cleanedBody, nil
+	}
+
+	lines := strings.Split(originalBody, "\n")
+	quoted := make([]string, 0, len(lines))
+	for _, line := range lines {
+		quoted = append(quoted, "> "+line)
+	}
+	quotedOriginal := strings.Join(quoted, "\n")
+	if quotedOriginal == "" {
+		return &replySubject, cleanedBody, nil
+	}
+	replyBody := strings.TrimRight(cleanedBody, " \t\r\n") + "\n\nOriginal message:\n" + quotedOriginal + "\n"
+	return &replySubject, replyBody, nil
+}
+
+func parseEmailEnvelopeContent(content string) (string, string) {
+	if !strings.HasPrefix(content, "Subject: ") {
+		return "(no subject)", strings.TrimSpace(content)
+	}
+	subject, body, ok := strings.Cut(content, "\n\n")
+	if !ok {
+		body = ""
+	}
+	subjectValue := strings.TrimSpace(strings.TrimPrefix(subject, "Subject: "))
+	if subjectValue == "" {
+		subjectValue = "(no subject)"
+	}
+	return subjectValue, strings.TrimSpace(body)
+}
+
+func toReplySubject(subject string) string {
+	if strings.HasPrefix(strings.ToLower(subject), "re:") {
+		return subject
+	}
+	return "Re: " + subject
+}
+
+func stripLeadingSubjectLine(body string) string {
+	stripped := strings.TrimLeft(body, " \t\r\n")
+	if !strings.HasPrefix(strings.ToLower(stripped), "subject:") {
+		return body
+	}
+	firstLine, remainder, _ := strings.Cut(stripped, "\n")
+	subjectCandidate := strings.TrimSpace(strings.TrimPrefix(firstLine, "Subject:"))
+	if subjectCandidate == "" {
+		return body
+	}
+	cleaned := strings.TrimLeft(remainder, " \t\r\n")
+	if cleaned == "" {
+		return body
+	}
+	return cleaned
+}

--- a/go/handler/internal/dispatch/dispatch_test.go
+++ b/go/handler/internal/dispatch/dispatch_test.go
@@ -1,0 +1,186 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+func TestDispatcherSendsEmailMessage(t *testing.T) {
+	body := "Done."
+	sender := &recordingEmailSender{}
+	message := contracts.OutboundMessage{
+		Channel: "email",
+		Target:  "alice@example.com",
+		Body:    &body,
+	}
+
+	dispatched, err := (Dispatcher{EmailSender: sender}).Dispatch(context.Background(), message, contracts.TaskEnvelope{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dispatched == nil || dispatched.Channel != "email" {
+		t.Fatalf("dispatched = %#v", dispatched)
+	}
+	if len(sender.messages) != 1 {
+		t.Fatalf("sent count = %d", len(sender.messages))
+	}
+	if sender.messages[0].target != "alice@example.com" || sender.messages[0].body != "Done." || sender.messages[0].subject != nil {
+		t.Fatalf("sent = %#v", sender.messages[0])
+	}
+}
+
+func TestDispatcherDropsEmailWhenSenderNotConfigured(t *testing.T) {
+	body := "Done."
+	message := contracts.OutboundMessage{
+		Channel: "email",
+		Target:  "alice@example.com",
+		Body:    &body,
+	}
+
+	dispatched, err := (Dispatcher{}).Dispatch(context.Background(), message, contracts.TaskEnvelope{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dispatched != nil {
+		t.Fatalf("dispatched = %#v", dispatched)
+	}
+}
+
+func TestDispatcherFormatsEmailReplySubjectAndQuotedOriginal(t *testing.T) {
+	body := "Here is the answer."
+	sender := &recordingEmailSender{}
+	message := contracts.OutboundMessage{
+		Channel: "email",
+		Target:  "alice@example.com",
+		Body:    &body,
+	}
+
+	_, err := (Dispatcher{EmailSender: sender}).Dispatch(context.Background(), message, emailEnvelope("Quarterly update", "Can you summarize the key points?"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sent := sender.messages[0]
+	if sent.subject == nil || *sent.subject != "Re: Quarterly update" {
+		t.Fatalf("subject = %#v", sent.subject)
+	}
+	if !strings.Contains(sent.body, "Here is the answer.") ||
+		!strings.Contains(sent.body, "Original message:") ||
+		!strings.Contains(sent.body, "> Can you summarize the key points?") {
+		t.Fatalf("body = %q", sent.body)
+	}
+}
+
+func TestDispatcherStripsLeadingSubjectLineFromEmailBody(t *testing.T) {
+	body := "Subject: Re: Ice-cream\n\nGreat choice. Let's go classic."
+	sender := &recordingEmailSender{}
+	message := contracts.OutboundMessage{
+		Channel: "email",
+		Target:  "alice@example.com",
+		Body:    &body,
+	}
+
+	_, err := (Dispatcher{EmailSender: sender}).Dispatch(context.Background(), message, emailEnvelope("Ice-cream", "Yes please"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sent := sender.messages[0]
+	if sent.subject == nil || *sent.subject != "Re: Ice-cream" {
+		t.Fatalf("subject = %#v", sent.subject)
+	}
+	if strings.HasPrefix(strings.TrimSpace(sent.body), "Subject:") {
+		t.Fatalf("body still starts with subject line: %q", sent.body)
+	}
+	if !strings.Contains(sent.body, "Great choice. Let's go classic.") {
+		t.Fatalf("body = %q", sent.body)
+	}
+}
+
+func TestDispatcherResolvesFinalToEnvelopeReplyChannel(t *testing.T) {
+	body := "Final answer."
+	sender := &recordingEmailSender{}
+	message := contracts.OutboundMessage{
+		Channel: "final",
+		Target:  "unused",
+		Body:    &body,
+	}
+
+	dispatched, err := (Dispatcher{EmailSender: sender}).Dispatch(context.Background(), message, emailEnvelope("Question", "Body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dispatched == nil || dispatched.Channel != "email" || dispatched.Target != "alice@example.com" {
+		t.Fatalf("dispatched = %#v", dispatched)
+	}
+	if sender.messages[0].target != "alice@example.com" {
+		t.Fatalf("target = %q", sender.messages[0].target)
+	}
+}
+
+func TestDispatcherReturnsEmailFailureReason(t *testing.T) {
+	body := "Done."
+	message := contracts.OutboundMessage{
+		Channel: "email",
+		Target:  "alice@example.com",
+		Body:    &body,
+	}
+
+	_, err := (Dispatcher{EmailSender: &recordingEmailSender{err: errors.New("boom")}}).Dispatch(context.Background(), message, contracts.TaskEnvelope{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var dispatchErr MessageDispatchError
+	if !errors.As(err, &dispatchErr) || dispatchErr.ReasonCode != "email_dispatch_failed" {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+type sentEmail struct {
+	target  string
+	body    string
+	subject *string
+}
+
+type recordingEmailSender struct {
+	messages []sentEmail
+	err      error
+}
+
+func (sender *recordingEmailSender) Send(_ context.Context, target string, body string, subject *string) error {
+	if sender.err != nil {
+		return sender.err
+	}
+	sender.messages = append(sender.messages, sentEmail{target: target, body: body, subject: subject})
+	return nil
+}
+
+func emailEnvelope(subject string, body string) contracts.TaskEnvelope {
+	actor := "alice@example.com"
+	return contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            "email:1",
+		Source:        "email",
+		ReceivedAt:    contracts.NewTimestamp(mustTime("2026-03-06T11:00:00Z")),
+		Actor:         &actor,
+		Content:       "Subject: " + subject + "\n\n" + body,
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   "email",
+			Target: "alice@example.com",
+		},
+		DedupeKey: "email:1",
+	}
+}
+
+func mustTime(raw string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}

--- a/go/handler/internal/dispatch/smtp.go
+++ b/go/handler/internal/dispatch/smtp.go
@@ -1,0 +1,162 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/smtp"
+	"strings"
+	"time"
+)
+
+const defaultSubject = "Automation response"
+
+type SMTPConfig struct {
+	Host        string
+	Port        int
+	FromAddress string
+	Username    string
+	Password    string
+	UseSSL      bool
+	StartTLS    bool
+	Timeout     time.Duration
+}
+
+type SMTPClient interface {
+	StartTLS(config *tls.Config) error
+	Auth(auth smtp.Auth) error
+	Mail(from string) error
+	Rcpt(to string) error
+	Data() (io.WriteCloser, error)
+	Quit() error
+	Close() error
+}
+
+type SMTPEmailSender struct {
+	config SMTPConfig
+	dial   func(ctx context.Context, config SMTPConfig) (SMTPClient, error)
+}
+
+func NewSMTPEmailSender(config SMTPConfig) (*SMTPEmailSender, error) {
+	if strings.TrimSpace(config.Host) == "" {
+		return nil, errors.New("smtp host is required")
+	}
+	if config.Port <= 0 {
+		return nil, errors.New("smtp port must be positive")
+	}
+	if strings.TrimSpace(config.FromAddress) == "" {
+		return nil, errors.New("smtp from address is required")
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = 10 * time.Second
+	}
+	return &SMTPEmailSender{config: config, dial: dialSMTP}, nil
+}
+
+func NewSMTPEmailSenderForTest(config SMTPConfig, dial func(ctx context.Context, config SMTPConfig) (SMTPClient, error)) (*SMTPEmailSender, error) {
+	sender, err := NewSMTPEmailSender(config)
+	if err != nil {
+		return nil, err
+	}
+	sender.dial = dial
+	return sender, nil
+}
+
+func (sender *SMTPEmailSender) Send(ctx context.Context, target string, body string, subject *string) error {
+	if strings.TrimSpace(target) == "" {
+		return errors.New("target is required")
+	}
+	if strings.TrimSpace(body) == "" {
+		return errors.New("body is required")
+	}
+
+	client, err := sender.dial(ctx, sender.config)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	host := sender.config.Host
+	if sender.config.StartTLS {
+		tlsConfig := &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12}
+		if err := client.StartTLS(tlsConfig); err != nil {
+			return err
+		}
+	}
+	if sender.config.Username != "" && sender.config.Password != "" {
+		if err := client.Auth(smtp.PlainAuth("", sender.config.Username, sender.config.Password, host)); err != nil {
+			return err
+		}
+	}
+	if err := client.Mail(sender.config.FromAddress); err != nil {
+		return err
+	}
+	if err := client.Rcpt(target); err != nil {
+		return err
+	}
+	writer, err := client.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := writer.Write(renderEmailMessage(sender.config.FromAddress, target, body, subject)); err != nil {
+		_ = writer.Close()
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	return client.Quit()
+}
+
+func renderEmailMessage(from string, to string, body string, subject *string) []byte {
+	subjectValue := defaultSubject
+	if subject != nil && strings.TrimSpace(*subject) != "" {
+		subjectValue = strings.TrimSpace(*subject)
+	}
+
+	var buffer bytes.Buffer
+	writeHeader(&buffer, "From", from)
+	writeHeader(&buffer, "To", to)
+	writeHeader(&buffer, "Subject", mime.QEncoding.Encode("utf-8", subjectValue))
+	buffer.WriteString("MIME-Version: 1.0\r\n")
+	buffer.WriteString("Content-Type: text/plain; charset=utf-8\r\n")
+	buffer.WriteString("Content-Transfer-Encoding: 8bit\r\n")
+	buffer.WriteString("\r\n")
+	buffer.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		buffer.WriteString("\n")
+	}
+	return buffer.Bytes()
+}
+
+func writeHeader(buffer *bytes.Buffer, key string, value string) {
+	buffer.WriteString(key)
+	buffer.WriteString(": ")
+	buffer.WriteString(strings.ReplaceAll(strings.ReplaceAll(value, "\r", ""), "\n", " "))
+	buffer.WriteString("\r\n")
+}
+
+func dialSMTP(ctx context.Context, config SMTPConfig) (SMTPClient, error) {
+	address := net.JoinHostPort(config.Host, fmt.Sprintf("%d", config.Port))
+	dialer := &net.Dialer{Timeout: config.Timeout}
+	if config.UseSSL {
+		conn, err := tls.DialWithDialer(dialer, "tcp", address, &tls.Config{
+			ServerName: config.Host,
+			MinVersion: tls.VersionTLS12,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return smtp.NewClient(conn, config.Host)
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	return smtp.NewClient(conn, config.Host)
+}

--- a/go/handler/internal/dispatch/smtp_test.go
+++ b/go/handler/internal/dispatch/smtp_test.go
@@ -1,0 +1,149 @@
+package dispatch
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/mail"
+	"net/smtp"
+	"strings"
+	"testing"
+)
+
+func TestSMTPEmailSenderSendsRenderedMessage(t *testing.T) {
+	client := &fakeSMTPClient{}
+	sender, err := NewSMTPEmailSenderForTest(SMTPConfig{
+		Host:        "smtp.example.com",
+		Port:        25,
+		FromAddress: "bot@example.com",
+	}, func(_ context.Context, _ SMTPConfig) (SMTPClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := "Re: Quarterly update"
+
+	if err := sender.Send(context.Background(), "alice@example.com", "Done.", &subject); err != nil {
+		t.Fatal(err)
+	}
+
+	if client.from != "bot@example.com" {
+		t.Fatalf("from = %q", client.from)
+	}
+	if len(client.recipients) != 1 || client.recipients[0] != "alice@example.com" {
+		t.Fatalf("recipients = %#v", client.recipients)
+	}
+	parsed, err := mail.ReadMessage(strings.NewReader(client.data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Header.Get("From") != "bot@example.com" || parsed.Header.Get("To") != "alice@example.com" {
+		t.Fatalf("headers = %#v", parsed.Header)
+	}
+	if parsed.Header.Get("Subject") != "Re: Quarterly update" {
+		t.Fatalf("subject = %q", parsed.Header.Get("Subject"))
+	}
+	body, err := io.ReadAll(parsed.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "Done.\n" {
+		t.Fatalf("body = %q", string(body))
+	}
+	if !client.quit {
+		t.Fatal("quit was not called")
+	}
+}
+
+func TestSMTPEmailSenderUsesStartTLSAndAuth(t *testing.T) {
+	client := &fakeSMTPClient{}
+	sender, err := NewSMTPEmailSenderForTest(SMTPConfig{
+		Host:        "smtp.example.com",
+		Port:        587,
+		FromAddress: "bot@example.com",
+		Username:    "bot@example.com",
+		Password:    "secret",
+		StartTLS:    true,
+	}, func(_ context.Context, _ SMTPConfig) (SMTPClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sender.Send(context.Background(), "alice@example.com", "Done.", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if !client.startTLS {
+		t.Fatal("starttls was not called")
+	}
+	if !client.auth {
+		t.Fatal("auth was not called")
+	}
+}
+
+func TestNewSMTPEmailSenderValidatesConfig(t *testing.T) {
+	_, err := NewSMTPEmailSender(SMTPConfig{Host: "smtp.example.com", Port: 25})
+	if err == nil || !strings.Contains(err.Error(), "smtp from address is required") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+type fakeSMTPClient struct {
+	from       string
+	recipients []string
+	data       string
+	startTLS   bool
+	auth       bool
+	quit       bool
+	closed     bool
+}
+
+func (client *fakeSMTPClient) StartTLS(_ *tls.Config) error {
+	client.startTLS = true
+	return nil
+}
+
+func (client *fakeSMTPClient) Auth(_ smtp.Auth) error {
+	client.auth = true
+	return nil
+}
+
+func (client *fakeSMTPClient) Mail(from string) error {
+	client.from = from
+	return nil
+}
+
+func (client *fakeSMTPClient) Rcpt(to string) error {
+	client.recipients = append(client.recipients, to)
+	return nil
+}
+
+func (client *fakeSMTPClient) Data() (io.WriteCloser, error) {
+	return &fakeDataWriter{client: client}, nil
+}
+
+func (client *fakeSMTPClient) Quit() error {
+	client.quit = true
+	return nil
+}
+
+func (client *fakeSMTPClient) Close() error {
+	client.closed = true
+	return nil
+}
+
+type fakeDataWriter struct {
+	client *fakeSMTPClient
+}
+
+func (writer *fakeDataWriter) Write(data []byte) (int, error) {
+	writer.client.data += string(data)
+	return len(data), nil
+}
+
+func (writer *fakeDataWriter) Close() error {
+	return nil
+}

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -233,5 +233,8 @@ func (engine *Engine) channelAllowed(message contracts.EgressQueueMessage, task 
 	if task != nil && heartbeat.IsLogPong(message.Message, task.TaskMessage.Envelope) {
 		return true
 	}
+	if task != nil && message.Message.Channel == "final" {
+		return engine.allowedChannels[task.TaskMessage.Envelope.ReplyChannel.Type]
+	}
 	return engine.allowedChannels[message.Message.Channel]
 }

--- a/go/handler/internal/egress/egress_test.go
+++ b/go/handler/internal/egress/egress_test.go
@@ -68,6 +68,28 @@ func TestHandleDropsDisallowedChannel(t *testing.T) {
 	}
 }
 
+func TestHandleAllowsFinalChannelWhenEnvelopeReplyChannelAllowed(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngine(t, state, dispatcher)
+	message := testEgressMessage(t, task, nil, "evt:final:1", "incremental")
+	message.Message.Channel = "final"
+	message.Message.Target = "unused"
+
+	result, err := engine.Handle(context.Background(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDispatched {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(dispatcher.messages) != 1 {
+		t.Fatalf("dispatch count = %d", len(dispatcher.messages))
+	}
+}
+
 func TestHandleAllowsInternalHeartbeatLogPongWhenLogDisallowed(t *testing.T) {
 	task := contracts.NewTaskQueueMessage(
 		heartbeat.BuildEnvelope(1, mustTime(t, "2026-03-09T12:00:00Z")),


### PR DESCRIPTION
## Summary

- add Go handler dispatch support for email/log/drop channels, including final-channel resolution to the task reply channel
- add SMTP config parsing and SMTP sender wiring for the Go handler
- match Python email reply subject/body formatting, including subject stripping and quoted original body
- mark SMTP dispatch complete in the Go handler porting plan

## Validation

- `cd go/handler && go test ./...`
- `git diff --check`
