### PR TITLE
Add Go GitHub checkpoint foundation

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -699,6 +699,10 @@ Validation:
 
 ### 17. GitHub Checkpoint Store
 
+Status: complete. The Go handler now has Python-compatible SQLite persistence
+for `github_assignment_checkpoints`, plus deterministic checkpoint scope and
+event boundary helpers for assignment and review streams.
+
 Implement GitHub checkpoint persistence.
 
 Validation:
@@ -745,5 +749,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add GitHub checkpoint persistence.
+1. Add GitHub issue assignment and pull request review polling.
 2. Continue closing remaining Python handler parity gaps before a side-by-side dry run.

--- a/go/handler/internal/connectors/github/checkpoint.go
+++ b/go/handler/internal/connectors/github/checkpoint.go
@@ -1,0 +1,69 @@
+package github
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"time"
+)
+
+type AssignmentCheckpoint struct {
+	EventCreatedAt time.Time
+	EventID        string
+}
+
+type CheckpointedEvent interface {
+	CheckpointEventID() string
+	CheckpointEventCreatedAt() time.Time
+}
+
+func CheckpointScopeKey(repositories []string, assigneeLogin string, streamName string) (string, error) {
+	if len(repositories) == 0 {
+		return "", errors.New("repositories are required")
+	}
+	if strings.TrimSpace(streamName) == "" {
+		return "", errors.New("stream_name is required")
+	}
+	normalizedRepositories := make([]string, 0, len(repositories))
+	for _, repository := range repositories {
+		normalizedRepositories = append(normalizedRepositories, strings.TrimSpace(repository))
+	}
+	sort.Strings(normalizedRepositories)
+	return strings.ToLower(strings.TrimSpace(streamName)) + ":" +
+		strings.ToLower(assigneeLogin) + ":" +
+		strings.Join(normalizedRepositories, ","), nil
+}
+
+func SelectEventsAfterCheckpoint[T CheckpointedEvent](events []T, checkpoint *AssignmentCheckpoint) []T {
+	uniqueByID := map[string]T{}
+	for _, event := range events {
+		uniqueByID[event.CheckpointEventID()] = event
+	}
+	ordered := make([]T, 0, len(uniqueByID))
+	for _, event := range uniqueByID {
+		ordered = append(ordered, event)
+	}
+	sort.Slice(ordered, func(leftIndex, rightIndex int) bool {
+		left := ordered[leftIndex]
+		right := ordered[rightIndex]
+		leftCreatedAt := left.CheckpointEventCreatedAt().UTC()
+		rightCreatedAt := right.CheckpointEventCreatedAt().UTC()
+		if !leftCreatedAt.Equal(rightCreatedAt) {
+			return leftCreatedAt.Before(rightCreatedAt)
+		}
+		return left.CheckpointEventID() < right.CheckpointEventID()
+	})
+	if checkpoint == nil {
+		return ordered
+	}
+	boundaryCreatedAt := checkpoint.EventCreatedAt.UTC()
+	filtered := make([]T, 0, len(ordered))
+	for _, event := range ordered {
+		eventCreatedAt := event.CheckpointEventCreatedAt().UTC()
+		if eventCreatedAt.After(boundaryCreatedAt) ||
+			(eventCreatedAt.Equal(boundaryCreatedAt) && event.CheckpointEventID() > checkpoint.EventID) {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}

--- a/go/handler/internal/connectors/github/checkpoint_test.go
+++ b/go/handler/internal/connectors/github/checkpoint_test.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+type testCheckpointEvent struct {
+	id        string
+	createdAt time.Time
+}
+
+func (event testCheckpointEvent) CheckpointEventID() string {
+	return event.id
+}
+
+func (event testCheckpointEvent) CheckpointEventCreatedAt() time.Time {
+	return event.createdAt
+}
+
+func TestCheckpointScopeKeyMatchesPythonFormat(t *testing.T) {
+	scopeKey, err := CheckpointScopeKey(
+		[]string{"EdwardSalkeld/workout-data", "EdwardSalkeld/chatting"},
+		"BillyAcachofa",
+		"reviews",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scopeKey != "reviews:billyacachofa:EdwardSalkeld/chatting,EdwardSalkeld/workout-data" {
+		t.Fatalf("scopeKey = %q", scopeKey)
+	}
+}
+
+func TestCheckpointScopeKeyDefaultsValidateRequiredInputs(t *testing.T) {
+	if _, err := CheckpointScopeKey(nil, "BillyAcachofa", "assignments"); err == nil || err.Error() != "repositories are required" {
+		t.Fatalf("missing repositories err = %v", err)
+	}
+	if _, err := CheckpointScopeKey([]string{"EdwardSalkeld/chatting"}, "BillyAcachofa", " "); err == nil || err.Error() != "stream_name is required" {
+		t.Fatalf("missing stream err = %v", err)
+	}
+}
+
+func TestSelectEventsAfterCheckpointSortsDedupesAndFiltersBoundary(t *testing.T) {
+	first := mustCheckpointTime(t, "2026-05-30T12:00:00Z")
+	second := mustCheckpointTime(t, "2026-05-30T12:01:00Z")
+	events := []testCheckpointEvent{
+		{id: "evt-3", createdAt: second},
+		{id: "evt-1", createdAt: first},
+		{id: "evt-2", createdAt: first},
+		{id: "evt-2", createdAt: first},
+	}
+
+	selected := SelectEventsAfterCheckpoint(events, &AssignmentCheckpoint{
+		EventCreatedAt: first,
+		EventID:        "evt-1",
+	})
+
+	if len(selected) != 2 || selected[0].id != "evt-2" || selected[1].id != "evt-3" {
+		t.Fatalf("selected = %#v", selected)
+	}
+}
+
+func TestSelectEventsAfterCheckpointReturnsOrderedEventsWithoutCheckpoint(t *testing.T) {
+	first := mustCheckpointTime(t, "2026-05-30T12:00:00Z")
+	second := mustCheckpointTime(t, "2026-05-30T12:01:00Z")
+	events := []testCheckpointEvent{
+		{id: "evt-3", createdAt: second},
+		{id: "evt-1", createdAt: first},
+	}
+
+	selected := SelectEventsAfterCheckpoint(events, nil)
+
+	if len(selected) != 2 || selected[0].id != "evt-1" || selected[1].id != "evt-3" {
+		t.Fatalf("selected = %#v", selected)
+	}
+}
+
+func mustCheckpointTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/go/handler/internal/state/sqlite/sqlite.go
+++ b/go/handler/internal/state/sqlite/sqlite.go
@@ -85,6 +85,11 @@ type TelegramAttachmentCleanupResult struct {
 	ReclaimedBytes int64
 }
 
+type GitHubAssignmentCheckpoint struct {
+	EventCreatedAt time.Time
+	EventID        string
+}
+
 func Open(ctx context.Context, dbPath string) (*Store, error) {
 	if strings.TrimSpace(dbPath) == "" {
 		return nil, errors.New("db_path is required")
@@ -172,6 +177,12 @@ func (store *Store) initialize(ctx context.Context) error {
 			cleanup_attempts INTEGER NOT NULL,
 			last_cleanup_error TEXT
 		)`,
+		`CREATE TABLE IF NOT EXISTS github_assignment_checkpoints (
+			scope_key TEXT PRIMARY KEY,
+			event_created_at TEXT NOT NULL,
+			event_id TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
 	}
 	for _, statement := range statements {
 		if _, err := store.db.ExecContext(ctx, statement); err != nil {
@@ -179,6 +190,64 @@ func (store *Store) initialize(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (store *Store) GetGitHubAssignmentCheckpoint(ctx context.Context, scopeKey string) (*GitHubAssignmentCheckpoint, error) {
+	if strings.TrimSpace(scopeKey) == "" {
+		return nil, errors.New("scope_key is required")
+	}
+	var eventCreatedAt string
+	checkpoint := GitHubAssignmentCheckpoint{}
+	err := store.db.QueryRowContext(
+		ctx,
+		`SELECT event_created_at, event_id
+		FROM github_assignment_checkpoints
+		WHERE scope_key = ?`,
+		scopeKey,
+	).Scan(&eventCreatedAt, &checkpoint.EventID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := parseTimestamp(eventCreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	checkpoint.EventCreatedAt = parsed
+	return &checkpoint, nil
+}
+
+func (store *Store) SetGitHubAssignmentCheckpoint(ctx context.Context, scopeKey string, checkpoint GitHubAssignmentCheckpoint) error {
+	if strings.TrimSpace(scopeKey) == "" {
+		return errors.New("scope_key is required")
+	}
+	if strings.TrimSpace(checkpoint.EventID) == "" {
+		return errors.New("event_id is required")
+	}
+	if checkpoint.EventCreatedAt.IsZero() {
+		return errors.New("event_created_at is required")
+	}
+	_, err := store.db.ExecContext(
+		ctx,
+		`INSERT INTO github_assignment_checkpoints (
+			scope_key,
+			event_created_at,
+			event_id,
+			updated_at
+		)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(scope_key) DO UPDATE SET
+			event_created_at = excluded.event_created_at,
+			event_id = excluded.event_id,
+			updated_at = excluded.updated_at`,
+		scopeKey,
+		formatTimestamp(checkpoint.EventCreatedAt),
+		checkpoint.EventID,
+		formatTimestamp(time.Now()),
+	)
+	return err
 }
 
 func (store *Store) RecordTelegramTaskAttachments(ctx context.Context, taskMessage contracts.TaskQueueMessage, attachmentRootDir string) (int, error) {

--- a/go/handler/internal/state/sqlite/sqlite_test.go
+++ b/go/handler/internal/state/sqlite/sqlite_test.go
@@ -105,6 +105,40 @@ func TestTelegramChatRegistryUpsertsObservedMetadata(t *testing.T) {
 	}
 }
 
+func TestGitHubAssignmentCheckpointRoundTripUsesPythonCompatibleTable(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	store := openStoreAt(t, dbPath)
+	scopeKey := "assignments:billyacachofa:EdwardSalkeld/chatting"
+	checkpoint := GitHubAssignmentCheckpoint{
+		EventCreatedAt: mustTime(t, "2026-05-30T12:34:56.123456789Z"),
+		EventID:        "AE_lADOB9Rs6s4A9fxGzwAAAAAB",
+	}
+
+	empty, err := store.GetGitHubAssignmentCheckpoint(ctx, scopeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if empty != nil {
+		t.Fatalf("unexpected checkpoint before set: %#v", empty)
+	}
+	if err := store.SetGitHubAssignmentCheckpoint(ctx, scopeKey, checkpoint); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.GetGitHubAssignmentCheckpoint(ctx, scopeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded == nil {
+		t.Fatal("checkpoint was not persisted")
+	}
+	if !loaded.EventCreatedAt.Equal(checkpoint.EventCreatedAt) || loaded.EventID != checkpoint.EventID {
+		t.Fatalf("loaded checkpoint = %#v", loaded)
+	}
+
+	assertGitHubAssignmentCheckpointSchemaAndPayload(t, dbPath, scopeKey, checkpoint)
+}
+
 func TestRecordTaskRoundTripsAndUsesPythonCompatibleTable(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "state.db")
@@ -134,6 +168,31 @@ func TestRecordTaskRoundTripsAndUsesPythonCompatibleTable(t *testing.T) {
 
 	assertTaskLedgerSchemaAndPayload(t, dbPath, taskMessage)
 	assertPythonTaskLedgerCanRead(t, dbPath, taskMessage)
+}
+
+func assertGitHubAssignmentCheckpointSchemaAndPayload(t *testing.T, dbPath string, scopeKey string, checkpoint GitHubAssignmentCheckpoint) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	row := db.QueryRow(
+		`SELECT event_created_at, event_id, updated_at
+		FROM github_assignment_checkpoints
+		WHERE scope_key = ?`,
+		scopeKey,
+	)
+	var eventCreatedAt, eventID, updatedAt string
+	if err := row.Scan(&eventCreatedAt, &eventID, &updatedAt); err != nil {
+		t.Fatal(err)
+	}
+	if eventCreatedAt != formatTimestamp(checkpoint.EventCreatedAt) || eventID != checkpoint.EventID {
+		t.Fatalf("checkpoint row = event_created_at:%q event_id:%q", eventCreatedAt, eventID)
+	}
+	if _, err := parseTimestamp(updatedAt); err != nil {
+		t.Fatalf("updated_at is not RFC3339Nano: %q", updatedAt)
+	}
 }
 
 func TestCompletionBlocksSameEnvelopeAndRemovesOpenTask(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Go SQLite persistence for Python-compatible GitHub assignment checkpoints
- add deterministic Go checkpoint scope and event-boundary filtering helpers for upcoming GitHub polling
- update the Go handler porting plan so the next slice is GitHub polling

## Validation
- go test ./...
- uv run python -m unittest tests.test_github_ingress_runtime
