### PR TITLE
Add Go handler IMAP ingress

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -645,6 +645,12 @@ Validation:
 
 ### 14. IMAP Ingress
 
+Status: complete. The Go handler now accepts the Python handler IMAP config keys,
+wires an IMAP-backed email connector into ingress, normalizes messages into
+Python-compatible email task envelopes, preserves global/email prompt context and
+context refs, and falls back to handler time when email dates are missing or
+invalid.
+
 Implement IMAP polling and email normalization.
 
 Validation:
@@ -720,5 +726,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add SMTP dispatch.
-2. Add IMAP ingress.
+1. Add Telegram dispatch.
+2. Add Telegram ingress and attachment tracking.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -15,6 +15,7 @@ import (
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/auxiliary"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/imap"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/schedule"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/dispatch"
@@ -121,6 +122,32 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 			config.CronPromptContext,
 			nil,
 		)
+		if err != nil {
+			_ = store.Close()
+			return nil, err
+		}
+		connectors = append(connectors, connector)
+	}
+	if config.IMAPHost != "" {
+		password := os.Getenv(config.IMAPPasswordEnv)
+		if password == "" {
+			_ = store.Close()
+			return nil, fmt.Errorf("missing IMAP password env var: %s", config.IMAPPasswordEnv)
+		}
+		connector, err := imap.New(imap.Config{
+			Host:            config.IMAPHost,
+			Port:            config.IMAPPort,
+			Username:        config.IMAPUsername,
+			Password:        password,
+			Mailbox:         config.IMAPMailbox,
+			SearchCriterion: config.IMAPSearch,
+			ContextRefs:     config.ContextRefs,
+			PromptContext: contracts.PromptContext{
+				GlobalInstructions:       config.GlobalPromptContext,
+				ReplyChannelInstructions: config.EmailPromptContext,
+			},
+			UseSSL: config.IMAPUseSSL,
+		})
 		if err != nil {
 			_ = store.Close()
 			return nil, err

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -34,7 +34,16 @@ var allowedKeys = map[string]bool{
 	"allowed_egress_channels": true,
 	"global_prompt_context":   true,
 	"cron_prompt_context":     true,
+	"email_prompt_context":    true,
+	"context_refs":            true,
 	"schedule_file":           true,
+	"imap_host":               true,
+	"imap_port":               true,
+	"imap_username":           true,
+	"imap_password_env":       true,
+	"imap_mailbox":            true,
+	"imap_search":             true,
+	"imap_use_ssl":            true,
 	"smtp_host":               true,
 	"smtp_port":               true,
 	"smtp_username":           true,
@@ -60,7 +69,16 @@ type Config struct {
 	AllowedEgressChannels []string
 	GlobalPromptContext   []string
 	CronPromptContext     []string
+	EmailPromptContext    []string
+	ContextRefs           []string
 	ScheduleFile          string
+	IMAPHost              string
+	IMAPPort              int
+	IMAPUsername          string
+	IMAPPasswordEnv       string
+	IMAPMailbox           string
+	IMAPSearch            string
+	IMAPUseSSL            bool
 	SMTPHost              string
 	SMTPPort              int
 	SMTPUsername          string
@@ -87,7 +105,16 @@ func Defaults() Config {
 		AllowedEgressChannels: []string{"email", "telegram", "telegram_reaction", "log"},
 		GlobalPromptContext:   []string{},
 		CronPromptContext:     []string{},
+		EmailPromptContext:    []string{},
+		ContextRefs:           []string{},
 		ScheduleFile:          "",
+		IMAPHost:              "",
+		IMAPPort:              993,
+		IMAPUsername:          "",
+		IMAPPasswordEnv:       "CHATTING_IMAP_PASSWORD",
+		IMAPMailbox:           "INBOX",
+		IMAPSearch:            "UNSEEN",
+		IMAPUseSSL:            true,
 		SMTPHost:              "",
 		SMTPPort:              465,
 		SMTPUsername:          "",
@@ -220,8 +247,62 @@ func Load(raw []byte) (Config, error) {
 			return Config{}, err
 		}
 	}
+	if rawValue, ok := payload["email_prompt_context"]; ok && !isNull(rawValue) {
+		config.EmailPromptContext, err = decodeStringList(rawValue, "email_prompt_context")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["context_refs"]; ok && !isNull(rawValue) {
+		config.ContextRefs, err = decodeStringList(rawValue, "context_refs")
+		if err != nil {
+			return Config{}, err
+		}
+	}
 	if rawValue, ok := payload["schedule_file"]; ok && !isNull(rawValue) {
 		config.ScheduleFile, err = decodeNonEmptyString(rawValue, "schedule_file")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["imap_host"]; ok && !isNull(rawValue) {
+		config.IMAPHost, err = decodeNonEmptyString(rawValue, "imap_host")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["imap_port"]; ok && !isNull(rawValue) {
+		config.IMAPPort, err = decodePositiveInt(rawValue, "imap_port")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["imap_username"]; ok && !isNull(rawValue) {
+		config.IMAPUsername, err = decodeNonEmptyString(rawValue, "imap_username")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["imap_password_env"]; ok && !isNull(rawValue) {
+		config.IMAPPasswordEnv, err = decodeNonEmptyString(rawValue, "imap_password_env")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["imap_mailbox"]; ok && !isNull(rawValue) {
+		config.IMAPMailbox, err = decodeNonEmptyString(rawValue, "imap_mailbox")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["imap_search"]; ok && !isNull(rawValue) {
+		config.IMAPSearch, err = decodeNonEmptyString(rawValue, "imap_search")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["imap_use_ssl"]; ok && !isNull(rawValue) {
+		config.IMAPUseSSL, err = decodeBool(rawValue, "imap_use_ssl")
 		if err != nil {
 			return Config{}, err
 		}
@@ -297,6 +378,14 @@ func Load(raw []byte) (Config, error) {
 	}
 	if config.AuxiliaryIngressEnabled && len(config.AuxiliaryIngressQueues) == 0 {
 		return Config{}, errors.New("auxiliary ingress requires auxiliary_ingress_queues")
+	}
+	if config.IMAPHost != "" {
+		if config.IMAPUsername == "" {
+			return Config{}, errors.New("imap_username is required when imap_host is set")
+		}
+		if config.IMAPPasswordEnv == "" {
+			return Config{}, errors.New("imap_password_env is required when imap_host is set")
+		}
 	}
 	if config.SMTPHost != "" {
 		if config.SMTPFrom == "" {

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -32,7 +32,16 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 		"allowed_egress_channels": ["log", "email"],
 		"global_prompt_context": ["Keep replies terse."],
 		"cron_prompt_context": ["This is a scheduled automation task."],
+		"email_prompt_context": ["Use a clear subject."],
+		"context_refs": ["repo:/workspace/chatting"],
 		"schedule_file": "/tmp/schedule.json",
+		"imap_host": "imap.example.com",
+		"imap_port": 143,
+		"imap_username": "inbox@example.com",
+		"imap_password_env": "IMAP_PASSWORD",
+		"imap_mailbox": "Tasks",
+		"imap_search": "ALL",
+		"imap_use_ssl": false,
 		"smtp_host": "smtp.example.com",
 		"smtp_port": 587,
 		"smtp_username": "bot@example.com",
@@ -79,8 +88,35 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 	if !reflect.DeepEqual(config.CronPromptContext, []string{"This is a scheduled automation task."}) {
 		t.Fatalf("CronPromptContext = %#v", config.CronPromptContext)
 	}
+	if !reflect.DeepEqual(config.EmailPromptContext, []string{"Use a clear subject."}) {
+		t.Fatalf("EmailPromptContext = %#v", config.EmailPromptContext)
+	}
+	if !reflect.DeepEqual(config.ContextRefs, []string{"repo:/workspace/chatting"}) {
+		t.Fatalf("ContextRefs = %#v", config.ContextRefs)
+	}
 	if config.ScheduleFile != "/tmp/schedule.json" {
 		t.Fatalf("ScheduleFile = %q", config.ScheduleFile)
+	}
+	if config.IMAPHost != "imap.example.com" {
+		t.Fatalf("IMAPHost = %q", config.IMAPHost)
+	}
+	if config.IMAPPort != 143 {
+		t.Fatalf("IMAPPort = %d", config.IMAPPort)
+	}
+	if config.IMAPUsername != "inbox@example.com" {
+		t.Fatalf("IMAPUsername = %q", config.IMAPUsername)
+	}
+	if config.IMAPPasswordEnv != "IMAP_PASSWORD" {
+		t.Fatalf("IMAPPasswordEnv = %q", config.IMAPPasswordEnv)
+	}
+	if config.IMAPMailbox != "Tasks" {
+		t.Fatalf("IMAPMailbox = %q", config.IMAPMailbox)
+	}
+	if config.IMAPSearch != "ALL" {
+		t.Fatalf("IMAPSearch = %q", config.IMAPSearch)
+	}
+	if config.IMAPUseSSL {
+		t.Fatal("IMAPUseSSL = true")
 	}
 	if config.SMTPHost != "smtp.example.com" {
 		t.Fatalf("SMTPHost = %q", config.SMTPHost)
@@ -196,6 +232,21 @@ func TestLoadRejectsInvalidValues(t *testing.T) {
 			name:    "non-bool auxiliary enabled",
 			raw:     `{"auxiliary_ingress_enabled": "yes"}`,
 			message: "config auxiliary_ingress_enabled must be a boolean",
+		},
+		{
+			name:    "imap without username",
+			raw:     `{"imap_host": "imap.example.com"}`,
+			message: "imap_username is required when imap_host is set",
+		},
+		{
+			name:    "imap bad port",
+			raw:     `{"imap_host": "imap.example.com", "imap_username": "bot@example.com", "imap_port": 0}`,
+			message: "config imap_port must be a positive integer",
+		},
+		{
+			name:    "imap ssl wrong type",
+			raw:     `{"imap_use_ssl": "no"}`,
+			message: "config imap_use_ssl must be a boolean",
 		},
 		{
 			name:    "smtp without sender",

--- a/go/handler/internal/connectors/imap/imap.go
+++ b/go/handler/internal/connectors/imap/imap.go
@@ -1,0 +1,404 @@
+package imap
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net"
+	"net/mail"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+const Source = "email"
+
+type Client interface {
+	Login(username string, password string) error
+	Select(mailbox string) error
+	Search(criterion string) ([]string, error)
+	FetchRFC822(uid string) ([]byte, error)
+	Logout() error
+}
+
+type ClientFactory func(ctx context.Context, config ClientConfig) (Client, error)
+
+type ClientConfig struct {
+	Host    string
+	Port    int
+	UseSSL  bool
+	Timeout time.Duration
+}
+
+type Config struct {
+	Host            string
+	Port            int
+	Username        string
+	Password        string
+	Mailbox         string
+	SearchCriterion string
+	ContextRefs     []string
+	PromptContext   contracts.PromptContext
+	UseSSL          bool
+	Now             func() time.Time
+	ClientFactory   ClientFactory
+}
+
+type Connector struct {
+	config        Config
+	clientFactory ClientFactory
+	now           func() time.Time
+	prompt        *contracts.PromptContext
+}
+
+func New(config Config) (*Connector, error) {
+	if strings.TrimSpace(config.Host) == "" {
+		return nil, errors.New("host is required")
+	}
+	if strings.TrimSpace(config.Username) == "" {
+		return nil, errors.New("username is required")
+	}
+	if config.Password == "" {
+		return nil, errors.New("password is required")
+	}
+	if config.Port <= 0 {
+		return nil, errors.New("port must be positive")
+	}
+	if strings.TrimSpace(config.Mailbox) == "" {
+		config.Mailbox = "INBOX"
+	}
+	if strings.TrimSpace(config.SearchCriterion) == "" {
+		config.SearchCriterion = "UNSEEN"
+	}
+	now := config.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	factory := config.ClientFactory
+	if factory == nil {
+		factory = DialClient
+	}
+	var prompt *contracts.PromptContext
+	if config.PromptContext.HasContent() {
+		copy := config.PromptContext
+		prompt = &copy
+	}
+	config.Host = strings.TrimSpace(config.Host)
+	config.Username = strings.TrimSpace(config.Username)
+	config.Mailbox = strings.TrimSpace(config.Mailbox)
+	config.SearchCriterion = strings.TrimSpace(config.SearchCriterion)
+	return &Connector{config: config, clientFactory: factory, now: now, prompt: prompt}, nil
+}
+
+func (connector *Connector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	client, err := connector.clientFactory(ctx, ClientConfig{
+		Host:    connector.config.Host,
+		Port:    connector.config.Port,
+		UseSSL:  connector.config.UseSSL,
+		Timeout: 10 * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = client.Logout() }()
+	if err := client.Login(connector.config.Username, connector.config.Password); err != nil {
+		return nil, errors.New("imap_login_failed")
+	}
+	if err := client.Select(connector.config.Mailbox); err != nil {
+		return nil, fmt.Errorf("imap_select_failed:%s", connector.config.Mailbox)
+	}
+	uids, err := client.Search(connector.config.SearchCriterion)
+	if err != nil {
+		return nil, errors.New("imap_search_failed")
+	}
+	envelopes := make([]contracts.TaskEnvelope, 0, len(uids))
+	for _, uid := range uids {
+		raw, err := client.FetchRFC822(uid)
+		if err != nil || len(raw) == 0 {
+			continue
+		}
+		envelope, err := connector.toEnvelope(uid, raw)
+		if err != nil {
+			continue
+		}
+		envelopes = append(envelopes, envelope)
+	}
+	return envelopes, nil
+}
+
+func (connector *Connector) toEnvelope(uid string, raw []byte) (contracts.TaskEnvelope, error) {
+	parsed, err := mail.ReadMessage(bytes.NewReader(raw))
+	if err != nil {
+		return contracts.TaskEnvelope{}, err
+	}
+	fromHeader := parsed.Header.Get("From")
+	fromAddress := ""
+	if address, err := mail.ParseAddress(fromHeader); err == nil {
+		fromAddress = address.Address
+	}
+	target := fromAddress
+	if target == "" {
+		target = connector.config.Username
+	}
+	subject := strings.TrimSpace(decodeHeader(parsed.Header.Get("Subject")))
+	if subject == "" {
+		subject = "(no subject)"
+	}
+	body := extractBodyText(parsed)
+	receivedAt := parseReceivedAt(parsed.Header.Get("Date"), connector.now())
+	eventID := "email:" + uid
+	var actor *string
+	if fromAddress != "" {
+		value := fromAddress
+		actor = &value
+	}
+	return contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            eventID,
+		Source:        Source,
+		ReceivedAt:    contracts.NewTimestamp(receivedAt),
+		Actor:         actor,
+		Content:       "Subject: " + subject + "\n\n" + body,
+		Attachments:   []contracts.AttachmentRef{},
+		ContextRefs:   append([]string{}, connector.config.ContextRefs...),
+		PromptContext: connector.prompt,
+		ReplyChannel:  contracts.ReplyChannel{Type: "email", Target: target},
+		DedupeKey:     eventID,
+	}, nil
+}
+
+func decodeHeader(value string) string {
+	decoded, err := new(mime.WordDecoder).DecodeHeader(value)
+	if err != nil {
+		return value
+	}
+	return decoded
+}
+
+func extractBodyText(message *mail.Message) string {
+	contentType := message.Header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err == nil && strings.HasPrefix(strings.ToLower(mediaType), "multipart/") {
+		reader := multipart.NewReader(message.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				break
+			}
+			disposition := strings.ToLower(part.Header.Get("Content-Disposition"))
+			if strings.Contains(disposition, "attachment") {
+				continue
+			}
+			partType, _, _ := mime.ParseMediaType(part.Header.Get("Content-Type"))
+			if strings.ToLower(partType) != "text/plain" {
+				continue
+			}
+			if body := readBody(part.Header, part); body != "" {
+				return body
+			}
+		}
+		return "(empty body)"
+	}
+	if body := readBody(message.Header, message.Body); body != "" {
+		return body
+	}
+	return "(empty body)"
+}
+
+type headerGetter interface {
+	Get(key string) string
+}
+
+func readBody(header headerGetter, reader io.Reader) string {
+	var decoded io.Reader = reader
+	switch strings.ToLower(strings.TrimSpace(header.Get("Content-Transfer-Encoding"))) {
+	case "base64":
+		decoded = base64.NewDecoder(base64.StdEncoding, reader)
+	case "quoted-printable":
+		decoded = quotedprintable.NewReader(reader)
+	}
+	raw, err := io.ReadAll(decoded)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func parseReceivedAt(value string, fallback time.Time) time.Time {
+	if strings.TrimSpace(value) == "" {
+		return fallback.UTC()
+	}
+	parsed, err := mail.ParseDate(value)
+	if err != nil {
+		return fallback.UTC()
+	}
+	return parsed.UTC()
+}
+
+type NetClient struct {
+	conn   net.Conn
+	reader *bufio.Reader
+	writer *bufio.Writer
+	nextID atomic.Uint64
+}
+
+func DialClient(ctx context.Context, config ClientConfig) (Client, error) {
+	if config.Timeout <= 0 {
+		config.Timeout = 10 * time.Second
+	}
+	address := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
+	dialer := net.Dialer{Timeout: config.Timeout}
+	var conn net.Conn
+	var err error
+	if config.UseSSL {
+		conn, err = tls.DialWithDialer(&dialer, "tcp", address, &tls.Config{
+			ServerName: config.Host,
+			MinVersion: tls.VersionTLS12,
+		})
+	} else {
+		conn, err = dialer.DialContext(ctx, "tcp", address)
+	}
+	if err != nil {
+		return nil, err
+	}
+	client := &NetClient{
+		conn:   conn,
+		reader: bufio.NewReader(conn),
+		writer: bufio.NewWriter(conn),
+	}
+	if _, err := client.reader.ReadString('\n'); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return client, nil
+}
+
+func (client *NetClient) Login(username string, password string) error {
+	_, err := client.commandOK("LOGIN %s %s", quoteIMAP(username), quoteIMAP(password))
+	return err
+}
+
+func (client *NetClient) Select(mailbox string) error {
+	_, err := client.commandOK("SELECT %s", quoteIMAP(mailbox))
+	return err
+}
+
+func (client *NetClient) Search(criterion string) ([]string, error) {
+	lines, err := client.commandOK("SEARCH %s", criterion)
+	if err != nil {
+		return nil, err
+	}
+	for _, line := range lines {
+		if strings.HasPrefix(line, "* SEARCH") {
+			fields := strings.Fields(strings.TrimPrefix(line, "* SEARCH"))
+			return fields, nil
+		}
+	}
+	return []string{}, nil
+}
+
+func (client *NetClient) FetchRFC822(uid string) ([]byte, error) {
+	tag := client.nextTag()
+	if err := client.writeCommand(tag, "FETCH %s (RFC822)", uid); err != nil {
+		return nil, err
+	}
+	var payload []byte
+	for {
+		line, err := client.reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if strings.HasPrefix(line, tag+" ") {
+			if strings.Contains(line, " OK") {
+				return payload, nil
+			}
+			return nil, errors.New(line)
+		}
+		size, ok := literalSize(line)
+		if !ok {
+			continue
+		}
+		payload = make([]byte, size)
+		if _, err := io.ReadFull(client.reader, payload); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (client *NetClient) Logout() error {
+	_, err := client.commandOK("LOGOUT")
+	if closeErr := client.conn.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+func (client *NetClient) commandOK(format string, args ...any) ([]string, error) {
+	tag := client.nextTag()
+	if err := client.writeCommand(tag, format, args...); err != nil {
+		return nil, err
+	}
+	lines := []string{}
+	for {
+		line, err := client.reader.ReadString('\n')
+		if err != nil {
+			return lines, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if strings.HasPrefix(line, tag+" ") {
+			if strings.Contains(line, " OK") {
+				return lines, nil
+			}
+			return lines, errors.New(line)
+		}
+		lines = append(lines, line)
+	}
+}
+
+func (client *NetClient) writeCommand(tag string, format string, args ...any) error {
+	if _, err := fmt.Fprintf(client.writer, tag+" "+format+"\r\n", args...); err != nil {
+		return err
+	}
+	return client.writer.Flush()
+}
+
+func (client *NetClient) nextTag() string {
+	return fmt.Sprintf("A%04d", client.nextID.Add(1))
+}
+
+func quoteIMAP(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+}
+
+var literalPattern = regexp.MustCompile(`\{(\d+)\}$`)
+
+func literalSize(line string) (int, bool) {
+	matches := literalPattern.FindStringSubmatch(line)
+	if len(matches) != 2 {
+		return 0, false
+	}
+	size, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, false
+	}
+	return size, true
+}

--- a/go/handler/internal/connectors/imap/imap_test.go
+++ b/go/handler/internal/connectors/imap/imap_test.go
@@ -1,0 +1,193 @@
+package imap
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+func TestPollNormalizesMessagesToEnvelopes(t *testing.T) {
+	raw := buildRawEmail("alice@example.com", "Please summarize", "Summarize this inbox thread.", "Sat, 28 Feb 2026 10:15:00 +0000")
+	fake := &fakeClient{messages: map[string][]byte{"101": []byte(raw)}}
+	connector, err := New(Config{
+		Host:            "imap.example.com",
+		Port:            993,
+		Username:        "bot@example.com",
+		Password:        "secret",
+		ContextRefs:     []string{"repo:/home/edward/chatting"},
+		SearchCriterion: "UNSEEN",
+		ClientFactory: func(ctx context.Context, config ClientConfig) (Client, error) {
+			return fake, nil
+		},
+		Now: func() time.Time {
+			return time.Date(2026, 2, 28, 10, 30, 0, 0, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("len(envelopes) = %d", len(envelopes))
+	}
+	envelope := envelopes[0]
+	if envelope.Source != "email" {
+		t.Fatalf("Source = %q", envelope.Source)
+	}
+	if envelope.Actor == nil || *envelope.Actor != "alice@example.com" {
+		t.Fatalf("Actor = %#v", envelope.Actor)
+	}
+	if envelope.ReplyChannel.Target != "alice@example.com" {
+		t.Fatalf("ReplyChannel.Target = %q", envelope.ReplyChannel.Target)
+	}
+	if envelope.DedupeKey != "email:101" {
+		t.Fatalf("DedupeKey = %q", envelope.DedupeKey)
+	}
+	if envelope.Content != "Subject: Please summarize\n\nSummarize this inbox thread." {
+		t.Fatalf("Content = %q", envelope.Content)
+	}
+	if !envelope.ReceivedAt.Equal(time.Date(2026, 2, 28, 10, 15, 0, 0, time.UTC)) {
+		t.Fatalf("ReceivedAt = %s", envelope.ReceivedAt.Format(time.RFC3339))
+	}
+	if len(envelope.ContextRefs) != 1 || envelope.ContextRefs[0] != "repo:/home/edward/chatting" {
+		t.Fatalf("ContextRefs = %#v", envelope.ContextRefs)
+	}
+	if !fake.loggedOut {
+		t.Fatal("client was not logged out")
+	}
+}
+
+func TestPollAttachesPromptContext(t *testing.T) {
+	raw := buildRawEmail("alice@example.com", "Please summarize", "Body", "Sat, 28 Feb 2026 10:15:00 +0000")
+	fake := &fakeClient{messages: map[string][]byte{"101": []byte(raw)}}
+	connector, err := New(Config{
+		Host:     "imap.example.com",
+		Port:     993,
+		Username: "bot@example.com",
+		Password: "secret",
+		PromptContext: contracts.PromptContext{
+			GlobalInstructions:       []string{"Keep replies concise."},
+			ReplyChannelInstructions: []string{"Use a clear email subject line."},
+		},
+		ClientFactory: func(ctx context.Context, config ClientConfig) (Client, error) {
+			return fake, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := envelopes[0].PromptContext.AssembledInstructions()
+	want := []string{"Keep replies concise.", "Use a clear email subject line."}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("instructions = %#v", got)
+	}
+}
+
+func TestPollFallsBackToNowForInvalidDateHeader(t *testing.T) {
+	raw := buildRawEmail("alice@example.com", "No Date", "Body", "not-a-date")
+	fake := &fakeClient{messages: map[string][]byte{"201": []byte(raw)}}
+	fallback := time.Date(2026, 2, 28, 11, 0, 0, 0, time.UTC)
+	connector, err := New(Config{
+		Host:     "imap.example.com",
+		Port:     993,
+		Username: "bot@example.com",
+		Password: "secret",
+		ClientFactory: func(ctx context.Context, config ClientConfig) (Client, error) {
+			return fake, nil
+		},
+		Now: func() time.Time { return fallback },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !envelopes[0].ReceivedAt.Equal(fallback) {
+		t.Fatalf("ReceivedAt = %s", envelopes[0].ReceivedAt.Format(time.RFC3339))
+	}
+}
+
+func TestPollUsesUsernameAsReplyTargetWhenFromAddressIsMissing(t *testing.T) {
+	raw := "To: bot@example.com\r\nSubject: No Sender\r\nDate: Sat, 28 Feb 2026 10:15:00 +0000\r\n\r\nBody"
+	fake := &fakeClient{messages: map[string][]byte{"301": []byte(raw)}}
+	connector, err := New(Config{
+		Host:     "imap.example.com",
+		Port:     993,
+		Username: "bot@example.com",
+		Password: "secret",
+		ClientFactory: func(ctx context.Context, config ClientConfig) (Client, error) {
+			return fake, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envelopes[0].Actor != nil {
+		t.Fatalf("Actor = %#v", envelopes[0].Actor)
+	}
+	if envelopes[0].ReplyChannel.Target != "bot@example.com" {
+		t.Fatalf("ReplyChannel.Target = %q", envelopes[0].ReplyChannel.Target)
+	}
+}
+
+type fakeClient struct {
+	messages  map[string][]byte
+	loggedOut bool
+}
+
+func (client *fakeClient) Login(username string, password string) error {
+	return nil
+}
+
+func (client *fakeClient) Select(mailbox string) error {
+	return nil
+}
+
+func (client *fakeClient) Search(criterion string) ([]string, error) {
+	uids := make([]string, 0, len(client.messages))
+	for uid := range client.messages {
+		uids = append(uids, uid)
+	}
+	return uids, nil
+}
+
+func (client *fakeClient) FetchRFC822(uid string) ([]byte, error) {
+	return client.messages[uid], nil
+}
+
+func (client *fakeClient) Logout() error {
+	client.loggedOut = true
+	return nil
+}
+
+func buildRawEmail(sender string, subject string, body string, date string) string {
+	return "From: " + sender + "\r\n" +
+		"To: bot@example.com\r\n" +
+		"Subject: " + subject + "\r\n" +
+		"Date: " + date + "\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"\r\n" +
+		body
+}


### PR DESCRIPTION
## Summary
- add Go handler IMAP config parsing with Python-compatible defaults for mailbox/search/password env/context refs/email prompt context
- add an IMAP ingress connector that logs in, selects/searches/fetches messages, and normalizes them to email task envelopes
- wire the connector into the Go handler runtime and mark the IMAP slice complete in the porting plan

## Validation
- `cd go/handler && test -z "$(gofmt -l .)"`
- `cd go/handler && go test ./...`
- `uv run python -m unittest discover -s tests`
- `uv run python -m unittest tests.e2e.test_email_e2e -v` (skipped locally: `CHATTING_BBMB_SERVER_BIN` is not set)
