### PR TITLE
Port Telegram ingress registry to Go handler

### DIFF
--- a/configs/handler.json.example
+++ b/configs/handler.json.example
@@ -17,5 +17,11 @@
   "smtp_from": "bot@example.com",
   "telegram_enabled": false,
   "telegram_bot_token_env": "CHATTING_TELEGRAM_BOT_TOKEN",
+  "telegram_api_base_url": "https://api.telegram.org",
+  "telegram_poll_timeout_seconds": 20,
+  "telegram_allowed_chat_ids": [],
+  "telegram_allowed_channel_ids": [],
+  "telegram_context_refs": [],
+  "telegram_prompt_context": [],
   "telegram_attachment_dir": "/var/lib/chatting/telegram-attachments"
 }

--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -675,6 +675,14 @@ Validation:
 
 ### 16. Telegram Ingress, Chat Registry, And Attachments
 
+Status: in progress. The Go handler now accepts Telegram ingress config keys,
+polls Bot API `getUpdates`, normalizes allowlisted text/caption/location
+`message` and `channel_post` updates into Python-compatible IM task envelopes,
+advances update offsets, observes `my_chat_member` updates, and upserts observed
+Telegram chat metadata into the Python-compatible `telegram_chat_registry`
+SQLite table before allowlist filtering. Media download and attachment cleanup
+state remain to be ported.
+
 Implement Telegram getUpdates polling, update normalization, attachment download, conversation memory,
 chat registry state, and attachment cleanup state.
 
@@ -734,5 +742,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add Telegram ingress, chat registry, and attachment tracking.
+1. Finish Telegram media download, attachment tracking, and cleanup state.
 2. Add GitHub checkpoint persistence.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/imap"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/schedule"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/telegram"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/dispatch"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/egress"
@@ -147,6 +148,46 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 				ReplyChannelInstructions: config.EmailPromptContext,
 			},
 			UseSSL: config.IMAPUseSSL,
+		})
+		if err != nil {
+			_ = store.Close()
+			return nil, err
+		}
+		connectors = append(connectors, connector)
+	}
+	if config.TelegramEnabled {
+		token := os.Getenv(config.TelegramBotTokenEnv)
+		if token == "" {
+			_ = store.Close()
+			return nil, fmt.Errorf("missing Telegram bot token env var: %s", config.TelegramBotTokenEnv)
+		}
+		telegramContextRefs := config.TelegramContextRefs
+		if len(telegramContextRefs) == 0 {
+			telegramContextRefs = config.ContextRefs
+		}
+		connector, err := telegram.New(telegram.Config{
+			BotToken:           token,
+			APIBaseURL:         config.TelegramAPIBaseURL,
+			PollTimeoutSeconds: config.TelegramPollTimeoutSeconds,
+			AllowedChatIDs:     config.TelegramAllowedChatIDs,
+			AllowedChannelIDs:  config.TelegramAllowedChannelIDs,
+			ContextRefs:        telegramContextRefs,
+			PromptContext: contracts.PromptContext{
+				GlobalInstructions:       config.GlobalPromptContext,
+				ReplyChannelInstructions: config.TelegramPromptContext,
+			},
+			ObserveChat: func(ctx context.Context, observation telegram.ChatObservation) error {
+				return store.RecordTelegramChat(ctx, sqlitestate.TelegramChatObservation{
+					ChatID:      observation.ChatID,
+					ChatType:    observation.ChatType,
+					Title:       observation.Title,
+					Username:    observation.Username,
+					UpdateID:    observation.UpdateID,
+					UpdateKind:  observation.UpdateKind,
+					MessageDate: observation.MessageDate,
+					RetrievedAt: observation.RetrievedAt,
+				})
+			},
 		})
 		if err != nil {
 			_ = store.Close()

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -51,9 +51,19 @@ var allowedKeys = map[string]bool{
 	"smtp_from":               true,
 	"smtp_starttls":           true,
 	"smtp_use_ssl":            true,
-	"telegram_enabled":        true,
-	"telegram_bot_token_env":  true,
-	"telegram_api_base_url":   true,
+
+	"telegram_enabled":              true,
+	"telegram_bot_token_env":        true,
+	"telegram_api_base_url":         true,
+	"telegram_poll_timeout_seconds": true,
+	"telegram_allowed_chat_ids":     true,
+	"telegram_allowed_channel_ids":  true,
+
+	"telegram_attachment_dir":                   true,
+	"telegram_attachment_cleanup_grace_seconds": true,
+	"telegram_attachment_max_age_seconds":       true,
+	"telegram_prompt_context":                   true,
+	"telegram_context_refs":                     true,
 
 	"auxiliary_ingress_enabled":      true,
 	"auxiliary_ingress_bbmb_address": true,
@@ -89,9 +99,18 @@ type Config struct {
 	SMTPFrom              string
 	SMTPStartTLS          bool
 	SMTPUseSSL            bool
-	TelegramEnabled       bool
-	TelegramBotTokenEnv   string
-	TelegramAPIBaseURL    string
+
+	TelegramEnabled                       bool
+	TelegramBotTokenEnv                   string
+	TelegramAPIBaseURL                    string
+	TelegramPollTimeoutSeconds            int
+	TelegramAllowedChatIDs                []string
+	TelegramAllowedChannelIDs             []string
+	TelegramAttachmentDir                 string
+	TelegramAttachmentCleanupGraceSeconds int
+	TelegramAttachmentMaxAgeSeconds       int
+	TelegramPromptContext                 []string
+	TelegramContextRefs                   []string
 
 	AuxiliaryIngressEnabled     bool
 	AuxiliaryIngressBBMBAddress string
@@ -128,9 +147,18 @@ func Defaults() Config {
 		SMTPFrom:              "",
 		SMTPStartTLS:          false,
 		SMTPUseSSL:            true,
-		TelegramEnabled:       false,
-		TelegramBotTokenEnv:   "CHATTING_TELEGRAM_BOT_TOKEN",
-		TelegramAPIBaseURL:    "https://api.telegram.org",
+
+		TelegramEnabled:                       false,
+		TelegramBotTokenEnv:                   "CHATTING_TELEGRAM_BOT_TOKEN",
+		TelegramAPIBaseURL:                    "https://api.telegram.org",
+		TelegramPollTimeoutSeconds:            20,
+		TelegramAllowedChatIDs:                []string{},
+		TelegramAllowedChannelIDs:             []string{},
+		TelegramAttachmentDir:                 "",
+		TelegramAttachmentCleanupGraceSeconds: 604800,
+		TelegramAttachmentMaxAgeSeconds:       2592000,
+		TelegramPromptContext:                 []string{},
+		TelegramContextRefs:                   []string{},
 
 		AuxiliaryIngressEnabled:     false,
 		AuxiliaryIngressBBMBAddress: "",
@@ -375,6 +403,54 @@ func Load(raw []byte) (Config, error) {
 	}
 	if rawValue, ok := payload["telegram_api_base_url"]; ok && !isNull(rawValue) {
 		config.TelegramAPIBaseURL, err = decodeNonEmptyString(rawValue, "telegram_api_base_url")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_poll_timeout_seconds"]; ok && !isNull(rawValue) {
+		config.TelegramPollTimeoutSeconds, err = decodePositiveInt(rawValue, "telegram_poll_timeout_seconds")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_allowed_chat_ids"]; ok && !isNull(rawValue) {
+		config.TelegramAllowedChatIDs, err = decodeStringList(rawValue, "telegram_allowed_chat_ids")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_allowed_channel_ids"]; ok && !isNull(rawValue) {
+		config.TelegramAllowedChannelIDs, err = decodeStringList(rawValue, "telegram_allowed_channel_ids")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_attachment_dir"]; ok && !isNull(rawValue) {
+		config.TelegramAttachmentDir, err = decodeNonEmptyString(rawValue, "telegram_attachment_dir")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_attachment_cleanup_grace_seconds"]; ok && !isNull(rawValue) {
+		config.TelegramAttachmentCleanupGraceSeconds, err = decodePositiveInt(rawValue, "telegram_attachment_cleanup_grace_seconds")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_attachment_max_age_seconds"]; ok && !isNull(rawValue) {
+		config.TelegramAttachmentMaxAgeSeconds, err = decodePositiveInt(rawValue, "telegram_attachment_max_age_seconds")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_prompt_context"]; ok && !isNull(rawValue) {
+		config.TelegramPromptContext, err = decodeStringList(rawValue, "telegram_prompt_context")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["telegram_context_refs"]; ok && !isNull(rawValue) {
+		config.TelegramContextRefs, err = decodeStringList(rawValue, "telegram_context_refs")
 		if err != nil {
 			return Config{}, err
 		}

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -52,6 +52,14 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 		"telegram_enabled": true,
 		"telegram_bot_token_env": "TELEGRAM_TOKEN",
 		"telegram_api_base_url": "https://telegram.example.test",
+		"telegram_poll_timeout_seconds": 12,
+		"telegram_allowed_chat_ids": ["12345"],
+		"telegram_allowed_channel_ids": ["-100999"],
+		"telegram_attachment_dir": "/tmp/telegram-attachments",
+		"telegram_attachment_cleanup_grace_seconds": 30,
+		"telegram_attachment_max_age_seconds": 60,
+		"telegram_prompt_context": ["Telegram replies are visible in chat."],
+		"telegram_context_refs": ["repo:/workspace/telegram"],
 		"auxiliary_ingress_enabled": true,
 		"auxiliary_ingress_bbmb_address": "10.0.0.2:9998",
 		"auxiliary_ingress_queues": ["generic-post"],
@@ -150,6 +158,30 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 	}
 	if config.TelegramAPIBaseURL != "https://telegram.example.test" {
 		t.Fatalf("TelegramAPIBaseURL = %q", config.TelegramAPIBaseURL)
+	}
+	if config.TelegramPollTimeoutSeconds != 12 {
+		t.Fatalf("TelegramPollTimeoutSeconds = %d", config.TelegramPollTimeoutSeconds)
+	}
+	if !reflect.DeepEqual(config.TelegramAllowedChatIDs, []string{"12345"}) {
+		t.Fatalf("TelegramAllowedChatIDs = %#v", config.TelegramAllowedChatIDs)
+	}
+	if !reflect.DeepEqual(config.TelegramAllowedChannelIDs, []string{"-100999"}) {
+		t.Fatalf("TelegramAllowedChannelIDs = %#v", config.TelegramAllowedChannelIDs)
+	}
+	if config.TelegramAttachmentDir != "/tmp/telegram-attachments" {
+		t.Fatalf("TelegramAttachmentDir = %q", config.TelegramAttachmentDir)
+	}
+	if config.TelegramAttachmentCleanupGraceSeconds != 30 {
+		t.Fatalf("TelegramAttachmentCleanupGraceSeconds = %d", config.TelegramAttachmentCleanupGraceSeconds)
+	}
+	if config.TelegramAttachmentMaxAgeSeconds != 60 {
+		t.Fatalf("TelegramAttachmentMaxAgeSeconds = %d", config.TelegramAttachmentMaxAgeSeconds)
+	}
+	if !reflect.DeepEqual(config.TelegramPromptContext, []string{"Telegram replies are visible in chat."}) {
+		t.Fatalf("TelegramPromptContext = %#v", config.TelegramPromptContext)
+	}
+	if !reflect.DeepEqual(config.TelegramContextRefs, []string{"repo:/workspace/telegram"}) {
+		t.Fatalf("TelegramContextRefs = %#v", config.TelegramContextRefs)
 	}
 	if !config.AuxiliaryIngressEnabled {
 		t.Fatal("AuxiliaryIngressEnabled = false")

--- a/go/handler/internal/connectors/telegram/telegram.go
+++ b/go/handler/internal/connectors/telegram/telegram.go
@@ -1,0 +1,413 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+const Source = "im"
+
+type ChatObservation struct {
+	ChatID      string
+	ChatType    *string
+	Title       *string
+	Username    *string
+	UpdateID    int64
+	UpdateKind  string
+	MessageDate *time.Time
+	RetrievedAt time.Time
+}
+
+type ObserveChatFunc func(context.Context, ChatObservation) error
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Config struct {
+	BotToken           string
+	APIBaseURL         string
+	PollTimeoutSeconds int
+	AllowedChatIDs     []string
+	AllowedChannelIDs  []string
+	ContextRefs        []string
+	PromptContext      contracts.PromptContext
+	RequestTimeout     time.Duration
+	HTTPClient         HTTPClient
+	ObserveChat        ObserveChatFunc
+	Now                func() time.Time
+}
+
+type Connector struct {
+	config            Config
+	client            HTTPClient
+	now               func() time.Time
+	prompt            *contracts.PromptContext
+	allowedChatIDs    map[string]bool
+	allowedChannelIDs map[string]bool
+	nextOffset        *int64
+}
+
+func New(config Config) (*Connector, error) {
+	if strings.TrimSpace(config.BotToken) == "" {
+		return nil, errors.New("bot_token is required")
+	}
+	if strings.TrimSpace(config.APIBaseURL) == "" {
+		config.APIBaseURL = "https://api.telegram.org"
+	}
+	if config.PollTimeoutSeconds <= 0 {
+		config.PollTimeoutSeconds = 20
+	}
+	if config.RequestTimeout <= 0 {
+		config.RequestTimeout = 30 * time.Second
+	}
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: config.RequestTimeout}
+	}
+	now := config.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	var prompt *contracts.PromptContext
+	if config.PromptContext.HasContent() {
+		copy := config.PromptContext
+		prompt = &copy
+	}
+	return &Connector{
+		config:            config,
+		client:            client,
+		now:               now,
+		prompt:            prompt,
+		allowedChatIDs:    stringSet(config.AllowedChatIDs),
+		allowedChannelIDs: stringSet(config.AllowedChannelIDs),
+	}, nil
+}
+
+func (connector *Connector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	response, err := connector.getUpdates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !response.OK {
+		return nil, errors.New("telegram_get_updates_failed")
+	}
+	envelopes := make([]contracts.TaskEnvelope, 0, len(response.Result))
+	var highestUpdateID *int64
+	for _, update := range response.Result {
+		if highestUpdateID == nil || update.UpdateID > *highestUpdateID {
+			value := update.UpdateID
+			highestUpdateID = &value
+		}
+		envelope, err := connector.normalizeUpdate(ctx, update)
+		if err != nil {
+			return envelopes, err
+		}
+		if envelope != nil {
+			envelopes = append(envelopes, *envelope)
+		}
+	}
+	if highestUpdateID != nil {
+		next := *highestUpdateID + 1
+		connector.nextOffset = &next
+	}
+	return envelopes, nil
+}
+
+func (connector *Connector) getUpdates(ctx context.Context) (getUpdatesResponse, error) {
+	endpoint := strings.TrimRight(connector.config.APIBaseURL, "/") + "/bot" + connector.config.BotToken + "/getUpdates"
+	query := url.Values{"timeout": []string{strconv.Itoa(connector.config.PollTimeoutSeconds)}}
+	if connector.nextOffset != nil {
+		query.Set("offset", strconv.FormatInt(*connector.nextOffset, 10))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+query.Encode(), nil)
+	if err != nil {
+		return getUpdatesResponse{}, err
+	}
+	resp, err := connector.client.Do(req)
+	if err != nil {
+		return getUpdatesResponse{}, errors.New("telegram_http_error")
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return getUpdatesResponse{}, errors.New("telegram_http_error")
+	}
+	var decoded getUpdatesResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return getUpdatesResponse{}, errors.New("telegram_invalid_json")
+	}
+	return decoded, nil
+}
+
+func (connector *Connector) normalizeUpdate(ctx context.Context, update telegramUpdate) (*contracts.TaskEnvelope, error) {
+	if update.Message != nil {
+		return connector.normalizeMessage(ctx, update.UpdateID, "message", *update.Message, connector.actorFromUser(update.Message.From))
+	}
+	if update.ChannelPost != nil {
+		return connector.normalizeChannelPost(ctx, update.UpdateID, *update.ChannelPost)
+	}
+	if update.MyChatMember != nil {
+		if err := connector.observeChat(ctx, update.UpdateID, "my_chat_member", update.MyChatMember.Chat, nil); err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+func (connector *Connector) normalizeMessage(ctx context.Context, updateID int64, kind string, message telegramMessage, actor *string) (*contracts.TaskEnvelope, error) {
+	if message.MessageID == 0 || message.Chat.ID == 0 {
+		return nil, nil
+	}
+	chatID := strconv.FormatInt(message.Chat.ID, 10)
+	messageDate := messageDate(message.Date)
+	if err := connector.observeChat(ctx, updateID, kind, message.Chat, messageDate); err != nil {
+		return nil, err
+	}
+	if len(connector.allowedChatIDs) > 0 && !connector.allowedChatIDs[chatID] {
+		return nil, nil
+	}
+	return connector.buildEnvelope(updateID, message, chatID, actor)
+}
+
+func (connector *Connector) normalizeChannelPost(ctx context.Context, updateID int64, message telegramMessage) (*contracts.TaskEnvelope, error) {
+	if message.MessageID == 0 || message.Chat.ID == 0 {
+		return nil, nil
+	}
+	chatID := strconv.FormatInt(message.Chat.ID, 10)
+	messageDate := messageDate(message.Date)
+	if err := connector.observeChat(ctx, updateID, "channel_post", message.Chat, messageDate); err != nil {
+		return nil, err
+	}
+	if message.Chat.Type != "channel" || len(connector.allowedChannelIDs) == 0 || !connector.allowedChannelIDs[chatID] {
+		return nil, nil
+	}
+	return connector.buildEnvelope(updateID, message, chatID, connector.actorFromChat(message.SenderChat))
+}
+
+func (connector *Connector) buildEnvelope(updateID int64, message telegramMessage, chatID string, actor *string) (*contracts.TaskEnvelope, error) {
+	content := strings.TrimSpace(message.Text)
+	if content == "" {
+		content = strings.TrimSpace(message.Caption)
+	}
+	locationMetadata := locationMetadata(message.Location)
+	if locationMetadata != nil {
+		locationBlock := formatLocationContent(locationMetadata)
+		if content != "" {
+			content += "\n\n" + locationBlock
+		} else {
+			content = locationBlock
+		}
+	}
+	if content == "" {
+		return nil, nil
+	}
+	if message.MessageThreadID != nil {
+		content = fmt.Sprintf("[thread_id=%d] %s", *message.MessageThreadID, content)
+	}
+	eventID := "telegram:" + strconv.FormatInt(updateID, 10)
+	metadata := map[string]any{"message_id": message.MessageID}
+	if locationMetadata != nil {
+		metadata["location"] = locationMetadata
+	}
+	return &contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            eventID,
+		Source:        Source,
+		ReceivedAt:    contracts.NewTimestamp(parseTelegramDate(message.Date, connector.now())),
+		Actor:         actor,
+		Content:       content,
+		Attachments:   []contracts.AttachmentRef{},
+		ContextRefs:   append([]string{}, connector.config.ContextRefs...),
+		PromptContext: connector.prompt,
+		ReplyChannel: contracts.ReplyChannel{
+			Type:     "telegram",
+			Target:   chatID,
+			Metadata: metadata,
+		},
+		DedupeKey: eventID,
+	}, nil
+}
+
+func (connector *Connector) observeChat(ctx context.Context, updateID int64, updateKind string, chat telegramChat, messageDate *time.Time) error {
+	if connector.config.ObserveChat == nil || chat.ID == 0 {
+		return nil
+	}
+	return connector.config.ObserveChat(ctx, ChatObservation{
+		ChatID:      strconv.FormatInt(chat.ID, 10),
+		ChatType:    optionalString(chat.Type),
+		Title:       optionalString(chat.Title),
+		Username:    optionalString(chat.Username),
+		UpdateID:    updateID,
+		UpdateKind:  updateKind,
+		MessageDate: messageDate,
+		RetrievedAt: connector.now(),
+	})
+}
+
+func (connector *Connector) actorFromUser(user *telegramUser) *string {
+	if user == nil || user.ID == 0 {
+		return nil
+	}
+	if strings.TrimSpace(user.Username) != "" {
+		value := strconv.FormatInt(user.ID, 10) + ":" + strings.TrimSpace(user.Username)
+		return &value
+	}
+	value := strconv.FormatInt(user.ID, 10)
+	return &value
+}
+
+func (connector *Connector) actorFromChat(chat *telegramChat) *string {
+	if chat == nil || chat.ID == 0 {
+		return nil
+	}
+	if strings.TrimSpace(chat.Username) != "" {
+		value := strconv.FormatInt(chat.ID, 10) + ":" + strings.TrimSpace(chat.Username)
+		return &value
+	}
+	if strings.TrimSpace(chat.Title) != "" {
+		value := strconv.FormatInt(chat.ID, 10) + ":" + strings.TrimSpace(chat.Title)
+		return &value
+	}
+	value := strconv.FormatInt(chat.ID, 10)
+	return &value
+}
+
+type getUpdatesResponse struct {
+	OK     bool             `json:"ok"`
+	Result []telegramUpdate `json:"result"`
+}
+
+type telegramUpdate struct {
+	UpdateID     int64               `json:"update_id"`
+	Message      *telegramMessage    `json:"message"`
+	ChannelPost  *telegramMessage    `json:"channel_post"`
+	MyChatMember *telegramChatMember `json:"my_chat_member"`
+}
+
+type telegramChatMember struct {
+	Chat telegramChat `json:"chat"`
+}
+
+type telegramMessage struct {
+	MessageID       int64             `json:"message_id"`
+	MessageThreadID *int64            `json:"message_thread_id"`
+	Date            int64             `json:"date"`
+	Chat            telegramChat      `json:"chat"`
+	From            *telegramUser     `json:"from"`
+	SenderChat      *telegramChat     `json:"sender_chat"`
+	Text            string            `json:"text"`
+	Caption         string            `json:"caption"`
+	Location        *telegramLocation `json:"location"`
+}
+
+type telegramChat struct {
+	ID       int64  `json:"id"`
+	Type     string `json:"type"`
+	Title    string `json:"title"`
+	Username string `json:"username"`
+}
+
+type telegramUser struct {
+	ID       int64  `json:"id"`
+	Username string `json:"username"`
+}
+
+type telegramLocation struct {
+	Latitude             float64  `json:"latitude"`
+	Longitude            float64  `json:"longitude"`
+	HorizontalAccuracy   *float64 `json:"horizontal_accuracy"`
+	LivePeriod           *int64   `json:"live_period"`
+	Heading              *int64   `json:"heading"`
+	ProximityAlertRadius *int64   `json:"proximity_alert_radius"`
+}
+
+func parseTelegramDate(value int64, fallback time.Time) time.Time {
+	if value <= 0 {
+		return fallback.UTC()
+	}
+	return time.Unix(value, 0).UTC()
+}
+
+func messageDate(value int64) *time.Time {
+	if value <= 0 {
+		return nil
+	}
+	parsed := time.Unix(value, 0).UTC()
+	return &parsed
+}
+
+func optionalString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func stringSet(values []string) map[string]bool {
+	result := map[string]bool{}
+	for _, value := range values {
+		result[strings.TrimSpace(value)] = true
+	}
+	return result
+}
+
+func locationMetadata(location *telegramLocation) map[string]any {
+	if location == nil {
+		return nil
+	}
+	latitude := round6(location.Latitude)
+	longitude := round6(location.Longitude)
+	result := map[string]any{
+		"latitude":  latitude,
+		"longitude": longitude,
+		"map_url":   fmt.Sprintf("https://maps.google.com/?q=%.6f,%.6f", location.Latitude, location.Longitude),
+	}
+	if location.HorizontalAccuracy != nil {
+		result["horizontal_accuracy"] = *location.HorizontalAccuracy
+	}
+	if location.LivePeriod != nil {
+		result["live_period"] = *location.LivePeriod
+	}
+	if location.Heading != nil {
+		result["heading"] = *location.Heading
+	}
+	if location.ProximityAlertRadius != nil {
+		result["proximity_alert_radius"] = *location.ProximityAlertRadius
+	}
+	return result
+}
+
+func formatLocationContent(metadata map[string]any) string {
+	lines := []string{
+		"[location shared]",
+		fmt.Sprintf("latitude: %v", metadata["latitude"]),
+		fmt.Sprintf("longitude: %v", metadata["longitude"]),
+	}
+	for _, key := range []string{"horizontal_accuracy", "live_period", "heading", "proximity_alert_radius"} {
+		if value, ok := metadata[key]; ok {
+			lines = append(lines, fmt.Sprintf("%s: %v", key, value))
+		}
+	}
+	lines = append(lines, fmt.Sprintf("map: %s", metadata["map_url"]))
+	return strings.Join(lines, "\n")
+}
+
+func round6(value float64) float64 {
+	return math.Round(value*1000000) / 1000000
+}

--- a/go/handler/internal/connectors/telegram/telegram_test.go
+++ b/go/handler/internal/connectors/telegram/telegram_test.go
@@ -1,0 +1,213 @@
+package telegram
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+func TestPollNormalizesAllowedMessageAndObservesChatBeforeAllowlist(t *testing.T) {
+	var requestedURL string
+	client := &fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		requestedURL = req.URL.String()
+		return jsonResponse(`{
+			"ok": true,
+			"result": [
+				{
+					"update_id": 1001,
+					"message": {
+						"message_id": 55,
+						"date": 1779345600,
+						"chat": {"id": 12345, "type": "private", "username": "edward"},
+						"from": {"id": 7, "username": "sender"},
+						"text": "hello from telegram"
+					}
+				},
+				{
+					"update_id": 1002,
+					"message": {
+						"message_id": 56,
+						"date": 1779345660,
+						"chat": {"id": 99999, "type": "private", "username": "other"},
+						"from": {"id": 8},
+						"text": "ignored"
+					}
+				}
+			]
+		}`), nil
+	}}
+	observed := []ChatObservation{}
+	connector, err := New(Config{
+		BotToken:           "token",
+		APIBaseURL:         "https://telegram.example.test",
+		PollTimeoutSeconds: 12,
+		AllowedChatIDs:     []string{"12345"},
+		ContextRefs:        []string{"repo:/workspace/chatting"},
+		PromptContext: contracts.PromptContext{
+			GlobalInstructions:       []string{"global"},
+			ReplyChannelInstructions: []string{"telegram"},
+		},
+		HTTPClient: client,
+		ObserveChat: func(ctx context.Context, observation ChatObservation) error {
+			observed = append(observed, observation)
+			return nil
+		},
+		Now: func() time.Time { return mustTime(t, "2026-05-21T06:40:00Z") },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(requestedURL, "/bottoken/getUpdates?") || !strings.Contains(requestedURL, "timeout=12") {
+		t.Fatalf("requested URL = %q", requestedURL)
+	}
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	envelope := envelopes[0]
+	if envelope.ID != "telegram:1001" || envelope.Source != "im" || envelope.DedupeKey != "telegram:1001" {
+		t.Fatalf("envelope identity = %#v", envelope)
+	}
+	if envelope.Content != "hello from telegram" {
+		t.Fatalf("content = %q", envelope.Content)
+	}
+	if envelope.ReplyChannel.Type != "telegram" || envelope.ReplyChannel.Target != "12345" {
+		t.Fatalf("reply channel = %#v", envelope.ReplyChannel)
+	}
+	if envelope.ReplyChannel.Metadata["message_id"] != float64(55) && envelope.ReplyChannel.Metadata["message_id"] != int64(55) {
+		t.Fatalf("metadata = %#v", envelope.ReplyChannel.Metadata)
+	}
+	if deref(envelope.Actor) != "7:sender" {
+		t.Fatalf("actor = %#v", envelope.Actor)
+	}
+	if !reflect.DeepEqual(envelope.ContextRefs, []string{"repo:/workspace/chatting"}) {
+		t.Fatalf("context refs = %#v", envelope.ContextRefs)
+	}
+	if envelope.PromptContext == nil || !reflect.DeepEqual(envelope.PromptContext.AssembledInstructions(), []string{"global", "telegram"}) {
+		t.Fatalf("prompt context = %#v", envelope.PromptContext)
+	}
+	if len(observed) != 2 {
+		t.Fatalf("observed chats = %#v", observed)
+	}
+	if observed[0].ChatID != "12345" || deref(observed[0].Username) != "edward" || observed[0].UpdateKind != "message" {
+		t.Fatalf("first observation = %#v", observed[0])
+	}
+	if observed[1].ChatID != "99999" {
+		t.Fatalf("disallowed chat was not observed before allowlist: %#v", observed)
+	}
+
+	requestedURL = ""
+	client.do = func(req *http.Request) (*http.Response, error) {
+		requestedURL = req.URL.String()
+		return jsonResponse(`{"ok": true, "result": []}`), nil
+	}
+	if _, err := connector.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(requestedURL, "offset=1003") {
+		t.Fatalf("second requested URL = %q", requestedURL)
+	}
+}
+
+func TestPollNormalizesAllowedChannelPostAndMyChatMemberObservation(t *testing.T) {
+	client := &fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(`{
+			"ok": true,
+			"result": [
+				{
+					"update_id": 2001,
+					"channel_post": {
+						"message_id": 9,
+						"date": 1779345600,
+						"chat": {"id": -100999, "type": "channel", "title": "Deploys", "username": "deploys"},
+						"sender_chat": {"id": -100999, "type": "channel", "title": "Deploys"},
+						"text": "release shipped"
+					}
+				},
+				{
+					"update_id": 2002,
+					"my_chat_member": {
+						"chat": {"id": -100123, "type": "supergroup", "title": "Test Group"}
+					}
+				}
+			]
+		}`), nil
+	}}
+	observed := []ChatObservation{}
+	connector, err := New(Config{
+		BotToken:          "token",
+		AllowedChannelIDs: []string{"-100999"},
+		HTTPClient:        client,
+		ObserveChat: func(ctx context.Context, observation ChatObservation) error {
+			observed = append(observed, observation)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	if envelopes[0].ReplyChannel.Target != "-100999" || envelopes[0].Content != "release shipped" {
+		t.Fatalf("channel envelope = %#v", envelopes[0])
+	}
+	if len(observed) != 2 {
+		t.Fatalf("observed = %#v", observed)
+	}
+	if observed[0].UpdateKind != "channel_post" || observed[0].ChatID != "-100999" {
+		t.Fatalf("channel observation = %#v", observed[0])
+	}
+	if observed[1].UpdateKind != "my_chat_member" || observed[1].ChatID != "-100123" || deref(observed[1].Title) != "Test Group" {
+		t.Fatalf("membership observation = %#v", observed[1])
+	}
+}
+
+type fakeHTTPClient struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (client *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return client.do(req)
+}
+
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func deref(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/go/handler/internal/state/sqlite/sqlite.go
+++ b/go/handler/internal/state/sqlite/sqlite.go
@@ -42,6 +42,29 @@ type StagedEgressRecord struct {
 	CreatedAt     time.Time
 }
 
+type TelegramChatObservation struct {
+	ChatID      string
+	ChatType    *string
+	Title       *string
+	Username    *string
+	UpdateID    int64
+	UpdateKind  string
+	MessageDate *time.Time
+	RetrievedAt time.Time
+}
+
+type TelegramChatRecord struct {
+	ChatID          string
+	ChatType        *string
+	Title           *string
+	Username        *string
+	FirstSeenAt     time.Time
+	LastRetrievedAt time.Time
+	LastMessageAt   *time.Time
+	LastUpdateID    int64
+	LastUpdateKind  string
+}
+
 func Open(ctx context.Context, dbPath string) (*Store, error) {
 	if strings.TrimSpace(dbPath) == "" {
 		return nil, errors.New("db_path is required")
@@ -107,6 +130,17 @@ func (store *Store) initialize(ctx context.Context) error {
 			created_at TEXT NOT NULL,
 			PRIMARY KEY (task_id, event_id)
 		)`,
+		`CREATE TABLE IF NOT EXISTS telegram_chat_registry (
+			chat_id TEXT PRIMARY KEY,
+			chat_type TEXT,
+			title TEXT,
+			username TEXT,
+			first_seen_at TEXT NOT NULL,
+			last_retrieved_at TEXT NOT NULL,
+			last_message_at TEXT,
+			last_update_id INTEGER NOT NULL,
+			last_update_kind TEXT NOT NULL
+		)`,
 	}
 	for _, statement := range statements {
 		if _, err := store.db.ExecContext(ctx, statement); err != nil {
@@ -114,6 +148,119 @@ func (store *Store) initialize(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (store *Store) RecordTelegramChat(ctx context.Context, observation TelegramChatObservation) error {
+	if strings.TrimSpace(observation.ChatID) == "" {
+		return errors.New("chat_id is required")
+	}
+	if strings.TrimSpace(observation.UpdateKind) == "" {
+		return errors.New("update_kind is required")
+	}
+	retrievedAt := observation.RetrievedAt
+	if retrievedAt.IsZero() {
+		retrievedAt = time.Now().UTC()
+	}
+	var messageDate any
+	if observation.MessageDate != nil {
+		messageDate = formatTimestamp(*observation.MessageDate)
+	}
+	_, err := store.db.ExecContext(
+		ctx,
+		`INSERT INTO telegram_chat_registry (
+			chat_id,
+			chat_type,
+			title,
+			username,
+			first_seen_at,
+			last_retrieved_at,
+			last_message_at,
+			last_update_id,
+			last_update_kind
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(chat_id) DO UPDATE SET
+			chat_type = COALESCE(excluded.chat_type, telegram_chat_registry.chat_type),
+			title = COALESCE(excluded.title, telegram_chat_registry.title),
+			username = COALESCE(excluded.username, telegram_chat_registry.username),
+			last_retrieved_at = excluded.last_retrieved_at,
+			last_message_at = COALESCE(excluded.last_message_at, telegram_chat_registry.last_message_at),
+			last_update_id = excluded.last_update_id,
+			last_update_kind = excluded.last_update_kind`,
+		observation.ChatID,
+		nullableString(observation.ChatType),
+		nullableString(observation.Title),
+		nullableString(observation.Username),
+		formatTimestamp(retrievedAt),
+		formatTimestamp(retrievedAt),
+		messageDate,
+		observation.UpdateID,
+		observation.UpdateKind,
+	)
+	return err
+}
+
+func (store *Store) ListTelegramChats(ctx context.Context) ([]TelegramChatRecord, error) {
+	rows, err := store.db.QueryContext(
+		ctx,
+		`SELECT
+			chat_id,
+			chat_type,
+			title,
+			username,
+			first_seen_at,
+			last_retrieved_at,
+			last_message_at,
+			last_update_id,
+			last_update_kind
+		FROM telegram_chat_registry
+		ORDER BY last_retrieved_at DESC, chat_id ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	records := []TelegramChatRecord{}
+	for rows.Next() {
+		var chatType, title, username, lastMessageAt sql.NullString
+		var firstSeenAt, lastRetrievedAt string
+		record := TelegramChatRecord{}
+		if err := rows.Scan(
+			&record.ChatID,
+			&chatType,
+			&title,
+			&username,
+			&firstSeenAt,
+			&lastRetrievedAt,
+			&lastMessageAt,
+			&record.LastUpdateID,
+			&record.LastUpdateKind,
+		); err != nil {
+			return nil, err
+		}
+		record.ChatType = nullStringPointer(chatType)
+		record.Title = nullStringPointer(title)
+		record.Username = nullStringPointer(username)
+		parsedFirstSeenAt, err := parseTimestamp(firstSeenAt)
+		if err != nil {
+			return nil, err
+		}
+		record.FirstSeenAt = parsedFirstSeenAt
+		parsedLastRetrievedAt, err := parseTimestamp(lastRetrievedAt)
+		if err != nil {
+			return nil, err
+		}
+		record.LastRetrievedAt = parsedLastRetrievedAt
+		if lastMessageAt.Valid {
+			parsedLastMessageAt, err := parseTimestamp(lastMessageAt.String)
+			if err != nil {
+				return nil, err
+			}
+			record.LastMessageAt = &parsedLastMessageAt
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
 }
 
 func (store *Store) Seen(ctx context.Context, source string, dedupeKey string) (bool, error) {
@@ -512,4 +659,18 @@ func parseTimestamp(value string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return parsed.UTC(), nil
+}
+
+func nullableString(value *string) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func nullStringPointer(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+	return &value.String
 }

--- a/go/handler/internal/state/sqlite/sqlite_test.go
+++ b/go/handler/internal/state/sqlite/sqlite_test.go
@@ -48,6 +48,62 @@ func TestDedupeKeysAreScopedBySource(t *testing.T) {
 	}
 }
 
+func TestTelegramChatRegistryUpsertsObservedMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	firstSeenAt := mustTime(t, "2026-05-21T06:40:00Z")
+	firstMessageAt := mustTime(t, "2026-05-21T06:39:30Z")
+	updatedAt := mustTime(t, "2026-05-21T06:45:00Z")
+	chatType := "supergroup"
+	title := "Build Tests"
+	username := "build_tests"
+
+	if err := store.RecordTelegramChat(ctx, TelegramChatObservation{
+		ChatID:      "-100123",
+		ChatType:    &chatType,
+		Title:       &title,
+		Username:    &username,
+		UpdateID:    1001,
+		UpdateKind:  "message",
+		MessageDate: &firstMessageAt,
+		RetrievedAt: firstSeenAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordTelegramChat(ctx, TelegramChatObservation{
+		ChatID:      "-100123",
+		UpdateID:    1002,
+		UpdateKind:  "my_chat_member",
+		RetrievedAt: updatedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.ListTelegramChats(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %#v", records)
+	}
+	record := records[0]
+	if record.ChatID != "-100123" || derefString(record.ChatType) != "supergroup" || derefString(record.Title) != "Build Tests" || derefString(record.Username) != "build_tests" {
+		t.Fatalf("record metadata = %#v", record)
+	}
+	if !record.FirstSeenAt.Equal(firstSeenAt) {
+		t.Fatalf("FirstSeenAt = %s", record.FirstSeenAt)
+	}
+	if !record.LastRetrievedAt.Equal(updatedAt) {
+		t.Fatalf("LastRetrievedAt = %s", record.LastRetrievedAt)
+	}
+	if record.LastMessageAt == nil || !record.LastMessageAt.Equal(firstMessageAt) {
+		t.Fatalf("LastMessageAt = %#v", record.LastMessageAt)
+	}
+	if record.LastUpdateID != 1002 || record.LastUpdateKind != "my_chat_member" {
+		t.Fatalf("last update = %#v", record)
+	}
+}
+
 func TestRecordTaskRoundTripsAndUsesPythonCompatibleTable(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "state.db")


### PR DESCRIPTION
## Summary
- add a Go Telegram getUpdates connector for text/caption/location message and channel_post ingress
- upsert observed message, channel_post, and my_chat_member chats into the handler SQLite telegram_chat_registry table before allowlist filtering
- wire Telegram ingress config into the Go handler runtime and update the Go port plan/example config

## Validation
- go test ./...
- uv run python -m unittest discover -s tests

## Notes
Media download, Telegram attachment tracking, and cleanup state are left as the next Go port slice.
