### PR TITLE
Port Telegram dispatch to Go handler

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -661,6 +661,11 @@ Validation:
 
 ### 15. Telegram Dispatch
 
+Status: complete. The Go handler now accepts the Python handler Telegram
+dispatch config keys, wires Bot API text/reaction/attachment sending into the
+egress dispatcher, preserves parse-mode fallback behavior, and validates local
+attachment URIs before choosing `sendPhoto` or `sendDocument`.
+
 Implement Telegram text, reaction, and attachment dispatch.
 
 Validation:
@@ -729,5 +734,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add Telegram dispatch.
-2. Add Telegram ingress, chat registry, and attachment tracking.
+1. Add Telegram ingress, chat registry, and attachment tracking.
+2. Add GitHub checkpoint persistence.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -208,30 +208,46 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 }
 
 func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, error) {
-	if config.SMTPHost == "" {
-		return dispatch.Dispatcher{}, nil
-	}
-	password := ""
-	if config.SMTPUsername != "" {
-		password = os.Getenv(config.SMTPPasswordEnv)
-		if password == "" {
-			return nil, fmt.Errorf("missing SMTP password env var: %s", config.SMTPPasswordEnv)
+	dispatcher := dispatch.Dispatcher{}
+	if config.SMTPHost != "" {
+		password := ""
+		if config.SMTPUsername != "" {
+			password = os.Getenv(config.SMTPPasswordEnv)
+			if password == "" {
+				return nil, fmt.Errorf("missing SMTP password env var: %s", config.SMTPPasswordEnv)
+			}
 		}
+		sender, err := dispatch.NewSMTPEmailSender(dispatch.SMTPConfig{
+			Host:        config.SMTPHost,
+			Port:        config.SMTPPort,
+			FromAddress: config.SMTPFrom,
+			Username:    config.SMTPUsername,
+			Password:    password,
+			UseSSL:      config.SMTPUseSSL,
+			StartTLS:    config.SMTPStartTLS,
+			Timeout:     10 * time.Second,
+		})
+		if err != nil {
+			return nil, err
+		}
+		dispatcher.EmailSender = sender
 	}
-	sender, err := dispatch.NewSMTPEmailSender(dispatch.SMTPConfig{
-		Host:        config.SMTPHost,
-		Port:        config.SMTPPort,
-		FromAddress: config.SMTPFrom,
-		Username:    config.SMTPUsername,
-		Password:    password,
-		UseSSL:      config.SMTPUseSSL,
-		StartTLS:    config.SMTPStartTLS,
-		Timeout:     10 * time.Second,
-	})
-	if err != nil {
-		return nil, err
+	if config.TelegramEnabled {
+		token := os.Getenv(config.TelegramBotTokenEnv)
+		if token == "" {
+			return nil, fmt.Errorf("missing Telegram bot token env var: %s", config.TelegramBotTokenEnv)
+		}
+		sender, err := dispatch.NewTelegramMessageSender(dispatch.TelegramConfig{
+			BotToken:   token,
+			APIBaseURL: config.TelegramAPIBaseURL,
+			Timeout:    10 * time.Second,
+		})
+		if err != nil {
+			return nil, err
+		}
+		dispatcher.TelegramSender = sender
 	}
-	return dispatch.Dispatcher{EmailSender: sender}, nil
+	return dispatcher, nil
 }
 
 type egressHandlerFunc func(context.Context, []byte) error

--- a/go/handler/cmd/chatting-handler/main_test.go
+++ b/go/handler/cmd/chatting-handler/main_test.go
@@ -175,6 +175,21 @@ func TestBuildDispatcherRequiresSMTPPasswordEnvWhenUsernameConfigured(t *testing
 	}
 }
 
+func TestBuildDispatcherRequiresTelegramTokenWhenEnabled(t *testing.T) {
+	t.Setenv("MISSING_TELEGRAM_TOKEN", "")
+	_, err := buildDispatcher(handlerconfig.Config{
+		TelegramEnabled:     true,
+		TelegramBotTokenEnv: "MISSING_TELEGRAM_TOKEN",
+		TelegramAPIBaseURL:  "https://api.telegram.org",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "missing Telegram bot token env var: MISSING_TELEGRAM_TOKEN") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 type fakeRunnerFactory struct {
 	called bool
 	config handlerconfig.Config

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -51,6 +51,9 @@ var allowedKeys = map[string]bool{
 	"smtp_from":               true,
 	"smtp_starttls":           true,
 	"smtp_use_ssl":            true,
+	"telegram_enabled":        true,
+	"telegram_bot_token_env":  true,
+	"telegram_api_base_url":   true,
 
 	"auxiliary_ingress_enabled":      true,
 	"auxiliary_ingress_bbmb_address": true,
@@ -86,6 +89,9 @@ type Config struct {
 	SMTPFrom              string
 	SMTPStartTLS          bool
 	SMTPUseSSL            bool
+	TelegramEnabled       bool
+	TelegramBotTokenEnv   string
+	TelegramAPIBaseURL    string
 
 	AuxiliaryIngressEnabled     bool
 	AuxiliaryIngressBBMBAddress string
@@ -122,6 +128,9 @@ func Defaults() Config {
 		SMTPFrom:              "",
 		SMTPStartTLS:          false,
 		SMTPUseSSL:            true,
+		TelegramEnabled:       false,
+		TelegramBotTokenEnv:   "CHATTING_TELEGRAM_BOT_TOKEN",
+		TelegramAPIBaseURL:    "https://api.telegram.org",
 
 		AuxiliaryIngressEnabled:     false,
 		AuxiliaryIngressBBMBAddress: "",
@@ -348,6 +357,24 @@ func Load(raw []byte) (Config, error) {
 	}
 	if rawValue, ok := payload["smtp_use_ssl"]; ok && !isNull(rawValue) {
 		config.SMTPUseSSL, err = decodeBool(rawValue, "smtp_use_ssl")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_enabled"]; ok && !isNull(rawValue) {
+		config.TelegramEnabled, err = decodeBool(rawValue, "telegram_enabled")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_bot_token_env"]; ok && !isNull(rawValue) {
+		config.TelegramBotTokenEnv, err = decodeNonEmptyString(rawValue, "telegram_bot_token_env")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_api_base_url"]; ok && !isNull(rawValue) {
+		config.TelegramAPIBaseURL, err = decodeNonEmptyString(rawValue, "telegram_api_base_url")
 		if err != nil {
 			return Config{}, err
 		}

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -49,6 +49,9 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 		"smtp_from": "replies@example.com",
 		"smtp_starttls": true,
 		"smtp_use_ssl": false,
+		"telegram_enabled": true,
+		"telegram_bot_token_env": "TELEGRAM_TOKEN",
+		"telegram_api_base_url": "https://telegram.example.test",
 		"auxiliary_ingress_enabled": true,
 		"auxiliary_ingress_bbmb_address": "10.0.0.2:9998",
 		"auxiliary_ingress_queues": ["generic-post"],
@@ -138,6 +141,15 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 	}
 	if config.SMTPUseSSL {
 		t.Fatal("SMTPUseSSL = true")
+	}
+	if !config.TelegramEnabled {
+		t.Fatal("TelegramEnabled = false")
+	}
+	if config.TelegramBotTokenEnv != "TELEGRAM_TOKEN" {
+		t.Fatalf("TelegramBotTokenEnv = %q", config.TelegramBotTokenEnv)
+	}
+	if config.TelegramAPIBaseURL != "https://telegram.example.test" {
+		t.Fatalf("TelegramAPIBaseURL = %q", config.TelegramAPIBaseURL)
 	}
 	if !config.AuxiliaryIngressEnabled {
 		t.Fatal("AuxiliaryIngressEnabled = false")
@@ -262,6 +274,16 @@ func TestLoadRejectsInvalidValues(t *testing.T) {
 			name:    "smtp starttls wrong type",
 			raw:     `{"smtp_starttls": "yes"}`,
 			message: "config smtp_starttls must be a boolean",
+		},
+		{
+			name:    "telegram enabled wrong type",
+			raw:     `{"telegram_enabled": "yes"}`,
+			message: "config telegram_enabled must be a boolean",
+		},
+		{
+			name:    "blank telegram token env",
+			raw:     `{"telegram_bot_token_env": ""}`,
+			message: "config telegram_bot_token_env must be a non-empty string",
 		},
 		{
 			name:    "enabled auxiliary without queues",

--- a/go/handler/internal/dispatch/dispatch.go
+++ b/go/handler/internal/dispatch/dispatch.go
@@ -13,8 +13,14 @@ type EmailSender interface {
 	Send(ctx context.Context, target string, body string, subject *string) error
 }
 
+type TelegramSender interface {
+	Send(ctx context.Context, target string, message contracts.OutboundMessage) error
+	React(ctx context.Context, target string, messageID int64, emoji string) error
+}
+
 type Dispatcher struct {
-	EmailSender EmailSender
+	EmailSender    EmailSender
+	TelegramSender TelegramSender
 }
 
 type MessageDispatchError struct {
@@ -44,6 +50,29 @@ func (dispatcher Dispatcher) Dispatch(ctx context.Context, message contracts.Out
 		}
 		if err := dispatcher.EmailSender.Send(ctx, target, body, subject); err != nil {
 			return nil, MessageDispatchError{ReasonCode: "email_dispatch_failed"}
+		}
+		return &normalized, nil
+	case "telegram":
+		if dispatcher.TelegramSender == nil {
+			return nil, nil
+		}
+		if err := dispatcher.TelegramSender.Send(ctx, target, message); err != nil {
+			return nil, MessageDispatchError{ReasonCode: telegramDispatchReasonCode(message, err)}
+		}
+		return &normalized, nil
+	case "telegram_reaction":
+		if dispatcher.TelegramSender == nil {
+			return nil, nil
+		}
+		if message.Body == nil {
+			return nil, MessageDispatchError{ReasonCode: "telegram_dispatch_failed"}
+		}
+		messageID, ok := resolveTelegramReactionMessageID(message, envelope)
+		if !ok {
+			return nil, MessageDispatchError{ReasonCode: "telegram_dispatch_failed"}
+		}
+		if err := dispatcher.TelegramSender.React(ctx, target, messageID, *message.Body); err != nil {
+			return nil, MessageDispatchError{ReasonCode: "telegram_dispatch_failed"}
 		}
 		return &normalized, nil
 	default:
@@ -126,4 +155,46 @@ func stripLeadingSubjectLine(body string) string {
 		return body
 	}
 	return cleaned
+}
+
+func resolveTelegramReactionMessageID(message contracts.OutboundMessage, envelope contracts.TaskEnvelope) (int64, bool) {
+	if value, ok := metadataPositiveInt(message.Metadata, "message_id"); ok {
+		return value, true
+	}
+	return metadataPositiveInt(envelope.ReplyChannel.Metadata, "message_id")
+}
+
+func metadataPositiveInt(metadata map[string]any, key string) (int64, bool) {
+	if metadata == nil {
+		return 0, false
+	}
+	switch value := metadata[key].(type) {
+	case int:
+		if value > 0 {
+			return int64(value), true
+		}
+	case int64:
+		if value > 0 {
+			return value, true
+		}
+	case float64:
+		asInt := int64(value)
+		if value > 0 && float64(asInt) == value {
+			return asInt, true
+		}
+	}
+	return 0, false
+}
+
+func telegramDispatchReasonCode(message contracts.OutboundMessage, err error) string {
+	if err != nil {
+		reason := strings.TrimSpace(err.Error())
+		if strings.HasPrefix(reason, "telegram_") {
+			return reason
+		}
+	}
+	if message.Attachment != nil {
+		return "telegram_attachment_dispatch_failed"
+	}
+	return "telegram_dispatch_failed"
 }

--- a/go/handler/internal/dispatch/dispatch_test.go
+++ b/go/handler/internal/dispatch/dispatch_test.go
@@ -2,7 +2,14 @@ package dispatch
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -141,6 +148,199 @@ func TestDispatcherReturnsEmailFailureReason(t *testing.T) {
 	}
 }
 
+func TestDispatcherSendsTelegramMessage(t *testing.T) {
+	body := "Done via telegram."
+	sender := &recordingTelegramSender{}
+	message := contracts.OutboundMessage{
+		Channel: "telegram",
+		Target:  "12345",
+		Body:    &body,
+	}
+
+	dispatched, err := (Dispatcher{TelegramSender: sender}).Dispatch(context.Background(), message, contracts.TaskEnvelope{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dispatched == nil || dispatched.Channel != "telegram" || dispatched.Target != "12345" {
+		t.Fatalf("dispatched = %#v", dispatched)
+	}
+	if len(sender.messages) != 1 || sender.messages[0].target != "12345" {
+		t.Fatalf("messages = %#v", sender.messages)
+	}
+}
+
+func TestDispatcherSendsTelegramReactionFromEnvelopeMetadata(t *testing.T) {
+	body := "👍"
+	sender := &recordingTelegramSender{}
+	message := contracts.OutboundMessage{
+		Channel: "telegram_reaction",
+		Target:  "12345",
+		Body:    &body,
+	}
+	envelope := contracts.TaskEnvelope{
+		ReplyChannel: contracts.ReplyChannel{
+			Type:     "telegram",
+			Target:   "12345",
+			Metadata: map[string]any{"message_id": float64(42)},
+		},
+	}
+
+	_, err := (Dispatcher{TelegramSender: sender}).Dispatch(context.Background(), message, envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.reactions) != 1 || sender.reactions[0].messageID != 42 || sender.reactions[0].emoji != "👍" {
+		t.Fatalf("reactions = %#v", sender.reactions)
+	}
+}
+
+func TestDispatcherReturnsTelegramAttachmentFailureReason(t *testing.T) {
+	body := "photo"
+	message := contracts.OutboundMessage{
+		Channel: "telegram",
+		Target:  "12345",
+		Body:    &body,
+		Attachment: &contracts.AttachmentRef{
+			URI: "/tmp/missing.png",
+		},
+	}
+
+	_, err := (Dispatcher{TelegramSender: &recordingTelegramSender{err: errors.New("telegram_attachment_missing")}}).Dispatch(context.Background(), message, contracts.TaskEnvelope{})
+	var dispatchErr MessageDispatchError
+	if !errors.As(err, &dispatchErr) || dispatchErr.ReasonCode != "telegram_attachment_missing" {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestTelegramMessageSenderSendsTextAndFallsBackWithoutParseMode(t *testing.T) {
+	var calls []telegramHTTPCall
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		call := recordTelegramJSONCall(t, request)
+		calls = append(calls, call)
+		if len(calls) == 1 {
+			_ = json.NewEncoder(writer).Encode(map[string]any{"ok": false, "description": "Bad Request: can't parse entities"})
+			return
+		}
+		_ = json.NewEncoder(writer).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+	sender := newTestTelegramSender(t, server.URL)
+	body := `Line 1.\nNeeds *escaping*.`
+
+	err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{Channel: "telegram", Target: "12345", Body: &body})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls = %#v", calls)
+	}
+	if calls[0].path != "/bottoken/sendMessage" || calls[0].payload["parse_mode"] != "Markdown" {
+		t.Fatalf("first call = %#v", calls[0])
+	}
+	if calls[0].payload["text"] != "Line 1.\nNeeds \\*escaping\\*." {
+		t.Fatalf("first text = %#v", calls[0].payload["text"])
+	}
+	if _, ok := calls[1].payload["parse_mode"]; ok {
+		t.Fatalf("fallback still has parse_mode: %#v", calls[1].payload)
+	}
+	if calls[1].payload["text"] != "Line 1.\nNeeds *escaping*." {
+		t.Fatalf("fallback text = %#v", calls[1].payload["text"])
+	}
+}
+
+func TestTelegramMessageSenderSendsReaction(t *testing.T) {
+	var call telegramHTTPCall
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		call = recordTelegramJSONCall(t, request)
+		_ = json.NewEncoder(writer).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+	sender := newTestTelegramSender(t, server.URL)
+
+	if err := sender.React(context.Background(), "12345", 99, "🙂"); err != nil {
+		t.Fatal(err)
+	}
+	if call.path != "/bottoken/setMessageReaction" || call.payload["message_id"] != float64(99) {
+		t.Fatalf("call = %#v", call)
+	}
+	reactions, ok := call.payload["reaction"].([]any)
+	if !ok || len(reactions) != 1 {
+		t.Fatalf("reaction = %#v", call.payload["reaction"])
+	}
+}
+
+func TestTelegramMessageSenderSendsPhotoAttachment(t *testing.T) {
+	tempDir := t.TempDir()
+	photoPath := filepath.Join(tempDir, "plant.png")
+	if err := os.WriteFile(photoPath, []byte("png bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var multipartCall telegramMultipartCall
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		multipartCall = recordTelegramMultipartCall(t, request)
+		_ = json.NewEncoder(writer).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+	sender := newTestTelegramSender(t, server.URL)
+	body := "what is this?"
+
+	if err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{
+		Channel: "telegram",
+		Target:  "12345",
+		Body:    &body,
+		Attachment: &contracts.AttachmentRef{
+			URI: photoPath,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if multipartCall.path != "/bottoken/sendPhoto" || multipartCall.fields["chat_id"] != "12345" || multipartCall.fileField != "photo" {
+		t.Fatalf("multipart call = %#v", multipartCall)
+	}
+}
+
+func TestTelegramMessageSenderSendsDocumentAttachmentFromFileURI(t *testing.T) {
+	tempDir := t.TempDir()
+	documentPath := filepath.Join(tempDir, "report.txt")
+	if err := os.WriteFile(documentPath, []byte("report"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var multipartCall telegramMultipartCall
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		multipartCall = recordTelegramMultipartCall(t, request)
+		_ = json.NewEncoder(writer).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+	sender := newTestTelegramSender(t, server.URL)
+
+	if err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{
+		Channel: "telegram",
+		Target:  "12345",
+		Attachment: &contracts.AttachmentRef{
+			URI: "file://" + documentPath,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if multipartCall.path != "/bottoken/sendDocument" || multipartCall.fileField != "document" {
+		t.Fatalf("multipart call = %#v", multipartCall)
+	}
+}
+
+func TestTelegramMessageSenderRejectsUnsupportedAttachmentURI(t *testing.T) {
+	sender := newTestTelegramSender(t, "http://127.0.0.1")
+	err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{
+		Channel: "telegram",
+		Target:  "12345",
+		Attachment: &contracts.AttachmentRef{
+			URI: "https://example.com/image.png",
+		},
+	})
+	if err == nil || err.Error() != "telegram_attachment_unsupported_uri" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 type sentEmail struct {
 	target  string
 	body    string
@@ -158,6 +358,101 @@ func (sender *recordingEmailSender) Send(_ context.Context, target string, body 
 	}
 	sender.messages = append(sender.messages, sentEmail{target: target, body: body, subject: subject})
 	return nil
+}
+
+type sentTelegram struct {
+	target  string
+	message contracts.OutboundMessage
+}
+
+type sentReaction struct {
+	target    string
+	messageID int64
+	emoji     string
+}
+
+type recordingTelegramSender struct {
+	messages  []sentTelegram
+	reactions []sentReaction
+	err       error
+}
+
+func (sender *recordingTelegramSender) Send(_ context.Context, target string, message contracts.OutboundMessage) error {
+	if sender.err != nil {
+		return sender.err
+	}
+	sender.messages = append(sender.messages, sentTelegram{target: target, message: message})
+	return nil
+}
+
+func (sender *recordingTelegramSender) React(_ context.Context, target string, messageID int64, emoji string) error {
+	if sender.err != nil {
+		return sender.err
+	}
+	sender.reactions = append(sender.reactions, sentReaction{target: target, messageID: messageID, emoji: emoji})
+	return nil
+}
+
+type telegramHTTPCall struct {
+	path    string
+	payload map[string]any
+}
+
+type telegramMultipartCall struct {
+	path      string
+	fields    map[string]string
+	fileField string
+	fileName  string
+}
+
+func newTestTelegramSender(t *testing.T, apiBaseURL string) *TelegramMessageSender {
+	t.Helper()
+	sender, err := NewTelegramMessageSender(TelegramConfig{BotToken: "token", APIBaseURL: apiBaseURL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sender
+}
+
+func recordTelegramJSONCall(t *testing.T, request *http.Request) telegramHTTPCall {
+	t.Helper()
+	if request.Method != http.MethodPost {
+		t.Fatalf("method = %s", request.Method)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	return telegramHTTPCall{path: request.URL.Path, payload: payload}
+}
+
+func recordTelegramMultipartCall(t *testing.T, request *http.Request) telegramMultipartCall {
+	t.Helper()
+	reader, err := request.MultipartReader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	call := telegramMultipartCall{path: request.URL.Path, fields: map[string]string{}}
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, multipart.ErrMessageTooLarge) {
+			t.Fatal(err)
+		}
+		if err != nil {
+			break
+		}
+		if part.FileName() == "" {
+			raw, err := io.ReadAll(part)
+			if err != nil {
+				t.Fatal(err)
+			}
+			call.fields[part.FormName()] = string(raw)
+			continue
+		}
+		call.fileField = part.FormName()
+		call.fileName = part.FileName()
+	}
+	return call
 }
 
 func emailEnvelope(subject string, body string) contracts.TaskEnvelope {

--- a/go/handler/internal/dispatch/telegram.go
+++ b/go/handler/internal/dispatch/telegram.go
@@ -1,0 +1,332 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+type TelegramConfig struct {
+	BotToken   string
+	APIBaseURL string
+	ParseMode  *string
+	Timeout    time.Duration
+	HTTPClient *http.Client
+}
+
+type TelegramMessageSender struct {
+	botToken   string
+	apiBaseURL string
+	parseMode  *string
+	client     *http.Client
+}
+
+func NewTelegramMessageSender(config TelegramConfig) (*TelegramMessageSender, error) {
+	if strings.TrimSpace(config.BotToken) == "" {
+		return nil, errors.New("bot_token is required")
+	}
+	if strings.TrimSpace(config.APIBaseURL) == "" {
+		return nil, errors.New("api_base_url is required")
+	}
+	parseMode := config.ParseMode
+	if parseMode == nil {
+		defaultParseMode := "Markdown"
+		parseMode = &defaultParseMode
+	}
+	if parseMode != nil && *parseMode != "Markdown" && *parseMode != "MarkdownV2" && *parseMode != "HTML" {
+		return nil, errors.New("parse_mode must be one of Markdown, MarkdownV2, HTML, or nil")
+	}
+	timeout := config.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+	if timeout < 0 {
+		return nil, errors.New("timeout must be positive")
+	}
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+	return &TelegramMessageSender{
+		botToken:   config.BotToken,
+		apiBaseURL: strings.TrimRight(config.APIBaseURL, "/"),
+		parseMode:  parseMode,
+		client:     client,
+	}, nil
+}
+
+func (sender *TelegramMessageSender) Send(ctx context.Context, target string, message contracts.OutboundMessage) error {
+	if strings.TrimSpace(target) == "" {
+		return errors.New("target is required")
+	}
+	if message.Attachment == nil {
+		if message.Body == nil || strings.TrimSpace(*message.Body) == "" {
+			return errors.New("body is required")
+		}
+		return sender.sendText(ctx, target, *message.Body)
+	}
+
+	filePath, err := resolveTelegramAttachmentPath(message.Attachment.URI)
+	if err != nil {
+		return err
+	}
+	method := telegramAPIMethodForAttachment(filePath)
+	fileField := "document"
+	if method == "sendPhoto" {
+		fileField = "photo"
+	}
+	payload := map[string]string{"chat_id": target}
+	if message.Body != nil {
+		payload["caption"] = normalizeTelegramTextForParseMode(*message.Body, sender.parseMode)
+		if sender.parseMode != nil {
+			payload["parse_mode"] = *sender.parseMode
+		}
+	}
+	response, err := sender.postMultipart(ctx, method, payload, fileField, filePath)
+	if err == nil && response.OK {
+		return nil
+	}
+	if err == nil && sender.parseMode != nil && message.Body != nil && isTelegramParseModeError(response) {
+		fallback := map[string]string{"chat_id": target, "caption": *message.Body}
+		response, err = sender.postMultipart(ctx, method, fallback, fileField, filePath)
+		if err == nil && response.OK {
+			return nil
+		}
+	}
+	return errors.New("telegram_attachment_send_failed")
+}
+
+func (sender *TelegramMessageSender) React(ctx context.Context, target string, messageID int64, emoji string) error {
+	if strings.TrimSpace(target) == "" {
+		return errors.New("target is required")
+	}
+	if messageID <= 0 {
+		return errors.New("message_id must be positive")
+	}
+	if strings.TrimSpace(emoji) == "" {
+		return errors.New("emoji is required")
+	}
+	payload := map[string]any{
+		"chat_id":    target,
+		"message_id": messageID,
+		"reaction": []map[string]string{
+			{"type": "emoji", "emoji": strings.TrimSpace(emoji)},
+		},
+	}
+	response, err := sender.postJSON(ctx, "setMessageReaction", payload)
+	if err != nil || !response.OK {
+		return errors.New("telegram_reaction_failed")
+	}
+	return nil
+}
+
+func (sender *TelegramMessageSender) sendText(ctx context.Context, target string, body string) error {
+	normalizedBody := normalizeTelegramOutboundText(body)
+	payload := map[string]any{
+		"chat_id": target,
+		"text":    normalizeTelegramTextForParseMode(normalizedBody, sender.parseMode),
+	}
+	if sender.parseMode != nil {
+		payload["parse_mode"] = *sender.parseMode
+	}
+	response, err := sender.postJSON(ctx, "sendMessage", payload)
+	if err == nil && response.OK {
+		return nil
+	}
+	if err == nil && sender.parseMode != nil && isTelegramParseModeError(response) {
+		fallback := map[string]any{"chat_id": target, "text": normalizedBody}
+		response, err = sender.postJSON(ctx, "sendMessage", fallback)
+		if err == nil && response.OK {
+			return nil
+		}
+	}
+	return errors.New("telegram_send_failed")
+}
+
+type telegramAPIResponse struct {
+	OK          bool   `json:"ok"`
+	Description string `json:"description"`
+}
+
+func (sender *TelegramMessageSender) postJSON(ctx context.Context, method string, payload any) (telegramAPIResponse, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return telegramAPIResponse{}, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, sender.methodURL(method), bytes.NewReader(body))
+	if err != nil {
+		return telegramAPIResponse{}, err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	return sender.do(request)
+}
+
+func (sender *TelegramMessageSender) postMultipart(ctx context.Context, method string, payload map[string]string, fileField string, filePath string) (telegramAPIResponse, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for key, value := range payload {
+		if err := writer.WriteField(key, value); err != nil {
+			return telegramAPIResponse{}, err
+		}
+	}
+	file, err := os.Open(filePath)
+	if err != nil {
+		return telegramAPIResponse{}, err
+	}
+	defer file.Close()
+	mimeType := mime.TypeByExtension(filepath.Ext(filePath))
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	part, err := writer.CreatePart(map[string][]string{
+		"Content-Disposition": {fmt.Sprintf(`form-data; name="%s"; filename="%s"`, fileField, filepath.Base(filePath))},
+		"Content-Type":        {mimeType},
+	})
+	if err != nil {
+		return telegramAPIResponse{}, err
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return telegramAPIResponse{}, err
+	}
+	if err := writer.Close(); err != nil {
+		return telegramAPIResponse{}, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, sender.methodURL(method), &body)
+	if err != nil {
+		return telegramAPIResponse{}, err
+	}
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	return sender.do(request)
+}
+
+func (sender *TelegramMessageSender) do(request *http.Request) (telegramAPIResponse, error) {
+	response, err := sender.client.Do(request)
+	if err != nil {
+		return telegramAPIResponse{}, err
+	}
+	defer response.Body.Close()
+	raw, err := io.ReadAll(response.Body)
+	if err != nil {
+		return telegramAPIResponse{}, err
+	}
+	var parsed telegramAPIResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return telegramAPIResponse{}, err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return parsed, nil
+	}
+	return parsed, nil
+}
+
+func (sender *TelegramMessageSender) methodURL(method string) string {
+	return sender.apiBaseURL + "/bot" + sender.botToken + "/" + method
+}
+
+func resolveTelegramAttachmentPath(rawURI string) (string, error) {
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return "", errors.New("telegram_attachment_unsupported_uri")
+	}
+	var path string
+	switch parsed.Scheme {
+	case "":
+		path = rawURI
+	case "file":
+		unescaped, err := url.PathUnescape(parsed.Path)
+		if err != nil {
+			return "", errors.New("telegram_attachment_unsupported_uri")
+		}
+		path = unescaped
+		if parsed.Host != "" {
+			path = "//" + parsed.Host + path
+		}
+	default:
+		return "", errors.New("telegram_attachment_unsupported_uri")
+	}
+	if !filepath.IsAbs(path) {
+		return "", errors.New("telegram_attachment_path_not_absolute")
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return "", errors.New("telegram_attachment_missing")
+	}
+	return path, nil
+}
+
+func telegramAPIMethodForAttachment(filePath string) string {
+	mimeType := mime.TypeByExtension(filepath.Ext(filePath))
+	if strings.HasPrefix(mimeType, "image/") {
+		return "sendPhoto"
+	}
+	return "sendDocument"
+}
+
+func isTelegramParseModeError(response telegramAPIResponse) bool {
+	return strings.Contains(strings.ToLower(response.Description), "parse entities")
+}
+
+func normalizeTelegramTextForParseMode(text string, parseMode *string) string {
+	if parseMode == nil {
+		return text
+	}
+	switch *parseMode {
+	case "HTML":
+		return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(text)
+	case "MarkdownV2":
+		return escapeWithBackslashPrefix(text, "\\_*[]()~`>#+-=|{}.!")
+	case "Markdown":
+		return escapeWithBackslashPrefix(text, "\\_*`[]()")
+	default:
+		return text
+	}
+}
+
+func escapeWithBackslashPrefix(text string, specials string) string {
+	var builder strings.Builder
+	for _, character := range text {
+		if strings.ContainsRune(specials, character) {
+			builder.WriteRune('\\')
+		}
+		builder.WriteRune(character)
+	}
+	return builder.String()
+}
+
+func normalizeTelegramOutboundText(text string) string {
+	normalized := strings.ReplaceAll(text, "\r\n", "\n")
+	patterns := []struct {
+		expression  *regexp.Regexp
+		replacement string
+	}{
+		{regexp.MustCompile(`(?:\\)+r(?:\\)+n`), "\n"},
+		{regexp.MustCompile(`(?:\\)+n`), "\n"},
+		{regexp.MustCompile(`(?:\\)+r`), "\n"},
+		{regexp.MustCompile(`(?:\\)+([\\_*` + "`" + `\[\]\(\)~>#\+\-=|{}.!])`), "$1"},
+	}
+	for range 3 {
+		previous := normalized
+		for _, pattern := range patterns {
+			normalized = pattern.expression.ReplaceAllString(normalized, pattern.replacement)
+		}
+		normalized = strings.ReplaceAll(normalized, `\t`, "\t")
+		if normalized == previous {
+			break
+		}
+	}
+	return normalized
+}


### PR DESCRIPTION
## Summary
- port Telegram egress config into the Go handler bootstrap
- add Go Bot API sender for sendMessage, setMessageReaction, sendPhoto, and sendDocument
- preserve Python-compatible parse-mode fallback and local attachment URI validation
- mark Telegram dispatch complete in the Go port plan

## Validation
- gofmt -l .
- go test ./...
