### PR TITLE
Track observed Telegram chats

### DIFF
--- a/app/handler/connectors/telegram_connector.py
+++ b/app/handler/connectors/telegram_connector.py
@@ -33,6 +33,19 @@ class TelegramFileMetadata:
     file_path: str
 
 
+@dataclass(frozen=True)
+class TelegramChatObservation:
+    """Telegram chat metadata observed while polling updates."""
+
+    chat_id: str
+    chat_type: str | None
+    title: str | None
+    username: str | None
+    update_id: int
+    update_kind: str
+    message_date: datetime | None
+
+
 class TelegramConnector:
     """Poll Telegram updates and normalize supported messages into envelopes."""
 
@@ -53,6 +66,7 @@ class TelegramConnector:
         http_get_json: Callable[[str, float], TelegramGetUpdatesResponse] | None = None,
         resolve_file_metadata: Callable[[str, float], TelegramFileMetadata] | None = None,
         download_file_bytes: Callable[[str, float], bytes] | None = None,
+        observe_chat: Callable[[TelegramChatObservation], None] | None = None,
     ) -> None:
         if not bot_token:
             raise ValueError("bot_token is required")
@@ -90,6 +104,7 @@ class TelegramConnector:
         self._http_get_json = http_get_json or _default_http_get_json
         self._resolve_file_metadata = resolve_file_metadata or _default_resolve_file_metadata
         self._download_file_bytes = download_file_bytes or _default_download_file_bytes
+        self._observe_chat = observe_chat
         self._next_offset: int | None = None
 
     def poll(self) -> list[TaskEnvelope]:
@@ -135,6 +150,13 @@ class TelegramConnector:
         channel_post_payload = update.get("channel_post")
         if isinstance(channel_post_payload, dict):
             return self._normalize_channel_post(update_id=update_id, payload=channel_post_payload)
+        my_chat_member_payload = update.get("my_chat_member")
+        if isinstance(my_chat_member_payload, dict):
+            self._observe_chat_from_payload(
+                update_id=update_id,
+                update_kind="my_chat_member",
+                payload=my_chat_member_payload,
+            )
         return None
 
     def _normalize_message(self, *, update_id: int, payload: dict[str, object]) -> TaskEnvelope | None:
@@ -145,6 +167,7 @@ class TelegramConnector:
         chat_id_value = _extract_chat_id(chat)
         if chat_id_value is None:
             return None
+        self._observe_chat_from_payload(update_id=update_id, update_kind="message", payload=payload)
         if self._allowed_chat_ids and chat_id_value not in self._allowed_chat_ids:
             return None
         return self._build_envelope(
@@ -167,6 +190,7 @@ class TelegramConnector:
         chat_id_value = _extract_chat_id(chat)
         if chat_id_value is None:
             return None
+        self._observe_chat_from_payload(update_id=update_id, update_kind="channel_post", payload=payload)
         if chat.get("type") != "channel":
             return None
         if not self._allowed_channel_ids:
@@ -237,6 +261,33 @@ class TelegramConnector:
             ),
             dedupe_key=event_id,
             prompt_context=self._prompt_context,
+        )
+
+    def _observe_chat_from_payload(
+        self,
+        *,
+        update_id: int,
+        update_kind: str,
+        payload: dict[str, object],
+    ) -> None:
+        if self._observe_chat is None:
+            return
+        chat = payload.get("chat")
+        if not isinstance(chat, dict):
+            return
+        chat_id_value = _extract_chat_id(chat)
+        if chat_id_value is None:
+            return
+        self._observe_chat(
+            TelegramChatObservation(
+                chat_id=chat_id_value,
+                chat_type=_extract_optional_str(chat.get("type")),
+                title=_extract_optional_str(chat.get("title")),
+                username=_extract_optional_str(chat.get("username")),
+                update_id=update_id,
+                update_kind=update_kind,
+                message_date=_parse_optional_message_timestamp(payload.get("date")),
+            )
         )
 
     def _extract_attachments(
@@ -312,6 +363,12 @@ def _extract_actor(raw_sender: object) -> str | None:
         return username
     if isinstance(sender_id, int):
         return str(sender_id)
+    return None
+
+
+def _extract_optional_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
     return None
 
 
@@ -439,6 +496,12 @@ def _parse_message_timestamp(value: object) -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _parse_optional_message_timestamp(value: object) -> datetime | None:
+    if isinstance(value, int):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    return None
+
+
 def _default_http_get_json(url: str, timeout_seconds: float) -> TelegramGetUpdatesResponse:
     request = urllib.request.Request(url=url, method="GET")
     try:
@@ -489,4 +552,9 @@ def _default_download_file_bytes(url: str, timeout_seconds: float) -> bytes:
         raise RuntimeError("telegram_http_error") from error
 
 
-__all__ = ["TelegramConnector", "TelegramFileMetadata", "TelegramGetUpdatesResponse"]
+__all__ = [
+    "TelegramChatObservation",
+    "TelegramConnector",
+    "TelegramFileMetadata",
+    "TelegramGetUpdatesResponse",
+]

--- a/app/handler/main.py
+++ b/app/handler/main.py
@@ -56,6 +56,7 @@ from app.handler.runtime import (
     TaskLedgerStore,
     TelegramAttachmentCleanupResult,
     TelegramAttachmentStore,
+    TelegramChatRegistryStore,
     cleanup_telegram_attachments,
 )
 from app.models import OutboundMessage, PromptContext, TaskEnvelope
@@ -1016,7 +1017,7 @@ def _is_connector_configured(
 
 
 def _build_live_connectors(
-    args: argparse.Namespace, config: dict[str, object]
+    args: argparse.Namespace, config: dict[str, object], *, db_path: str | None = None
 ) -> list[Connector]:
     connectors: list[Connector] = []
     global_prompt_context = _resolve_prompt_context_values(
@@ -1152,6 +1153,9 @@ def _build_live_connectors(
             raise ValueError(
                 f"missing Telegram bot token env var: {telegram_bot_token_env}"
             )
+        telegram_chat_registry = (
+            TelegramChatRegistryStore(db_path) if db_path is not None else None
+        )
         connectors.append(
             TelegramConnector(
                 bot_token=bot_token,
@@ -1175,6 +1179,21 @@ def _build_live_connectors(
                     reply_channel_instructions=telegram_prompt_context,
                 ),
                 attachment_root_dir=_resolve_telegram_attachment_dir(args, config),
+                observe_chat=(
+                    (
+                        lambda observation: telegram_chat_registry.record_chat(
+                            chat_id=observation.chat_id,
+                            chat_type=observation.chat_type,
+                            title=observation.title,
+                            username=observation.username,
+                            update_id=observation.update_id,
+                            update_kind=observation.update_kind,
+                            message_date=observation.message_date,
+                        )
+                    )
+                    if telegram_chat_registry is not None
+                    else None
+                ),
             )
         )
 
@@ -1569,7 +1588,9 @@ def _build_live_connectors_fail_open(
                     )
                 )
                 continue
-            connectors.extend(_build_live_connectors(scoped_args, scoped_config))
+            connectors.extend(
+                _build_live_connectors(scoped_args, scoped_config, db_path=db_path)
+            )
         except Exception as error:  # noqa: BLE001
             LOGGER.exception(
                 "ingress_connector_startup_failed connector=%s", connector_name

--- a/app/handler/runtime.py
+++ b/app/handler/runtime.py
@@ -57,6 +57,19 @@ class TelegramAttachmentRecord:
 
 
 @dataclass(frozen=True)
+class TelegramChatRecord:
+    chat_id: str
+    chat_type: str | None
+    title: str | None
+    username: str | None
+    first_seen_at: datetime
+    last_retrieved_at: datetime
+    last_message_at: datetime | None
+    last_update_id: int
+    last_update_kind: str
+
+
+@dataclass(frozen=True)
 class TelegramAttachmentCleanupResult:
     deleted_count: int = 0
     missing_count: int = 0
@@ -598,6 +611,122 @@ class TelegramAttachmentStore:
         return [_attachment_record_from_row(row) for row in rows]
 
 
+class TelegramChatRegistryStore:
+    """Persist Telegram chats observed during handler polling."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._db_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _initialize(self) -> None:
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS telegram_chat_registry (
+                    chat_id TEXT PRIMARY KEY,
+                    chat_type TEXT,
+                    title TEXT,
+                    username TEXT,
+                    first_seen_at TEXT NOT NULL,
+                    last_retrieved_at TEXT NOT NULL,
+                    last_message_at TEXT,
+                    last_update_id INTEGER NOT NULL,
+                    last_update_kind TEXT NOT NULL
+                )
+                """
+            )
+            connection.commit()
+
+    def record_chat(
+        self,
+        *,
+        chat_id: str,
+        chat_type: str | None,
+        title: str | None,
+        username: str | None,
+        update_id: int,
+        update_kind: str,
+        message_date: datetime | None,
+        retrieved_at: datetime | None = None,
+    ) -> None:
+        if not chat_id:
+            raise ValueError("chat_id is required")
+        if not update_kind:
+            raise ValueError("update_kind is required")
+        if message_date is not None and message_date.tzinfo is None:
+            raise ValueError("message_date must be timezone-aware")
+        observed_at = retrieved_at or datetime.now(timezone.utc)
+        if observed_at.tzinfo is None:
+            raise ValueError("retrieved_at must be timezone-aware")
+        serialized_observed_at = _serialize_rfc3339_utc(observed_at)
+        serialized_message_date = (
+            _serialize_rfc3339_utc(message_date) if message_date is not None else None
+        )
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                INSERT INTO telegram_chat_registry (
+                    chat_id,
+                    chat_type,
+                    title,
+                    username,
+                    first_seen_at,
+                    last_retrieved_at,
+                    last_message_at,
+                    last_update_id,
+                    last_update_kind
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(chat_id) DO UPDATE SET
+                    chat_type = COALESCE(excluded.chat_type, telegram_chat_registry.chat_type),
+                    title = COALESCE(excluded.title, telegram_chat_registry.title),
+                    username = COALESCE(excluded.username, telegram_chat_registry.username),
+                    last_retrieved_at = excluded.last_retrieved_at,
+                    last_message_at = COALESCE(excluded.last_message_at, telegram_chat_registry.last_message_at),
+                    last_update_id = excluded.last_update_id,
+                    last_update_kind = excluded.last_update_kind
+                """,
+                (
+                    chat_id,
+                    chat_type,
+                    title,
+                    username,
+                    serialized_observed_at,
+                    serialized_observed_at,
+                    serialized_message_date,
+                    update_id,
+                    update_kind,
+                ),
+            )
+            connection.commit()
+
+    def list_chats(self) -> list[TelegramChatRecord]:
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT
+                    chat_id,
+                    chat_type,
+                    title,
+                    username,
+                    first_seen_at,
+                    last_retrieved_at,
+                    last_message_at,
+                    last_update_id,
+                    last_update_kind
+                FROM telegram_chat_registry
+                ORDER BY last_retrieved_at DESC, chat_id ASC
+                """
+            ).fetchall()
+        return [_telegram_chat_record_from_row(row) for row in rows]
+
+
 def cleanup_telegram_attachments(
     *,
     attachment_store: TelegramAttachmentStore,
@@ -723,6 +852,23 @@ def _attachment_record_from_row(row: sqlite3.Row) -> TelegramAttachmentRecord:
     )
 
 
+def _telegram_chat_record_from_row(row: sqlite3.Row) -> TelegramChatRecord:
+    last_message_at = row["last_message_at"]
+    return TelegramChatRecord(
+        chat_id=row["chat_id"],
+        chat_type=row["chat_type"],
+        title=row["title"],
+        username=row["username"],
+        first_seen_at=_parse_rfc3339_utc(row["first_seen_at"]),
+        last_retrieved_at=_parse_rfc3339_utc(row["last_retrieved_at"]),
+        last_message_at=(
+            _parse_rfc3339_utc(last_message_at) if last_message_at is not None else None
+        ),
+        last_update_id=int(row["last_update_id"]),
+        last_update_kind=row["last_update_kind"],
+    )
+
+
 def _tracked_attachment_path(*, attachment_uri: str, attachment_root_dir: Path) -> Path | None:
     parsed = urlparse(attachment_uri)
     if parsed.scheme != "file":
@@ -749,5 +895,7 @@ __all__ = [
     "TelegramAttachmentCleanupResult",
     "TelegramAttachmentRecord",
     "TelegramAttachmentStore",
+    "TelegramChatRecord",
+    "TelegramChatRegistryStore",
     "cleanup_telegram_attachments",
 ]

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -44,6 +44,7 @@ Matching CLI flags exist (`--telegram-enabled`, `--telegram-bot-token-env`, etc.
 - When a message includes both text and a Telegram `location`, the location block is appended to the text so the worker can reason over both in one prompt.
 - `channel_post` updates are ignored unless the channel ID is present in `telegram_allowed_channel_ids`.
 - Ignored `channel_post` updates log `update_id`, `channel_id`, and an explicit reason so new channel IDs can be copied from logs.
+- Each observed `message`, `channel_post`, and `my_chat_member` chat is upserted into the handler SQLite table `telegram_chat_registry` before allowlist filtering. Query that table to discover new DM/group/supergroup/channel IDs, titles, usernames, and the latest retrieval timestamp.
 - Offset is advanced as `highest_update_id + 1` each poll.
 - The message handler tracks downloaded Telegram attachments in its SQLite DB and only makes them cleanup-eligible after the task reaches terminal completion.
 - Cleanup uses a hybrid policy:

--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -369,6 +369,7 @@ This covers the lowest-complexity real-world integration pair.
 Implement:
 - Telegram ingress
 - Telegram dispatch
+- Telegram chat registry state for observed DM/group/supergroup/channel IDs
 - attachment tracking and cleanup
 
 Telegram is more stateful and should come after the egress engine is already proven.
@@ -667,14 +668,16 @@ Validation:
 - parse-mode fallback behavior matches Python
 - attachment URI validation matches Python behavior
 
-### 16. Telegram Ingress And Attachments
+### 16. Telegram Ingress, Chat Registry, And Attachments
 
 Implement Telegram getUpdates polling, update normalization, attachment download, conversation memory,
-and attachment cleanup state.
+chat registry state, and attachment cleanup state.
 
 Validation:
 - fake Telegram update tests cover text, channel posts, reactions, photos, and location payloads
 - allowlist behavior matches Python
+- observed `message`, `channel_post`, and `my_chat_member` chats are recorded in the SQLite
+  `telegram_chat_registry` table before allowlist filtering
 - conversation memory is included for Telegram tasks
 - attachment cleanup tests match Python semantics
 
@@ -727,4 +730,4 @@ Validation:
 ## Immediate Next Steps
 
 1. Add Telegram dispatch.
-2. Add Telegram ingress and attachment tracking.
+2. Add Telegram ingress, chat registry, and attachment tracking.

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -21,6 +21,7 @@ from app.handler.connectors.auxiliary_ingress_connector import AuxiliaryIngressC
 from app.handler.connectors.telegram_connector import (
     TelegramFileMetadata,
     TelegramConnector,
+    TelegramChatObservation,
     TelegramGetUpdatesResponse,
 )
 from app.handler.github_ingress import GitHubAssignmentCheckpointStore
@@ -1004,6 +1005,94 @@ class TelegramConnectorTests(unittest.TestCase):
 
         self.assertEqual(len(envelopes), 1)
         self.assertEqual(envelopes[0].id, "telegram:2001")
+
+    def test_poll_observes_chats_before_allowlist_filtering(self) -> None:
+        observations: list[TelegramChatObservation] = []
+        connector = TelegramConnector(
+            bot_token="token",
+            allowed_chat_ids=["12345"],
+            allowed_channel_ids=["-100123"],
+            observe_chat=observations.append,
+            http_get_json=lambda _url, _timeout: TelegramGetUpdatesResponse(
+                ok=True,
+                result=[
+                    {
+                        "update_id": 2101,
+                        "message": {
+                            "message_id": 1,
+                            "date": 1772272800,
+                            "text": "blocked",
+                            "chat": {
+                                "id": -100999,
+                                "type": "supergroup",
+                                "title": "New group",
+                            },
+                        },
+                    },
+                    {
+                        "update_id": 2102,
+                        "channel_post": {
+                            "message_id": 2,
+                            "date": 1772272801,
+                            "text": "blocked channel",
+                            "chat": {
+                                "id": -100998,
+                                "type": "channel",
+                                "title": "New channel",
+                                "username": "new_channel",
+                            },
+                        },
+                    },
+                    {
+                        "update_id": 2103,
+                        "my_chat_member": {
+                            "date": 1772272802,
+                            "chat": {
+                                "id": -100997,
+                                "type": "group",
+                                "title": "Added here",
+                            },
+                        },
+                    },
+                ],
+            ),
+        )
+
+        envelopes = connector.poll()
+
+        self.assertEqual(envelopes, [])
+        self.assertEqual(
+            observations,
+            [
+                TelegramChatObservation(
+                    chat_id="-100999",
+                    chat_type="supergroup",
+                    title="New group",
+                    username=None,
+                    update_id=2101,
+                    update_kind="message",
+                    message_date=datetime.fromtimestamp(1772272800, tz=timezone.utc),
+                ),
+                TelegramChatObservation(
+                    chat_id="-100998",
+                    chat_type="channel",
+                    title="New channel",
+                    username="new_channel",
+                    update_id=2102,
+                    update_kind="channel_post",
+                    message_date=datetime.fromtimestamp(1772272801, tz=timezone.utc),
+                ),
+                TelegramChatObservation(
+                    chat_id="-100997",
+                    chat_type="group",
+                    title="Added here",
+                    username=None,
+                    update_id=2103,
+                    update_kind="my_chat_member",
+                    message_date=datetime.fromtimestamp(1772272802, tz=timezone.utc),
+                ),
+            ],
+        )
 
     def test_poll_accepts_channel_post_when_channel_id_is_explicitly_allowed(
         self,

--- a/tests/test_message_handler_runtime.py
+++ b/tests/test_message_handler_runtime.py
@@ -23,6 +23,7 @@ from app.internal_heartbeat import build_internal_heartbeat_egress, build_intern
 from app.handler.runtime import (
     TaskLedgerStore,
     TelegramAttachmentStore,
+    TelegramChatRegistryStore,
     cleanup_telegram_attachments,
 )
 from app.models import AttachmentRef, OutboundMessage, ReplyChannel, TaskEnvelope
@@ -38,6 +39,54 @@ class _RecordingApplier:
         return OutboundMessage(
             channel="email", target="alice@example.com", body="ok"
         )
+
+
+class TelegramChatRegistryStoreTests(unittest.TestCase):
+    def test_record_chat_upserts_observed_telegram_chat_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = TelegramChatRegistryStore(str(Path(tmpdir) / "handler.db"))
+            first_seen = datetime(2026, 5, 17, 8, 0, tzinfo=timezone.utc)
+            second_seen = datetime(2026, 5, 17, 8, 5, tzinfo=timezone.utc)
+
+            store.record_chat(
+                chat_id="-1004974044081",
+                chat_type="supergroup",
+                title="Test group",
+                username=None,
+                update_id=1001,
+                update_kind="my_chat_member",
+                message_date=None,
+                retrieved_at=first_seen,
+            )
+            store.record_chat(
+                chat_id="-1004974044081",
+                chat_type="supergroup",
+                title="Renamed group",
+                username="test_group",
+                update_id=1002,
+                update_kind="message",
+                message_date=datetime(2026, 5, 17, 8, 4, tzinfo=timezone.utc),
+                retrieved_at=second_seen,
+            )
+
+            records = store.list_chats()
+
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record.chat_id, "-1004974044081")
+        self.assertEqual(record.chat_type, "supergroup")
+        self.assertEqual(record.title, "Renamed group")
+        self.assertEqual(record.username, "test_group")
+        self.assertEqual(record.first_seen_at, first_seen)
+        self.assertEqual(record.last_retrieved_at, second_seen)
+        self.assertEqual(
+            record.last_message_at,
+            datetime(2026, 5, 17, 8, 4, tzinfo=timezone.utc),
+        )
+        self.assertEqual(record.last_update_id, 1002)
+        self.assertEqual(record.last_update_kind, "message")
+
+
 @dataclass
 class _DispatchFailingApplier:
     apply_calls: int = 0


### PR DESCRIPTION
## Summary
- add a handler SQLite telegram_chat_registry table for observed Telegram chats
- record message, channel_post, and my_chat_member chat metadata before Telegram allowlist filtering
- document the SQL discovery point and cover connector/store behaviour in tests

## Tests
- uv run ruff check app tests
- uv run pyright app/
- uv run python -m unittest tests.test_connectors.TelegramConnectorTests tests.test_message_handler_runtime.TelegramChatRegistryStoreTests
- uv run python -m unittest tests.test_main_github_ingress tests.test_message_handler_runtime
