### PR TITLE
Port Telegram attachment cleanup to Go handler

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -680,8 +680,11 @@ polls Bot API `getUpdates`, normalizes allowlisted text/caption/location
 `message` and `channel_post` updates into Python-compatible IM task envelopes,
 advances update offsets, observes `my_chat_member` updates, and upserts observed
 Telegram chat metadata into the Python-compatible `telegram_chat_registry`
-SQLite table before allowlist filtering. Media download and attachment cleanup
-state remain to be ported.
+SQLite table before allowlist filtering. It also downloads Telegram photo
+attachments into `telegram_attachment_dir`, tracks local Telegram attachments in
+the Python-compatible `telegram_attachment_ledger`, marks them cleanup-eligible
+after task completion, and runs max-age/grace-period cleanup from the handler
+loop.
 
 Implement Telegram getUpdates polling, update normalization, attachment download, conversation memory,
 chat registry state, and attachment cleanup state.
@@ -742,5 +745,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Finish Telegram media download, attachment tracking, and cleanup state.
-2. Add GitHub checkpoint persistence.
+1. Add GitHub checkpoint persistence.
+2. Continue closing remaining Python handler parity gaps before a side-by-side dry run.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -101,10 +101,21 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		_ = store.Close()
 		return nil, err
 	}
+	egressOptions := []egress.Option{
+		egress.WithAllowedChannels(config.AllowedEgressChannels),
+		egress.WithCompletionHook(func(ctx context.Context, message contracts.EgressQueueMessage) error {
+			if !config.TelegramEnabled {
+				return nil
+			}
+			eligibleAfter := time.Now().UTC().Add(time.Duration(config.TelegramAttachmentCleanupGraceSeconds) * time.Second)
+			_, err := store.MarkTelegramTaskAttachmentsEligible(ctx, message.TaskID, eligibleAfter)
+			return err
+		}),
+	}
 	engine, err := egress.New(
 		egress.NewSQLiteState(store),
 		dispatcher,
-		egress.WithAllowedChannels(config.AllowedEgressChannels),
+		egressOptions...,
 	)
 	if err != nil {
 		_ = store.Close()
@@ -172,6 +183,7 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 			AllowedChatIDs:     config.TelegramAllowedChatIDs,
 			AllowedChannelIDs:  config.TelegramAllowedChannelIDs,
 			ContextRefs:        telegramContextRefs,
+			AttachmentRootDir:  config.TelegramAttachmentDir,
 			PromptContext: contracts.PromptContext{
 				GlobalInstructions:       config.GlobalPromptContext,
 				ReplyChannelInstructions: config.TelegramPromptContext,

--- a/go/handler/internal/connectors/telegram/telegram.go
+++ b/go/handler/internal/connectors/telegram/telegram.go
@@ -9,6 +9,9 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
+	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +46,7 @@ type Config struct {
 	AllowedChannelIDs  []string
 	ContextRefs        []string
 	PromptContext      contracts.PromptContext
+	AttachmentRootDir  string
 	RequestTimeout     time.Duration
 	HTTPClient         HTTPClient
 	ObserveChat        ObserveChatFunc
@@ -200,6 +204,10 @@ func (connector *Connector) normalizeChannelPost(ctx context.Context, updateID i
 }
 
 func (connector *Connector) buildEnvelope(updateID int64, message telegramMessage, chatID string, actor *string) (*contracts.TaskEnvelope, error) {
+	attachments, err := connector.extractAttachments(updateID, message)
+	if err != nil {
+		return nil, err
+	}
 	content := strings.TrimSpace(message.Text)
 	if content == "" {
 		content = strings.TrimSpace(message.Caption)
@@ -214,7 +222,10 @@ func (connector *Connector) buildEnvelope(updateID int64, message telegramMessag
 		}
 	}
 	if content == "" {
-		return nil, nil
+		if len(attachments) == 0 {
+			return nil, nil
+		}
+		content = "[photo attached]"
 	}
 	if message.MessageThreadID != nil {
 		content = fmt.Sprintf("[thread_id=%d] %s", *message.MessageThreadID, content)
@@ -231,7 +242,7 @@ func (connector *Connector) buildEnvelope(updateID int64, message telegramMessag
 		ReceivedAt:    contracts.NewTimestamp(parseTelegramDate(message.Date, connector.now())),
 		Actor:         actor,
 		Content:       content,
-		Attachments:   []contracts.AttachmentRef{},
+		Attachments:   attachments,
 		ContextRefs:   append([]string{}, connector.config.ContextRefs...),
 		PromptContext: connector.prompt,
 		ReplyChannel: contracts.ReplyChannel{
@@ -241,6 +252,110 @@ func (connector *Connector) buildEnvelope(updateID int64, message telegramMessag
 		},
 		DedupeKey: eventID,
 	}, nil
+}
+
+func (connector *Connector) extractAttachments(updateID int64, message telegramMessage) ([]contracts.AttachmentRef, error) {
+	if len(message.Photo) == 0 {
+		return []contracts.AttachmentRef{}, nil
+	}
+	photo := selectBestPhoto(message.Photo)
+	if strings.TrimSpace(photo.FileID) == "" {
+		return nil, errors.New("telegram_photo_missing_file_id")
+	}
+	metadata, err := connector.resolveFileMetadata(photo.FileID)
+	if err != nil {
+		return nil, err
+	}
+	suffix := filepath.Ext(metadata.FilePath)
+	if suffix == "" {
+		suffix = ".jpg"
+	}
+	uniqueFragment := strings.TrimSpace(photo.FileUniqueID)
+	if uniqueFragment == "" {
+		uniqueFragment = photo.FileID
+	}
+	localName := fmt.Sprintf(
+		"telegram-%d-%d-%s%s",
+		updateID,
+		message.MessageID,
+		safePathFragment(uniqueFragment),
+		suffix,
+	)
+	rootDir := connector.config.AttachmentRootDir
+	if strings.TrimSpace(rootDir) == "" {
+		rootDir = filepath.Join(os.TempDir(), "chatting-telegram-attachments")
+	}
+	destination, err := filepath.Abs(filepath.Join(rootDir, localName))
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return nil, err
+	}
+	fileURL := connector.buildFileDownloadURL(metadata.FilePath)
+	raw, err := connector.fetchRaw(fileURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(destination, raw, 0o600); err != nil {
+		return nil, err
+	}
+	name := path.Base(metadata.FilePath)
+	if name == "." || name == "/" {
+		name = filepath.Base(destination)
+	}
+	return []contracts.AttachmentRef{{
+		URI:  (&url.URL{Scheme: "file", Path: filepath.ToSlash(destination)}).String(),
+		Name: &name,
+	}}, nil
+}
+
+func (connector *Connector) resolveFileMetadata(fileID string) (telegramFileMetadata, error) {
+	endpoint := strings.TrimRight(connector.config.APIBaseURL, "/") + "/bot" + connector.config.BotToken + "/getFile"
+	query := url.Values{"file_id": []string{fileID}}
+	req, err := http.NewRequest(http.MethodGet, endpoint+"?"+query.Encode(), nil)
+	if err != nil {
+		return telegramFileMetadata{}, err
+	}
+	resp, err := connector.client.Do(req)
+	if err != nil {
+		return telegramFileMetadata{}, errors.New("telegram_http_error")
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return telegramFileMetadata{}, errors.New("telegram_http_error")
+	}
+	var decoded getFileResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return telegramFileMetadata{}, errors.New("telegram_invalid_json")
+	}
+	if !decoded.OK || strings.TrimSpace(decoded.Result.FilePath) == "" {
+		return telegramFileMetadata{}, errors.New("telegram_invalid_response_shape")
+	}
+	return decoded.Result, nil
+}
+
+func (connector *Connector) fetchRaw(rawURL string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := connector.client.Do(req)
+	if err != nil {
+		return nil, errors.New("telegram_http_error")
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.New("telegram_http_error")
+	}
+	return raw, nil
+}
+
+func (connector *Connector) buildFileDownloadURL(filePath string) string {
+	quotedPath := strings.ReplaceAll(url.PathEscape(filePath), "%2F", "/")
+	return strings.TrimRight(connector.config.APIBaseURL, "/") + "/file/bot" + connector.config.BotToken + "/" + quotedPath
 }
 
 func (connector *Connector) observeChat(ctx context.Context, updateID int64, updateKind string, chat telegramChat, messageDate *time.Time) error {
@@ -292,6 +407,15 @@ type getUpdatesResponse struct {
 	Result []telegramUpdate `json:"result"`
 }
 
+type getFileResponse struct {
+	OK     bool                 `json:"ok"`
+	Result telegramFileMetadata `json:"result"`
+}
+
+type telegramFileMetadata struct {
+	FilePath string `json:"file_path"`
+}
+
 type telegramUpdate struct {
 	UpdateID     int64               `json:"update_id"`
 	Message      *telegramMessage    `json:"message"`
@@ -313,6 +437,15 @@ type telegramMessage struct {
 	Text            string            `json:"text"`
 	Caption         string            `json:"caption"`
 	Location        *telegramLocation `json:"location"`
+	Photo           []telegramPhoto   `json:"photo"`
+}
+
+type telegramPhoto struct {
+	FileID       string `json:"file_id"`
+	FileUniqueID string `json:"file_unique_id"`
+	FileSize     int64  `json:"file_size"`
+	Width        int64  `json:"width"`
+	Height       int64  `json:"height"`
 }
 
 type telegramChat struct {
@@ -410,4 +543,38 @@ func formatLocationContent(metadata map[string]any) string {
 
 func round6(value float64) float64 {
 	return math.Round(value*1000000) / 1000000
+}
+
+func selectBestPhoto(photos []telegramPhoto) telegramPhoto {
+	var best telegramPhoto
+	bestKey := [3]int64{-1, -1, -1}
+	for _, photo := range photos {
+		key := [3]int64{photo.FileSize, photo.Width, photo.Height}
+		if key[0] > bestKey[0] ||
+			(key[0] == bestKey[0] && key[1] > bestKey[1]) ||
+			(key[0] == bestKey[0] && key[1] == bestKey[1] && key[2] > bestKey[2]) {
+			best = photo
+			bestKey = key
+		}
+	}
+	return best
+}
+
+func safePathFragment(value string) string {
+	var builder strings.Builder
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			character == '-' ||
+			character == '_' {
+			builder.WriteRune(character)
+		} else {
+			builder.WriteByte('_')
+		}
+	}
+	if builder.Len() == 0 {
+		return "attachment"
+	}
+	return builder.String()
 }

--- a/go/handler/internal/connectors/telegram/telegram_test.go
+++ b/go/handler/internal/connectors/telegram/telegram_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -180,6 +182,139 @@ func TestPollNormalizesAllowedChannelPostAndMyChatMemberObservation(t *testing.T
 	}
 }
 
+func TestPollDownloadsPhotoAttachmentAndUsesCaptionAsContent(t *testing.T) {
+	attachmentDir := t.TempDir()
+	requestedURLs := []string{}
+	client := &fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		requestedURLs = append(requestedURLs, req.URL.String())
+		switch {
+		case strings.Contains(req.URL.Path, "/getUpdates"):
+			return jsonResponse(`{
+				"ok": true,
+				"result": [{
+					"update_id": 3001,
+					"message": {
+						"message_id": 77,
+						"date": 1779345600,
+						"chat": {"id": 12345, "type": "private"},
+						"from": {"id": 7},
+						"caption": "leaf spot",
+						"photo": [
+							{"file_id": "small", "file_unique_id": "small-unique", "width": 90, "height": 60, "file_size": 10},
+							{"file_id": "large", "file_unique_id": "large/unique", "width": 900, "height": 600, "file_size": 100}
+						]
+					}
+				}]
+			}`), nil
+		case strings.Contains(req.URL.Path, "/getFile"):
+			if got := req.URL.Query().Get("file_id"); got != "large" {
+				t.Fatalf("getFile file_id = %q", got)
+			}
+			return jsonResponse(`{"ok": true, "result": {"file_path": "photos/leaf.jpg"}}`), nil
+		case strings.Contains(req.URL.Path, "/file/bottoken/photos/leaf.jpg"):
+			return bytesResponse("jpeg-bytes"), nil
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+			return nil, nil
+		}
+	}}
+	connector, err := New(Config{
+		BotToken:          "token",
+		APIBaseURL:        "https://telegram.example.test",
+		AllowedChatIDs:    []string{"12345"},
+		AttachmentRootDir: attachmentDir,
+		HTTPClient:        client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	envelope := envelopes[0]
+	if envelope.Content != "leaf spot" {
+		t.Fatalf("content = %q", envelope.Content)
+	}
+	if len(envelope.Attachments) != 1 {
+		t.Fatalf("attachments = %#v", envelope.Attachments)
+	}
+	attachment := envelope.Attachments[0]
+	if deref(attachment.Name) != "leaf.jpg" {
+		t.Fatalf("attachment name = %#v", attachment.Name)
+	}
+	if !strings.HasPrefix(attachment.URI, "file://") || !strings.Contains(attachment.URI, "telegram-3001-77-large_unique.jpg") {
+		t.Fatalf("attachment URI = %q", attachment.URI)
+	}
+	downloadedPath := filepath.Join(attachmentDir, "telegram-3001-77-large_unique.jpg")
+	raw, err := os.ReadFile(downloadedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "jpeg-bytes" {
+		t.Fatalf("downloaded bytes = %q", string(raw))
+	}
+	if len(requestedURLs) != 3 {
+		t.Fatalf("requested URLs = %#v", requestedURLs)
+	}
+}
+
+func TestPollAcceptsPhotoOnlyMessageWithPlaceholderContent(t *testing.T) {
+	client := &fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.Contains(req.URL.Path, "/getUpdates"):
+			return jsonResponse(`{
+				"ok": true,
+				"result": [{
+					"update_id": 3002,
+					"message": {
+						"message_id": 78,
+						"date": 1779345600,
+						"chat": {"id": 12345, "type": "private"},
+						"photo": [{"file_id": "only", "width": 800, "height": 600}]
+					}
+				}]
+			}`), nil
+		case strings.Contains(req.URL.Path, "/getFile"):
+			return jsonResponse(`{"ok": true, "result": {"file_path": "photos/photo.jpg"}}`), nil
+		case strings.Contains(req.URL.Path, "/file/bottoken/photos/photo.jpg"):
+			return bytesResponse("jpeg-bytes"), nil
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+			return nil, nil
+		}
+	}}
+	connector, err := New(Config{
+		BotToken:          "token",
+		AllowedChatIDs:    []string{"12345"},
+		AttachmentRootDir: t.TempDir(),
+		HTTPClient:        client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	if envelopes[0].Content != "[photo attached]" {
+		t.Fatalf("content = %q", envelopes[0].Content)
+	}
+	if len(envelopes[0].Attachments) != 1 {
+		t.Fatalf("attachments = %#v", envelopes[0].Attachments)
+	}
+}
+
 type fakeHTTPClient struct {
 	do func(*http.Request) (*http.Response, error)
 }
@@ -193,6 +328,13 @@ func jsonResponse(body string) *http.Response {
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func bytesResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }
 

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -49,6 +49,7 @@ type Engine struct {
 	state           State
 	dispatcher      Dispatcher
 	allowedChannels map[string]bool
+	onCompletion    func(context.Context, contracts.EgressQueueMessage) error
 }
 
 type Option func(*Engine)
@@ -59,6 +60,12 @@ func WithAllowedChannels(channels []string) Option {
 		for _, channel := range channels {
 			engine.allowedChannels[channel] = true
 		}
+	}
+}
+
+func WithCompletionHook(hook func(context.Context, contracts.EgressQueueMessage) error) Option {
+	return func(engine *Engine) {
+		engine.onCompletion = hook
 	}
 }
 
@@ -202,6 +209,11 @@ func (engine *Engine) Flush(ctx context.Context, taskID string) (Result, error) 
 			}
 			if err := engine.state.MarkTaskCompleted(ctx, message.TaskID, message.EnvelopeID, message.TraceID); err != nil {
 				return Result{}, err
+			}
+			if engine.onCompletion != nil {
+				if err := engine.onCompletion(ctx, message); err != nil {
+					return Result{}, err
+				}
 			}
 			return Result{Status: StatusCompleted}, nil
 		}

--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -37,6 +37,14 @@ type IngressState interface {
 	RecordTask(ctx context.Context, taskMessage contracts.TaskQueueMessage) error
 }
 
+type TelegramAttachmentIngressState interface {
+	RecordTelegramTaskAttachments(ctx context.Context, taskMessage contracts.TaskQueueMessage, attachmentRootDir string) (int, error)
+}
+
+type TelegramAttachmentCleanupState interface {
+	CleanupTelegramAttachmentsForRuntime(ctx context.Context, attachmentRootDir string, notAfter time.Time, maxAgeCutoff time.Time) error
+}
+
 type Connector interface {
 	Poll(ctx context.Context) ([]contracts.TaskEnvelope, error)
 }
@@ -132,6 +140,9 @@ func (runner *Runner) Run(ctx context.Context) error {
 		if _, err := runner.DrainEgress(ctx); err != nil {
 			return err
 		}
+		if err := runner.cleanupTelegramAttachments(ctx); err != nil {
+			return err
+		}
 		if runner.metrics != nil {
 			runner.metrics.RecordLoop(published, runner.now())
 		}
@@ -142,6 +153,23 @@ func (runner *Runner) Run(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+func (runner *Runner) cleanupTelegramAttachments(ctx context.Context) error {
+	if !runner.config.TelegramEnabled {
+		return nil
+	}
+	cleanupState, ok := runner.ingressState.(TelegramAttachmentCleanupState)
+	if !ok {
+		return nil
+	}
+	now := runner.now()
+	return cleanupState.CleanupTelegramAttachmentsForRuntime(
+		ctx,
+		runner.config.TelegramAttachmentDir,
+		now,
+		now.Add(-time.Duration(runner.config.TelegramAttachmentMaxAgeSeconds)*time.Second),
+	)
 }
 
 func (runner *Runner) PublishIngress(ctx context.Context) (int, error) {
@@ -172,6 +200,11 @@ func (runner *Runner) PublishIngress(ctx context.Context) (int, error) {
 			)
 			if err := runner.ingressState.RecordTask(ctx, taskMessage); err != nil {
 				return published, err
+			}
+			if attachmentState, ok := runner.ingressState.(TelegramAttachmentIngressState); ok && envelope.ReplyChannel.Type == "telegram" && len(envelope.Attachments) > 0 {
+				if _, err := attachmentState.RecordTelegramTaskAttachments(ctx, taskMessage, runner.config.TelegramAttachmentDir); err != nil {
+					return published, err
+				}
 			}
 			payload, err := taskMessageMap(taskMessage)
 			if err != nil {

--- a/go/handler/internal/state/sqlite/sqlite.go
+++ b/go/handler/internal/state/sqlite/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,6 +64,25 @@ type TelegramChatRecord struct {
 	LastMessageAt   *time.Time
 	LastUpdateID    int64
 	LastUpdateKind  string
+}
+
+type TelegramAttachmentRecord struct {
+	AttachmentPath   string
+	AttachmentURI    string
+	TaskID           string
+	EnvelopeID       string
+	CreatedAt        time.Time
+	EligibleAfter    *time.Time
+	DeletedAt        *time.Time
+	CleanupAttempts  int
+	LastCleanupError *string
+}
+
+type TelegramAttachmentCleanupResult struct {
+	DeletedCount   int
+	MissingCount   int
+	FailedCount    int
+	ReclaimedBytes int64
 }
 
 func Open(ctx context.Context, dbPath string) (*Store, error) {
@@ -141,6 +161,17 @@ func (store *Store) initialize(ctx context.Context) error {
 			last_update_id INTEGER NOT NULL,
 			last_update_kind TEXT NOT NULL
 		)`,
+		`CREATE TABLE IF NOT EXISTS telegram_attachment_ledger (
+			attachment_path TEXT PRIMARY KEY,
+			attachment_uri TEXT NOT NULL,
+			task_id TEXT NOT NULL,
+			envelope_id TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			eligible_after TEXT,
+			deleted_at TEXT,
+			cleanup_attempts INTEGER NOT NULL,
+			last_cleanup_error TEXT
+		)`,
 	}
 	for _, statement := range statements {
 		if _, err := store.db.ExecContext(ctx, statement); err != nil {
@@ -148,6 +179,206 @@ func (store *Store) initialize(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (store *Store) RecordTelegramTaskAttachments(ctx context.Context, taskMessage contracts.TaskQueueMessage, attachmentRootDir string) (int, error) {
+	if taskMessage.Envelope.Source != "im" || taskMessage.Envelope.ReplyChannel.Type != "telegram" {
+		return 0, nil
+	}
+	rootDir, err := filepath.Abs(defaultTelegramAttachmentRoot(attachmentRootDir))
+	if err != nil {
+		return 0, err
+	}
+	type trackedAttachment struct {
+		path string
+		uri  string
+	}
+	tracked := []trackedAttachment{}
+	for _, attachment := range taskMessage.Envelope.Attachments {
+		path, ok := trackedTelegramAttachmentPath(attachment.URI, rootDir)
+		if ok {
+			tracked = append(tracked, trackedAttachment{path: path, uri: attachment.URI})
+		}
+	}
+	if len(tracked) == 0 {
+		return 0, nil
+	}
+	createdAt := formatTimestamp(time.Now())
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer rollbackUnlessCommitted(tx)
+	inserted := 0
+	for _, attachment := range tracked {
+		result, err := tx.ExecContext(
+			ctx,
+			`INSERT OR IGNORE INTO telegram_attachment_ledger (
+				attachment_path,
+				attachment_uri,
+				task_id,
+				envelope_id,
+				created_at,
+				eligible_after,
+				deleted_at,
+				cleanup_attempts,
+				last_cleanup_error
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			attachment.path,
+			attachment.uri,
+			taskMessage.TaskID,
+			taskMessage.Envelope.ID,
+			createdAt,
+			nil,
+			nil,
+			0,
+			nil,
+		)
+		if err != nil {
+			return 0, err
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return 0, err
+		}
+		inserted += int(rows)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return inserted, nil
+}
+
+func (store *Store) MarkTelegramTaskAttachmentsEligible(ctx context.Context, taskID string, eligibleAfter time.Time) (int, error) {
+	if strings.TrimSpace(taskID) == "" {
+		return 0, errors.New("task_id is required")
+	}
+	result, err := store.db.ExecContext(
+		ctx,
+		`UPDATE telegram_attachment_ledger
+		SET eligible_after = ?, last_cleanup_error = NULL
+		WHERE task_id = ? AND deleted_at IS NULL`,
+		formatTimestamp(eligibleAfter),
+		taskID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(rows), nil
+}
+
+func (store *Store) ListTelegramAttachmentRecords(ctx context.Context) ([]TelegramAttachmentRecord, error) {
+	rows, err := store.db.QueryContext(
+		ctx,
+		`SELECT
+			attachment_path,
+			attachment_uri,
+			task_id,
+			envelope_id,
+			created_at,
+			eligible_after,
+			deleted_at,
+			cleanup_attempts,
+			last_cleanup_error
+		FROM telegram_attachment_ledger
+		ORDER BY created_at ASC, attachment_path ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanTelegramAttachmentRecords(rows)
+}
+
+func (store *Store) CleanupTelegramAttachments(ctx context.Context, attachmentRootDir string, notAfter time.Time, maxAgeCutoff time.Time) (TelegramAttachmentCleanupResult, error) {
+	rootDir, err := filepath.Abs(defaultTelegramAttachmentRoot(attachmentRootDir))
+	if err != nil {
+		return TelegramAttachmentCleanupResult{}, err
+	}
+	rows, err := store.db.QueryContext(
+		ctx,
+		`SELECT
+			attachment_path,
+			attachment_uri,
+			task_id,
+			envelope_id,
+			created_at,
+			eligible_after,
+			deleted_at,
+			cleanup_attempts,
+			last_cleanup_error
+		FROM telegram_attachment_ledger
+		WHERE deleted_at IS NULL
+		  AND (
+			(eligible_after IS NOT NULL AND eligible_after <= ?)
+			OR created_at <= ?
+		  )
+		ORDER BY created_at ASC`,
+		formatTimestamp(notAfter),
+		formatTimestamp(maxAgeCutoff),
+	)
+	if err != nil {
+		return TelegramAttachmentCleanupResult{}, err
+	}
+	candidates, err := scanTelegramAttachmentRecords(rows)
+	if closeErr := rows.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return TelegramAttachmentCleanupResult{}, err
+	}
+	result := TelegramAttachmentCleanupResult{}
+	for _, candidate := range candidates {
+		if !pathWithinRoot(candidate.AttachmentPath, rootDir) {
+			if markErr := store.markTelegramAttachmentCleanupFailed(ctx, candidate.AttachmentPath, "attachment_path_outside_root"); markErr != nil {
+				return result, markErr
+			}
+			result.FailedCount++
+			continue
+		}
+		info, statErr := os.Stat(candidate.AttachmentPath)
+		if errors.Is(statErr, os.ErrNotExist) {
+			if err := store.markTelegramAttachmentDeleted(ctx, candidate.AttachmentPath); err != nil {
+				return result, err
+			}
+			result.MissingCount++
+			continue
+		}
+		if statErr != nil {
+			if markErr := store.markTelegramAttachmentCleanupFailed(ctx, candidate.AttachmentPath, statErr.Error()); markErr != nil {
+				return result, markErr
+			}
+			result.FailedCount++
+			continue
+		}
+		reclaimedBytes := int64(0)
+		if info.Mode().IsRegular() {
+			reclaimedBytes = info.Size()
+		}
+		if err := os.Remove(candidate.AttachmentPath); err != nil {
+			if markErr := store.markTelegramAttachmentCleanupFailed(ctx, candidate.AttachmentPath, err.Error()); markErr != nil {
+				return result, markErr
+			}
+			result.FailedCount++
+			continue
+		}
+		if err := store.markTelegramAttachmentDeleted(ctx, candidate.AttachmentPath); err != nil {
+			return result, err
+		}
+		result.DeletedCount++
+		result.ReclaimedBytes += reclaimedBytes
+	}
+	return result, nil
+}
+
+func (store *Store) CleanupTelegramAttachmentsForRuntime(ctx context.Context, attachmentRootDir string, notAfter time.Time, maxAgeCutoff time.Time) error {
+	_, err := store.CleanupTelegramAttachments(ctx, attachmentRootDir, notAfter, maxAgeCutoff)
+	return err
 }
 
 func (store *Store) RecordTelegramChat(ctx context.Context, observation TelegramChatObservation) error {
@@ -673,4 +904,102 @@ func nullStringPointer(value sql.NullString) *string {
 		return nil
 	}
 	return &value.String
+}
+
+func scanTelegramAttachmentRecords(rows *sql.Rows) ([]TelegramAttachmentRecord, error) {
+	records := []TelegramAttachmentRecord{}
+	for rows.Next() {
+		var createdAt string
+		var eligibleAfter, deletedAt, lastCleanupError sql.NullString
+		record := TelegramAttachmentRecord{}
+		if err := rows.Scan(
+			&record.AttachmentPath,
+			&record.AttachmentURI,
+			&record.TaskID,
+			&record.EnvelopeID,
+			&createdAt,
+			&eligibleAfter,
+			&deletedAt,
+			&record.CleanupAttempts,
+			&lastCleanupError,
+		); err != nil {
+			return nil, err
+		}
+		parsedCreatedAt, err := parseTimestamp(createdAt)
+		if err != nil {
+			return nil, err
+		}
+		record.CreatedAt = parsedCreatedAt
+		if eligibleAfter.Valid {
+			parsed, err := parseTimestamp(eligibleAfter.String)
+			if err != nil {
+				return nil, err
+			}
+			record.EligibleAfter = &parsed
+		}
+		if deletedAt.Valid {
+			parsed, err := parseTimestamp(deletedAt.String)
+			if err != nil {
+				return nil, err
+			}
+			record.DeletedAt = &parsed
+		}
+		record.LastCleanupError = nullStringPointer(lastCleanupError)
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func trackedTelegramAttachmentPath(rawURI string, rootDir string) (string, bool) {
+	parsed, err := url.Parse(rawURI)
+	if err != nil || parsed.Scheme != "file" {
+		return "", false
+	}
+	candidate, err := filepath.Abs(parsed.Path)
+	if err != nil {
+		return "", false
+	}
+	if !pathWithinRoot(candidate, rootDir) {
+		return "", false
+	}
+	return candidate, true
+}
+
+func defaultTelegramAttachmentRoot(rootDir string) string {
+	if strings.TrimSpace(rootDir) == "" {
+		return filepath.Join(os.TempDir(), "chatting-telegram-attachments")
+	}
+	return rootDir
+}
+
+func pathWithinRoot(candidate string, rootDir string) bool {
+	relative, err := filepath.Rel(rootDir, candidate)
+	if err != nil {
+		return false
+	}
+	return relative == "." || (!strings.HasPrefix(relative, ".."+string(filepath.Separator)) && relative != "..")
+}
+
+func (store *Store) markTelegramAttachmentDeleted(ctx context.Context, attachmentPath string) error {
+	_, err := store.db.ExecContext(
+		ctx,
+		`UPDATE telegram_attachment_ledger
+		SET deleted_at = ?, last_cleanup_error = NULL
+		WHERE attachment_path = ?`,
+		formatTimestamp(time.Now()),
+		attachmentPath,
+	)
+	return err
+}
+
+func (store *Store) markTelegramAttachmentCleanupFailed(ctx context.Context, attachmentPath string, cleanupError string) error {
+	_, err := store.db.ExecContext(
+		ctx,
+		`UPDATE telegram_attachment_ledger
+		SET cleanup_attempts = cleanup_attempts + 1, last_cleanup_error = ?
+		WHERE attachment_path = ?`,
+		cleanupError,
+		attachmentPath,
+	)
+	return err
 }

--- a/go/handler/internal/state/sqlite/sqlite_test.go
+++ b/go/handler/internal/state/sqlite/sqlite_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -316,6 +317,184 @@ func TestCompletionEventsCanBeStagedAndCompletionClearsEgressState(t *testing.T)
 	}
 }
 
+func TestTelegramAttachmentLedgerTracksLocalTaskAttachmentsAndCleanup(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	attachmentRoot := t.TempDir()
+	attachmentPath := filepath.Join(attachmentRoot, "telegram-1-2-photo.jpg")
+	if err := os.WriteFile(attachmentPath, []byte("jpeg-bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	name := "photo.jpg"
+	taskMessage := contracts.NewTaskQueueMessage(contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            "telegram:1",
+		Source:        "im",
+		ReceivedAt:    contracts.NewTimestamp(mustTime(t, "2026-05-30T12:00:00Z")),
+		Content:       "[photo attached]",
+		Attachments: []contracts.AttachmentRef{
+			{URI: fileURIForTest(attachmentPath), Name: &name},
+			{URI: "file:///tmp/outside.jpg", Name: &name},
+			{URI: "s3://bucket/photo.jpg", Name: &name},
+		},
+		ContextRefs: []string{},
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   "telegram",
+			Target: "12345",
+		},
+		DedupeKey: "telegram:1",
+	}, "trace:telegram:1", mustTime(t, "2026-05-30T12:00:01Z"))
+
+	tracked, err := store.RecordTelegramTaskAttachments(ctx, taskMessage, attachmentRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tracked != 1 {
+		t.Fatalf("tracked = %d", tracked)
+	}
+	eligibleAfter := mustTime(t, "2026-05-30T12:10:00Z")
+	eligible, err := store.MarkTelegramTaskAttachmentsEligible(ctx, taskMessage.TaskID, eligibleAfter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eligible != 1 {
+		t.Fatalf("eligible = %d", eligible)
+	}
+	records, err := store.ListTelegramAttachmentRecords(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %#v", records)
+	}
+	if records[0].AttachmentPath != attachmentPath || records[0].EligibleAfter == nil || !records[0].EligibleAfter.Equal(eligibleAfter) {
+		t.Fatalf("record = %#v", records[0])
+	}
+
+	result, err := store.CleanupTelegramAttachments(
+		ctx,
+		attachmentRoot,
+		mustTime(t, "2026-05-30T12:11:00Z"),
+		mustTime(t, "2026-01-01T00:00:00Z"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.DeletedCount != 1 || result.MissingCount != 0 || result.FailedCount != 0 || result.ReclaimedBytes != int64(len("jpeg-bytes")) {
+		t.Fatalf("cleanup result = %#v", result)
+	}
+	if _, err := os.Stat(attachmentPath); !os.IsNotExist(err) {
+		t.Fatalf("attachment still exists or unexpected stat error: %v", err)
+	}
+	records, err = store.ListTelegramAttachmentRecords(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records[0].DeletedAt == nil {
+		t.Fatalf("deleted_at not marked: %#v", records[0])
+	}
+}
+
+func TestTelegramAttachmentCleanupMarksMissingAndRejectsOutsideRoot(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	attachmentRoot := t.TempDir()
+	missingPath := filepath.Join(attachmentRoot, "missing.jpg")
+	name := "photo.jpg"
+	taskMessage := contracts.NewTaskQueueMessage(contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            "telegram:missing",
+		Source:        "im",
+		ReceivedAt:    contracts.NewTimestamp(mustTime(t, "2026-05-30T12:00:00Z")),
+		Content:       "[photo attached]",
+		Attachments: []contracts.AttachmentRef{{
+			URI:  fileURIForTest(missingPath),
+			Name: &name,
+		}},
+		ContextRefs: []string{},
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   "telegram",
+			Target: "12345",
+		},
+		DedupeKey: "telegram:missing",
+	}, "trace:telegram:missing", mustTime(t, "2026-05-30T12:00:01Z"))
+	if _, err := store.RecordTelegramTaskAttachments(ctx, taskMessage, attachmentRoot); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.MarkTelegramTaskAttachmentsEligible(ctx, taskMessage.TaskID, mustTime(t, "2026-05-30T12:01:00Z")); err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.CleanupTelegramAttachments(
+		ctx,
+		attachmentRoot,
+		mustTime(t, "2026-05-30T12:02:00Z"),
+		mustTime(t, "2026-01-01T00:00:00Z"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MissingCount != 1 || result.DeletedCount != 0 || result.FailedCount != 0 {
+		t.Fatalf("cleanup result = %#v", result)
+	}
+
+	outsidePath := filepath.Join(t.TempDir(), "outside.jpg")
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.db.ExecContext(
+		ctx,
+		`INSERT INTO telegram_attachment_ledger (
+			attachment_path,
+			attachment_uri,
+			task_id,
+			envelope_id,
+			created_at,
+			eligible_after,
+			deleted_at,
+			cleanup_attempts,
+			last_cleanup_error
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		outsidePath,
+		fileURIForTest(outsidePath),
+		"task:telegram:outside",
+		"telegram:outside",
+		formatTimestamp(mustTime(t, "2026-05-30T12:00:00Z")),
+		formatTimestamp(mustTime(t, "2026-05-30T12:01:00Z")),
+		nil,
+		0,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = store.CleanupTelegramAttachments(
+		ctx,
+		attachmentRoot,
+		mustTime(t, "2026-05-30T12:02:00Z"),
+		mustTime(t, "2026-01-01T00:00:00Z"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FailedCount != 1 {
+		t.Fatalf("cleanup result = %#v", result)
+	}
+	records, err := store.ListTelegramAttachmentRecords(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var outsideRecord *TelegramAttachmentRecord
+	for index := range records {
+		if records[index].AttachmentPath == outsidePath {
+			outsideRecord = &records[index]
+		}
+	}
+	if outsideRecord == nil || outsideRecord.CleanupAttempts != 1 || derefString(outsideRecord.LastCleanupError) != "attachment_path_outside_root" {
+		t.Fatalf("outside record = %#v", outsideRecord)
+	}
+}
+
 func openTestStore(t *testing.T) *Store {
 	t.Helper()
 	return openStoreAt(t, filepath.Join(t.TempDir(), "state.db"))
@@ -396,6 +575,10 @@ func derefString(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func fileURIForTest(path string) string {
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(path)}).String()
 }
 
 func assertTaskLedgerSchemaAndPayload(t *testing.T, dbPath string, taskMessage contracts.TaskQueueMessage) {


### PR DESCRIPTION
## Summary
- download Telegram photo attachments in the Go getUpdates connector and emit file:// AttachmentRefs, including photo-only placeholder content
- add the Go SQLite telegram_attachment_ledger with task attachment tracking, completion eligibility, and grace/max-age cleanup
- wire attachment tracking/cleanup into the Go handler loop and update the Go port plan so GitHub checkpoint persistence is next

## Validation
- go test ./...
- uv run python -m unittest discover -s tests
