### PR TITLE
Port GitHub polling to Go handler

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -712,6 +712,13 @@ Validation:
 
 ### 18. GitHub Polling
 
+Status: complete. The Go handler now accepts the Python handler GitHub polling
+config keys, derives the authenticated `gh` viewer when no assignee is set,
+expands `owner/*` repository selectors, polls issue assignment and pull request
+review GraphQL streams, normalizes both streams into Python-compatible GitHub
+task envelopes, and advances Python-compatible checkpoints after successful
+poll cycles.
+
 Implement GitHub issue assignment and pull request review polling.
 
 Validation:
@@ -749,5 +756,5 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add GitHub issue assignment and pull request review polling.
+1. Add GitHub comment dispatch.
 2. Continue closing remaining Python handler parity gaps before a side-by-side dry run.

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/auxiliary"
+	githubconnector "github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/github"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/imap"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/schedule"
@@ -207,6 +208,42 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		}
 		connectors = append(connectors, connector)
 	}
+	if len(config.GitHubRepositories) > 0 {
+		assigneeLogin := config.GitHubAssigneeLogin
+		if strings.TrimSpace(assigneeLogin) == "" {
+			assigneeLogin, err = githubconnector.FetchAuthenticatedViewerLogin(ctx, nil)
+			if err != nil {
+				_ = store.Close()
+				return nil, fmt.Errorf("github_assignee_login is required when github_repositories is configured unless it can be derived from authenticated gh user")
+			}
+		}
+		checkpointStore := githubCheckpointStore{store: store}
+		assignmentConnector, err := githubconnector.NewIssueAssignmentConnector(githubconnector.IssueAssignmentConfig{
+			RepositoryPatterns: config.GitHubRepositories,
+			AssigneeLogin:      assigneeLogin,
+			ContextRefs:        config.GitHubContextRefs,
+			CheckpointStore:    checkpointStore,
+			MaxIssues:          config.GitHubMaxIssues,
+			MaxTimelineEvents:  config.GitHubMaxTimelineEvents,
+		})
+		if err != nil {
+			_ = store.Close()
+			return nil, err
+		}
+		reviewConnector, err := githubconnector.NewPullRequestReviewConnector(githubconnector.PullRequestReviewConfig{
+			RepositoryPatterns: config.GitHubRepositories,
+			AuthorLogin:        assigneeLogin,
+			ContextRefs:        config.GitHubContextRefs,
+			CheckpointStore:    checkpointStore,
+			MaxPullRequests:    config.GitHubMaxIssues,
+			MaxReviews:         config.GitHubMaxTimelineEvents,
+		})
+		if err != nil {
+			_ = store.Close()
+			return nil, err
+		}
+		connectors = append(connectors, assignmentConnector, reviewConnector)
+	}
 	auxiliaryAdapter := adapter
 	if config.AuxiliaryIngressEnabled {
 		auxiliaryAddress := config.AuxiliaryIngressBBMBAddress
@@ -258,6 +295,28 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		return nil, err
 	}
 	return &closingRunner{runner: runner, closers: []closer{metricsServer, store}}, nil
+}
+
+type githubCheckpointStore struct {
+	store *sqlitestate.Store
+}
+
+func (store githubCheckpointStore) GetGitHubCheckpoint(ctx context.Context, scopeKey string) (*githubconnector.AssignmentCheckpoint, error) {
+	checkpoint, err := store.store.GetGitHubAssignmentCheckpoint(ctx, scopeKey)
+	if err != nil || checkpoint == nil {
+		return nil, err
+	}
+	return &githubconnector.AssignmentCheckpoint{
+		EventCreatedAt: checkpoint.EventCreatedAt,
+		EventID:        checkpoint.EventID,
+	}, nil
+}
+
+func (store githubCheckpointStore) SetGitHubCheckpoint(ctx context.Context, scopeKey string, checkpoint githubconnector.AssignmentCheckpoint) error {
+	return store.store.SetGitHubAssignmentCheckpoint(ctx, scopeKey, sqlitestate.GitHubAssignmentCheckpoint{
+		EventCreatedAt: checkpoint.EventCreatedAt,
+		EventID:        checkpoint.EventID,
+	})
 }
 
 func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, error) {

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -69,6 +69,12 @@ var allowedKeys = map[string]bool{
 	"auxiliary_ingress_bbmb_address": true,
 	"auxiliary_ingress_queues":       true,
 	"auxiliary_ingress_context_refs": true,
+
+	"github_repositories":        true,
+	"github_assignee_login":      true,
+	"github_context_refs":        true,
+	"github_max_issues":          true,
+	"github_max_timeline_events": true,
 }
 
 type Config struct {
@@ -116,6 +122,12 @@ type Config struct {
 	AuxiliaryIngressBBMBAddress string
 	AuxiliaryIngressQueues      []string
 	AuxiliaryIngressContextRefs []string
+
+	GitHubRepositories      []string
+	GitHubAssigneeLogin     string
+	GitHubContextRefs       []string
+	GitHubMaxIssues         int
+	GitHubMaxTimelineEvents int
 }
 
 func Defaults() Config {
@@ -164,6 +176,12 @@ func Defaults() Config {
 		AuxiliaryIngressBBMBAddress: "",
 		AuxiliaryIngressQueues:      []string{},
 		AuxiliaryIngressContextRefs: []string{},
+
+		GitHubRepositories:      []string{},
+		GitHubAssigneeLogin:     "",
+		GitHubContextRefs:       []string{},
+		GitHubMaxIssues:         25,
+		GitHubMaxTimelineEvents: 10,
 	}
 }
 
@@ -479,6 +497,36 @@ func Load(raw []byte) (Config, error) {
 			return Config{}, err
 		}
 	}
+	if rawValue, ok := payload["github_repositories"]; ok && !isNull(rawValue) {
+		config.GitHubRepositories, err = decodeGitHubRepositories(rawValue)
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["github_assignee_login"]; ok && !isNull(rawValue) {
+		config.GitHubAssigneeLogin, err = decodeNonEmptyString(rawValue, "github_assignee_login")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["github_context_refs"]; ok && !isNull(rawValue) {
+		config.GitHubContextRefs, err = decodeStringList(rawValue, "github_context_refs")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["github_max_issues"]; ok && !isNull(rawValue) {
+		config.GitHubMaxIssues, err = decodePositiveInt(rawValue, "github_max_issues")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["github_max_timeline_events"]; ok && !isNull(rawValue) {
+		config.GitHubMaxTimelineEvents, err = decodePositiveInt(rawValue, "github_max_timeline_events")
+		if err != nil {
+			return Config{}, err
+		}
+	}
 	if config.AuxiliaryIngressEnabled && len(config.AuxiliaryIngressQueues) == 0 {
 		return Config{}, errors.New("auxiliary ingress requires auxiliary_ingress_queues")
 	}
@@ -555,6 +603,39 @@ func decodeAllowedEgressChannels(raw json.RawMessage) ([]string, error) {
 		return Defaults().AllowedEgressChannels, nil
 	}
 	return values, nil
+}
+
+func decodeGitHubRepositories(raw json.RawMessage) ([]string, error) {
+	values, err := decodeStringList(raw, "github_repositories")
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, value := range values {
+		owner, name, err := parseGitHubRepositoryPattern(value)
+		if err != nil {
+			return nil, err
+		}
+		normalized := owner + "/" + name
+		if seen[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		result = append(result, normalized)
+	}
+	return result, nil
+}
+
+func parseGitHubRepositoryPattern(value string) (string, string, error) {
+	parts := strings.SplitN(strings.TrimSpace(value), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", errors.New("github_repositories entries must be owner/repo or owner/*")
+	}
+	if parts[1] != "*" && strings.Contains(parts[1], "*") {
+		return "", "", errors.New("github_repositories entries must be owner/repo or owner/*")
+	}
+	return parts[0], parts[1], nil
 }
 
 func decodeStringList(raw json.RawMessage, name string) ([]string, error) {

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -63,7 +63,12 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 		"auxiliary_ingress_enabled": true,
 		"auxiliary_ingress_bbmb_address": "10.0.0.2:9998",
 		"auxiliary_ingress_queues": ["generic-post"],
-		"auxiliary_ingress_context_refs": ["repo:/workspace/chatting"]
+		"auxiliary_ingress_context_refs": ["repo:/workspace/chatting"],
+		"github_repositories": ["EdwardSalkeld/chatting", "EdwardSalkeld/*", "EdwardSalkeld/chatting"],
+		"github_assignee_login": "BillyAcachofa",
+		"github_context_refs": ["repo:/workspace/chatting"],
+		"github_max_issues": 12,
+		"github_max_timeline_events": 8
 	}`))
 	if err != nil {
 		t.Fatal(err)
@@ -194,6 +199,21 @@ func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(config.AuxiliaryIngressContextRefs, []string{"repo:/workspace/chatting"}) {
 		t.Fatalf("AuxiliaryIngressContextRefs = %#v", config.AuxiliaryIngressContextRefs)
+	}
+	if !reflect.DeepEqual(config.GitHubRepositories, []string{"EdwardSalkeld/chatting", "EdwardSalkeld/*"}) {
+		t.Fatalf("GitHubRepositories = %#v", config.GitHubRepositories)
+	}
+	if config.GitHubAssigneeLogin != "BillyAcachofa" {
+		t.Fatalf("GitHubAssigneeLogin = %q", config.GitHubAssigneeLogin)
+	}
+	if !reflect.DeepEqual(config.GitHubContextRefs, []string{"repo:/workspace/chatting"}) {
+		t.Fatalf("GitHubContextRefs = %#v", config.GitHubContextRefs)
+	}
+	if config.GitHubMaxIssues != 12 {
+		t.Fatalf("GitHubMaxIssues = %d", config.GitHubMaxIssues)
+	}
+	if config.GitHubMaxTimelineEvents != 8 {
+		t.Fatalf("GitHubMaxTimelineEvents = %d", config.GitHubMaxTimelineEvents)
 	}
 }
 
@@ -326,6 +346,16 @@ func TestLoadRejectsInvalidValues(t *testing.T) {
 			name:    "blank auxiliary queue",
 			raw:     `{"auxiliary_ingress_queues": ["generic-post", ""]}`,
 			message: "auxiliary_ingress_queues entries must not be empty",
+		},
+		{
+			name:    "invalid github repository selector",
+			raw:     `{"github_repositories": ["EdwardSalkeld/chat*"]}`,
+			message: "github_repositories entries must be owner/repo or owner/*",
+		},
+		{
+			name:    "bad github max issues",
+			raw:     `{"github_max_issues": 0}`,
+			message: "config github_max_issues must be a positive integer",
 		},
 	}
 

--- a/go/handler/internal/connectors/github/github.go
+++ b/go/handler/internal/connectors/github/github.go
@@ -1,0 +1,1102 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+)
+
+const (
+	Source                   = "webhook"
+	IssueAssignmentsStream   = "issue-assignments"
+	PullRequestReviewsStream = "pull-request-reviews"
+)
+
+const AssignedEventsQuery = `
+query (
+  $repoOwner: String!
+  $repoName: String!
+  $issueLimit: Int!
+  $timelineLimit: Int!
+) {
+  repository(owner: $repoOwner, name: $repoName) {
+    id
+    nameWithOwner
+    issues(first: $issueLimit, orderBy: { field: UPDATED_AT, direction: DESC }) {
+      nodes {
+        id
+        number
+        title
+        body
+        url
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
+        timelineItems(last: $timelineLimit, itemTypes: [ASSIGNED_EVENT]) {
+          nodes {
+            ... on AssignedEvent {
+              id
+              createdAt
+              actor {
+                login
+              }
+              assignee {
+                __typename
+                ... on User {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+const PullRequestReviewsQuery = `
+query (
+  $repoOwner: String!
+  $repoName: String!
+  $pullRequestLimit: Int!
+  $reviewLimit: Int!
+) {
+  repository(owner: $repoOwner, name: $repoName) {
+    id
+    nameWithOwner
+    pullRequests(
+      first: $pullRequestLimit
+      states: OPEN
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      nodes {
+        id
+        number
+        title
+        body
+        url
+        author {
+          login
+        }
+        closingIssuesReferences(first: 10) {
+          nodes {
+            number
+            title
+            url
+          }
+        }
+        reviews(last: $reviewLimit) {
+          nodes {
+            id
+            submittedAt
+            state
+            body
+            url
+            author {
+              login
+            }
+            comments {
+              totalCount
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+const ViewerLoginQuery = `
+query {
+  viewer {
+    login
+  }
+}
+`
+
+const OwnerRepositoriesQuery = `
+query (
+  $owner: String!
+  $after: String
+) {
+  organization(login: $owner) {
+    repositories(first: 100, after: $after, orderBy: { field: UPDATED_AT, direction: DESC }) {
+      nodes {
+        nameWithOwner
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+  user(login: $owner) {
+    repositories(
+      first: 100
+      after: $after
+      ownerAffiliations: OWNER
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      nodes {
+        nameWithOwner
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+`
+
+type GraphQLRunner func(ctx context.Context, query string, variables map[string]any) (map[string]any, error)
+
+type CheckpointStore interface {
+	GetGitHubCheckpoint(ctx context.Context, scopeKey string) (*AssignmentCheckpoint, error)
+	SetGitHubCheckpoint(ctx context.Context, scopeKey string, checkpoint AssignmentCheckpoint) error
+}
+
+type IssueAssignmentEvent struct {
+	EventID                 string
+	EventCreatedAt          time.Time
+	RepositoryID            string
+	RepositoryNameWithOwner string
+	IssueID                 string
+	IssueNumber             int
+	IssueTitle              string
+	IssueBody               string
+	IssueURL                string
+	AssigneeLogin           string
+	ActorLogin              *string
+	Labels                  []string
+}
+
+func (event IssueAssignmentEvent) CheckpointEventID() string {
+	return event.EventID
+}
+
+func (event IssueAssignmentEvent) CheckpointEventCreatedAt() time.Time {
+	return event.EventCreatedAt
+}
+
+func (event IssueAssignmentEvent) DedupeKey() string {
+	return "github:" + event.RepositoryID + ":" + event.IssueID + ":" + event.EventID
+}
+
+func (event IssueAssignmentEvent) EnvelopeID() string {
+	return fmt.Sprintf("github-assignment:%s:%d:%s", event.RepositoryNameWithOwner, event.IssueNumber, event.EventID)
+}
+
+func (event IssueAssignmentEvent) ToTaskEnvelope(contextRefs []string) contracts.TaskEnvelope {
+	labelsSummary := "(none)"
+	if len(event.Labels) > 0 {
+		labelsSummary = strings.Join(event.Labels, ", ")
+	}
+	actor := "unknown"
+	if event.ActorLogin != nil && strings.TrimSpace(*event.ActorLogin) != "" {
+		actor = *event.ActorLogin
+	}
+	issueBody := strings.TrimSpace(event.IssueBody)
+	if issueBody == "" {
+		issueBody = "(empty)"
+	}
+	content := "GitHub issue assignment detected.\n\n" +
+		fmt.Sprintf("Repository: %s\n", event.RepositoryNameWithOwner) +
+		fmt.Sprintf("Issue: #%d %s\n", event.IssueNumber, event.IssueTitle) +
+		fmt.Sprintf("URL: %s\n", event.IssueURL) +
+		fmt.Sprintf("Assigned to: %s\n", event.AssigneeLogin) +
+		fmt.Sprintf("Assigned by: %s\n", actor) +
+		fmt.Sprintf("Labels: %s\n", labelsSummary) +
+		fmt.Sprintf("Assigned event id: %s\n", event.EventID) +
+		fmt.Sprintf("Assigned at: %s\n\n", formatEventTime(event.EventCreatedAt)) +
+		"Issue body:\n" + issueBody
+	return contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            event.EnvelopeID(),
+		Source:        Source,
+		ReceivedAt:    contracts.NewTimestamp(event.EventCreatedAt),
+		Actor:         event.ActorLogin,
+		Content:       content,
+		Attachments:   []contracts.AttachmentRef{},
+		ContextRefs:   append([]string{}, contextRefs...),
+		ReplyChannel:  contracts.ReplyChannel{Type: "github", Target: event.IssueURL},
+		DedupeKey:     event.DedupeKey(),
+	}
+}
+
+type PullRequestReviewEvent struct {
+	EventID                 string
+	EventCreatedAt          time.Time
+	RepositoryID            string
+	RepositoryNameWithOwner string
+	PullRequestID           string
+	PullRequestNumber       int
+	PullRequestTitle        string
+	PullRequestBody         string
+	PullRequestURL          string
+	PullRequestAuthorLogin  string
+	ReviewAuthorLogin       string
+	ReviewState             string
+	ReviewBody              string
+	ReviewURL               string
+	ReviewCommentCount      int
+	ClosingIssueRefs        []string
+}
+
+func (event PullRequestReviewEvent) CheckpointEventID() string {
+	return event.EventID
+}
+
+func (event PullRequestReviewEvent) CheckpointEventCreatedAt() time.Time {
+	return event.EventCreatedAt
+}
+
+func (event PullRequestReviewEvent) DedupeKey() string {
+	return "github-review:" + event.RepositoryID + ":" + event.PullRequestID + ":" + event.EventID
+}
+
+func (event PullRequestReviewEvent) EnvelopeID() string {
+	return fmt.Sprintf("github-review:%s:%d:%s", event.RepositoryNameWithOwner, event.PullRequestNumber, event.EventID)
+}
+
+func (event PullRequestReviewEvent) ToTaskEnvelope(contextRefs []string) contracts.TaskEnvelope {
+	closingIssuesSummary := "(none linked)"
+	if len(event.ClosingIssueRefs) > 0 {
+		closingIssuesSummary = strings.Join(event.ClosingIssueRefs, ", ")
+	}
+	reviewBody := strings.TrimSpace(event.ReviewBody)
+	if reviewBody == "" {
+		reviewBody = "(empty)"
+	}
+	pullRequestBody := strings.TrimSpace(event.PullRequestBody)
+	if pullRequestBody == "" {
+		pullRequestBody = "(empty)"
+	}
+	actor := event.ReviewAuthorLogin
+	content := "GitHub pull request review detected.\n\n" +
+		fmt.Sprintf("Repository: %s\n", event.RepositoryNameWithOwner) +
+		fmt.Sprintf("Pull request: #%d %s\n", event.PullRequestNumber, event.PullRequestTitle) +
+		fmt.Sprintf("Pull request URL: %s\n", event.PullRequestURL) +
+		fmt.Sprintf("Pull request author: %s\n", event.PullRequestAuthorLogin) +
+		fmt.Sprintf("Review state: %s\n", event.ReviewState) +
+		fmt.Sprintf("Review author: %s\n", event.ReviewAuthorLogin) +
+		fmt.Sprintf("Review URL: %s\n", event.ReviewURL) +
+		fmt.Sprintf("Inline review comments: %d\n", event.ReviewCommentCount) +
+		fmt.Sprintf("Linked issues: %s\n", closingIssuesSummary) +
+		fmt.Sprintf("Review id: %s\n", event.EventID) +
+		fmt.Sprintf("Reviewed at: %s\n\n", formatEventTime(event.EventCreatedAt)) +
+		"Read the review and any inline comments on this pull request, then make changes or respond on GitHub as needed.\n\n" +
+		"Review body:\n" + reviewBody + "\n\n" +
+		"Pull request body:\n" + pullRequestBody
+	return contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            event.EnvelopeID(),
+		Source:        Source,
+		ReceivedAt:    contracts.NewTimestamp(event.EventCreatedAt),
+		Actor:         &actor,
+		Content:       content,
+		Attachments:   []contracts.AttachmentRef{},
+		ContextRefs:   append([]string{}, contextRefs...),
+		ReplyChannel:  contracts.ReplyChannel{Type: "github", Target: event.PullRequestURL},
+		DedupeKey:     event.DedupeKey(),
+	}
+}
+
+type IssueAssignmentConnector struct {
+	repositoryPatterns []string
+	assigneeLogin      string
+	contextRefs        []string
+	checkpointStore    CheckpointStore
+	maxIssues          int
+	maxTimelineEvents  int
+	graphqlRunner      GraphQLRunner
+	pendingCheckpoint  *AssignmentCheckpoint
+}
+
+type IssueAssignmentConfig struct {
+	RepositoryPatterns []string
+	AssigneeLogin      string
+	ContextRefs        []string
+	CheckpointStore    CheckpointStore
+	MaxIssues          int
+	MaxTimelineEvents  int
+	GraphQLRunner      GraphQLRunner
+}
+
+func NewIssueAssignmentConnector(config IssueAssignmentConfig) (*IssueAssignmentConnector, error) {
+	if len(config.RepositoryPatterns) == 0 {
+		return nil, errors.New("repository_patterns are required")
+	}
+	if strings.TrimSpace(config.AssigneeLogin) == "" {
+		return nil, errors.New("assignee_login is required")
+	}
+	if config.CheckpointStore == nil {
+		return nil, errors.New("checkpoint_store is required")
+	}
+	if config.MaxIssues <= 0 {
+		config.MaxIssues = 25
+	}
+	if config.MaxTimelineEvents <= 0 {
+		config.MaxTimelineEvents = 10
+	}
+	runner := config.GraphQLRunner
+	if runner == nil {
+		runner = DefaultGraphQLRunner
+	}
+	return &IssueAssignmentConnector{
+		repositoryPatterns: append([]string{}, config.RepositoryPatterns...),
+		assigneeLogin:      strings.TrimSpace(config.AssigneeLogin),
+		contextRefs:        append([]string{}, config.ContextRefs...),
+		checkpointStore:    config.CheckpointStore,
+		maxIssues:          config.MaxIssues,
+		maxTimelineEvents:  config.MaxTimelineEvents,
+		graphqlRunner:      runner,
+	}, nil
+}
+
+func (connector *IssueAssignmentConnector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	if err := connector.flushPendingCheckpoint(ctx); err != nil {
+		return nil, err
+	}
+	scopeKey, err := CheckpointScopeKey(connector.repositoryPatterns, connector.assigneeLogin, IssueAssignmentsStream)
+	if err != nil {
+		return nil, err
+	}
+	checkpoint, err := connector.checkpointStore.GetGitHubCheckpoint(ctx, scopeKey)
+	if err != nil {
+		return nil, err
+	}
+	repositories, err := ExpandRepositoryPatterns(ctx, connector.repositoryPatterns, connector.graphqlRunner)
+	if err != nil {
+		return nil, err
+	}
+	events := []IssueAssignmentEvent{}
+	for _, repository := range repositories {
+		owner, name, err := ParseRepoSlug(repository)
+		if err != nil {
+			continue
+		}
+		repositoryEvents, err := FetchAssignmentEventsForRepository(ctx, owner, name, connector.assigneeLogin, connector.maxIssues, connector.maxTimelineEvents, connector.graphqlRunner)
+		if err != nil {
+			continue
+		}
+		events = append(events, repositoryEvents...)
+	}
+	newEvents := SelectEventsAfterCheckpoint(events, checkpoint)
+	if len(newEvents) > 0 {
+		latest := newEvents[len(newEvents)-1]
+		connector.pendingCheckpoint = &AssignmentCheckpoint{
+			EventCreatedAt: latest.EventCreatedAt,
+			EventID:        latest.EventID,
+		}
+	}
+	envelopes := make([]contracts.TaskEnvelope, 0, len(newEvents))
+	for _, event := range newEvents {
+		envelopes = append(envelopes, event.ToTaskEnvelope(connector.contextRefs))
+	}
+	return envelopes, nil
+}
+
+func (connector *IssueAssignmentConnector) flushPendingCheckpoint(ctx context.Context) error {
+	if connector.pendingCheckpoint == nil {
+		return nil
+	}
+	scopeKey, err := CheckpointScopeKey(connector.repositoryPatterns, connector.assigneeLogin, IssueAssignmentsStream)
+	if err != nil {
+		return err
+	}
+	if err := connector.checkpointStore.SetGitHubCheckpoint(ctx, scopeKey, *connector.pendingCheckpoint); err != nil {
+		return err
+	}
+	connector.pendingCheckpoint = nil
+	return nil
+}
+
+type PullRequestReviewConnector struct {
+	repositoryPatterns []string
+	authorLogin        string
+	contextRefs        []string
+	checkpointStore    CheckpointStore
+	maxPullRequests    int
+	maxReviews         int
+	graphqlRunner      GraphQLRunner
+	pendingCheckpoint  *AssignmentCheckpoint
+}
+
+type PullRequestReviewConfig struct {
+	RepositoryPatterns []string
+	AuthorLogin        string
+	ContextRefs        []string
+	CheckpointStore    CheckpointStore
+	MaxPullRequests    int
+	MaxReviews         int
+	GraphQLRunner      GraphQLRunner
+}
+
+func NewPullRequestReviewConnector(config PullRequestReviewConfig) (*PullRequestReviewConnector, error) {
+	if len(config.RepositoryPatterns) == 0 {
+		return nil, errors.New("repository_patterns are required")
+	}
+	if strings.TrimSpace(config.AuthorLogin) == "" {
+		return nil, errors.New("author_login is required")
+	}
+	if config.CheckpointStore == nil {
+		return nil, errors.New("checkpoint_store is required")
+	}
+	if config.MaxPullRequests <= 0 {
+		config.MaxPullRequests = 25
+	}
+	if config.MaxReviews <= 0 {
+		config.MaxReviews = 10
+	}
+	runner := config.GraphQLRunner
+	if runner == nil {
+		runner = DefaultGraphQLRunner
+	}
+	return &PullRequestReviewConnector{
+		repositoryPatterns: append([]string{}, config.RepositoryPatterns...),
+		authorLogin:        strings.TrimSpace(config.AuthorLogin),
+		contextRefs:        append([]string{}, config.ContextRefs...),
+		checkpointStore:    config.CheckpointStore,
+		maxPullRequests:    config.MaxPullRequests,
+		maxReviews:         config.MaxReviews,
+		graphqlRunner:      runner,
+	}, nil
+}
+
+func (connector *PullRequestReviewConnector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	if err := connector.flushPendingCheckpoint(ctx); err != nil {
+		return nil, err
+	}
+	scopeKey, err := CheckpointScopeKey(connector.repositoryPatterns, connector.authorLogin, PullRequestReviewsStream)
+	if err != nil {
+		return nil, err
+	}
+	checkpoint, err := connector.checkpointStore.GetGitHubCheckpoint(ctx, scopeKey)
+	if err != nil {
+		return nil, err
+	}
+	repositories, err := ExpandRepositoryPatterns(ctx, connector.repositoryPatterns, connector.graphqlRunner)
+	if err != nil {
+		return nil, err
+	}
+	events := []PullRequestReviewEvent{}
+	for _, repository := range repositories {
+		owner, name, err := ParseRepoSlug(repository)
+		if err != nil {
+			continue
+		}
+		repositoryEvents, err := FetchPullRequestReviewEventsForRepository(ctx, owner, name, connector.authorLogin, connector.maxPullRequests, connector.maxReviews, connector.graphqlRunner)
+		if err != nil {
+			continue
+		}
+		events = append(events, repositoryEvents...)
+	}
+	newEvents := SelectEventsAfterCheckpoint(events, checkpoint)
+	if len(newEvents) > 0 {
+		latest := newEvents[len(newEvents)-1]
+		connector.pendingCheckpoint = &AssignmentCheckpoint{
+			EventCreatedAt: latest.EventCreatedAt,
+			EventID:        latest.EventID,
+		}
+	}
+	envelopes := make([]contracts.TaskEnvelope, 0, len(newEvents))
+	for _, event := range newEvents {
+		envelopes = append(envelopes, event.ToTaskEnvelope(connector.contextRefs))
+	}
+	return envelopes, nil
+}
+
+func (connector *PullRequestReviewConnector) flushPendingCheckpoint(ctx context.Context) error {
+	if connector.pendingCheckpoint == nil {
+		return nil
+	}
+	scopeKey, err := CheckpointScopeKey(connector.repositoryPatterns, connector.authorLogin, PullRequestReviewsStream)
+	if err != nil {
+		return err
+	}
+	if err := connector.checkpointStore.SetGitHubCheckpoint(ctx, scopeKey, *connector.pendingCheckpoint); err != nil {
+		return err
+	}
+	connector.pendingCheckpoint = nil
+	return nil
+}
+
+func DefaultGraphQLRunner(ctx context.Context, query string, variables map[string]any) (map[string]any, error) {
+	args := []string{"api", "graphql", "-f", "query=" + query}
+	keys := make([]string, 0, len(variables))
+	for key := range variables {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := variables[key]
+		switch typed := value.(type) {
+		case bool:
+			args = append(args, "-F", fmt.Sprintf("%s=%t", key, typed))
+		case int:
+			args = append(args, "-F", fmt.Sprintf("%s=%d", key, typed))
+		default:
+			args = append(args, "-f", fmt.Sprintf("%s=%v", key, typed))
+		}
+	}
+	command := exec.CommandContext(ctx, "gh", args...)
+	output, err := command.Output()
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && len(exitError.Stderr) > 0 {
+			return nil, fmt.Errorf("github_graphql_failed:%s", strings.TrimSpace(string(exitError.Stderr)))
+		}
+		return nil, fmt.Errorf("github_graphql_failed:%v", err)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(bytes.NewReader(output)).Decode(&payload); err != nil {
+		return nil, errors.New("github_graphql_invalid_json")
+	}
+	return payload, nil
+}
+
+func FetchAuthenticatedViewerLogin(ctx context.Context, runner GraphQLRunner) (string, error) {
+	if runner == nil {
+		runner = DefaultGraphQLRunner
+	}
+	payload, err := runner(ctx, ViewerLoginQuery, map[string]any{})
+	if err != nil {
+		return "", err
+	}
+	if hasGraphQLErrors(payload) {
+		return "", fmt.Errorf("github_graphql_errors:%v", payload["errors"])
+	}
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		return "", errors.New("github_graphql_missing_data")
+	}
+	viewer, ok := data["viewer"].(map[string]any)
+	if !ok {
+		return "", errors.New("github_graphql_invalid_viewer")
+	}
+	return requireString(viewer["login"], "viewer.login")
+}
+
+func ExpandRepositoryPatterns(ctx context.Context, repositoryPatterns []string, runner GraphQLRunner) ([]string, error) {
+	if len(repositoryPatterns) == 0 {
+		return nil, errors.New("repository_patterns are required")
+	}
+	expanded := []string{}
+	seen := map[string]bool{}
+	for _, pattern := range repositoryPatterns {
+		owner, repo, err := parseRepositoryPattern(pattern)
+		if err != nil {
+			return nil, err
+		}
+		if repo == "*" {
+			repositories, err := ListOwnerRepositories(ctx, owner, runner)
+			if err != nil {
+				return nil, err
+			}
+			for _, repository := range repositories {
+				normalizedOwner, normalizedName, err := ParseRepoSlug(repository)
+				if err != nil {
+					continue
+				}
+				normalized := normalizedOwner + "/" + normalizedName
+				if !seen[normalized] {
+					seen[normalized] = true
+					expanded = append(expanded, normalized)
+				}
+			}
+			continue
+		}
+		normalized := owner + "/" + repo
+		if !seen[normalized] {
+			seen[normalized] = true
+			expanded = append(expanded, normalized)
+		}
+	}
+	return expanded, nil
+}
+
+func ListOwnerRepositories(ctx context.Context, owner string, runner GraphQLRunner) ([]string, error) {
+	if strings.TrimSpace(owner) == "" {
+		return nil, errors.New("owner must be a non-empty string")
+	}
+	if runner == nil {
+		runner = DefaultGraphQLRunner
+	}
+	repositories := []string{}
+	var after any
+	for {
+		variables := map[string]any{"owner": owner}
+		if after != nil {
+			variables["after"] = after
+		}
+		payload, err := runner(ctx, OwnerRepositoriesQuery, variables)
+		if err != nil {
+			return nil, err
+		}
+		data, ok := payload["data"].(map[string]any)
+		if !ok {
+			return nil, errors.New("github_graphql_missing_data")
+		}
+		ownerNode, _ := data["organization"].(map[string]any)
+		if ownerNode == nil {
+			ownerNode, _ = data["user"].(map[string]any)
+		}
+		if ownerNode == nil {
+			if hasGraphQLErrors(payload) {
+				return nil, fmt.Errorf("github_graphql_errors:%v", payload["errors"])
+			}
+			return repositories, nil
+		}
+		connection, ok := ownerNode["repositories"].(map[string]any)
+		if !ok {
+			return nil, errors.New("github_graphql_invalid_owner_repositories")
+		}
+		nodes, ok := connection["nodes"].([]any)
+		if !ok {
+			return nil, errors.New("github_graphql_invalid_owner_repository_nodes")
+		}
+		for _, rawNode := range nodes {
+			node, ok := rawNode.(map[string]any)
+			if !ok {
+				continue
+			}
+			if slug, ok := node["nameWithOwner"].(string); ok && strings.TrimSpace(slug) != "" {
+				repositories = append(repositories, strings.TrimSpace(slug))
+			}
+		}
+		pageInfo, ok := connection["pageInfo"].(map[string]any)
+		if !ok {
+			return nil, errors.New("github_graphql_invalid_owner_repositories_page_info")
+		}
+		hasNextPage, ok := pageInfo["hasNextPage"].(bool)
+		if !ok {
+			return nil, errors.New("github_graphql_invalid_owner_repositories_has_next_page")
+		}
+		if !hasNextPage {
+			break
+		}
+		endCursor, ok := pageInfo["endCursor"].(string)
+		if !ok || strings.TrimSpace(endCursor) == "" {
+			return nil, errors.New("github_graphql_invalid_owner_repositories_end_cursor")
+		}
+		after = endCursor
+	}
+	return repositories, nil
+}
+
+func FetchAssignmentEventsForRepository(ctx context.Context, repoOwner string, repoName string, assigneeLogin string, issueLimit int, timelineLimit int, runner GraphQLRunner) ([]IssueAssignmentEvent, error) {
+	if issueLimit <= 0 {
+		return nil, errors.New("issue_limit must be positive")
+	}
+	if timelineLimit <= 0 {
+		return nil, errors.New("timeline_limit must be positive")
+	}
+	if runner == nil {
+		runner = DefaultGraphQLRunner
+	}
+	payload, err := runner(ctx, AssignedEventsQuery, map[string]any{
+		"repoOwner":     repoOwner,
+		"repoName":      repoName,
+		"issueLimit":    issueLimit,
+		"timelineLimit": timelineLimit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if hasGraphQLErrors(payload) {
+		return nil, fmt.Errorf("github_graphql_errors:%v", payload["errors"])
+	}
+	repository, err := repositoryPayload(payload)
+	if err != nil || repository == nil {
+		return nil, err
+	}
+	repositoryID, err := requireString(repository["id"], "repository.id")
+	if err != nil {
+		return nil, err
+	}
+	repositoryNameWithOwner, err := requireString(repository["nameWithOwner"], "repository.nameWithOwner")
+	if err != nil {
+		return nil, err
+	}
+	issues, ok := repository["issues"].(map[string]any)
+	if !ok {
+		return nil, errors.New("github_graphql_invalid_issues")
+	}
+	issueNodes, ok := issues["nodes"].([]any)
+	if !ok {
+		return nil, errors.New("github_graphql_invalid_issue_nodes")
+	}
+	expectedAssigneeLogin := strings.ToLower(assigneeLogin)
+	events := []IssueAssignmentEvent{}
+	for _, rawIssue := range issueNodes {
+		issue, ok := rawIssue.(map[string]any)
+		if !ok {
+			continue
+		}
+		issueID, issueIDErr := requireString(issue["id"], "issue.id")
+		issueNumber, issueNumberErr := requirePositiveInt(issue["number"], "issue.number")
+		issueTitle, issueTitleErr := requireString(issue["title"], "issue.title")
+		issueURL, issueURLErr := requireString(issue["url"], "issue.url")
+		if issueIDErr != nil || issueNumberErr != nil || issueTitleErr != nil || issueURLErr != nil {
+			continue
+		}
+		issueBody, _ := issue["body"].(string)
+		labels := parseLabels(issue["labels"])
+		timelineItems, ok := issue["timelineItems"].(map[string]any)
+		if !ok {
+			continue
+		}
+		timelineNodes, ok := timelineItems["nodes"].([]any)
+		if !ok {
+			continue
+		}
+		for _, rawTimelineNode := range timelineNodes {
+			timelineNode, ok := rawTimelineNode.(map[string]any)
+			if !ok {
+				continue
+			}
+			assignee, ok := timelineNode["assignee"].(map[string]any)
+			if !ok || assignee["__typename"] != "User" {
+				continue
+			}
+			assigneeNodeLogin, ok := assignee["login"].(string)
+			if !ok || strings.ToLower(assigneeNodeLogin) != expectedAssigneeLogin {
+				continue
+			}
+			eventID, eventIDErr := requireString(timelineNode["id"], "assigned_event.id")
+			createdAtRaw, createdAtRawErr := requireString(timelineNode["createdAt"], "assigned_event.createdAt")
+			createdAt, createdAtErr := parseEventTime(createdAtRaw)
+			if eventIDErr != nil || createdAtRawErr != nil || createdAtErr != nil {
+				continue
+			}
+			events = append(events, IssueAssignmentEvent{
+				EventID:                 eventID,
+				EventCreatedAt:          createdAt,
+				RepositoryID:            repositoryID,
+				RepositoryNameWithOwner: repositoryNameWithOwner,
+				IssueID:                 issueID,
+				IssueNumber:             issueNumber,
+				IssueTitle:              issueTitle,
+				IssueBody:               issueBody,
+				IssueURL:                issueURL,
+				AssigneeLogin:           assigneeNodeLogin,
+				ActorLogin:              parseActorLogin(timelineNode["actor"]),
+				Labels:                  labels,
+			})
+		}
+	}
+	return events, nil
+}
+
+func FetchPullRequestReviewEventsForRepository(ctx context.Context, repoOwner string, repoName string, authorLogin string, pullRequestLimit int, reviewLimit int, runner GraphQLRunner) ([]PullRequestReviewEvent, error) {
+	if pullRequestLimit <= 0 {
+		return nil, errors.New("pull_request_limit must be positive")
+	}
+	if reviewLimit <= 0 {
+		return nil, errors.New("review_limit must be positive")
+	}
+	if runner == nil {
+		runner = DefaultGraphQLRunner
+	}
+	payload, err := runner(ctx, PullRequestReviewsQuery, map[string]any{
+		"repoOwner":        repoOwner,
+		"repoName":         repoName,
+		"pullRequestLimit": pullRequestLimit,
+		"reviewLimit":      reviewLimit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if hasGraphQLErrors(payload) {
+		return nil, fmt.Errorf("github_graphql_errors:%v", payload["errors"])
+	}
+	repository, err := repositoryPayload(payload)
+	if err != nil || repository == nil {
+		return nil, err
+	}
+	repositoryID, err := requireString(repository["id"], "repository.id")
+	if err != nil {
+		return nil, err
+	}
+	repositoryNameWithOwner, err := requireString(repository["nameWithOwner"], "repository.nameWithOwner")
+	if err != nil {
+		return nil, err
+	}
+	pullRequests, ok := repository["pullRequests"].(map[string]any)
+	if !ok {
+		return nil, errors.New("github_graphql_invalid_pull_requests")
+	}
+	pullRequestNodes, ok := pullRequests["nodes"].([]any)
+	if !ok {
+		return nil, errors.New("github_graphql_invalid_pull_request_nodes")
+	}
+	expectedAuthorLogin := strings.ToLower(authorLogin)
+	events := []PullRequestReviewEvent{}
+	for _, rawPullRequest := range pullRequestNodes {
+		pullRequest, ok := rawPullRequest.(map[string]any)
+		if !ok {
+			continue
+		}
+		pullRequestAuthorLogin := parseActorLogin(pullRequest["author"])
+		if pullRequestAuthorLogin == nil || strings.ToLower(*pullRequestAuthorLogin) != expectedAuthorLogin {
+			continue
+		}
+		pullRequestID, pullRequestIDErr := requireString(pullRequest["id"], "pull_request.id")
+		pullRequestNumber, pullRequestNumberErr := requirePositiveInt(pullRequest["number"], "pull_request.number")
+		pullRequestTitle, pullRequestTitleErr := requireString(pullRequest["title"], "pull_request.title")
+		pullRequestURL, pullRequestURLErr := requireString(pullRequest["url"], "pull_request.url")
+		if pullRequestIDErr != nil || pullRequestNumberErr != nil || pullRequestTitleErr != nil || pullRequestURLErr != nil {
+			continue
+		}
+		pullRequestBody, _ := pullRequest["body"].(string)
+		closingIssueRefs := parseIssueReferenceSummaries(pullRequest["closingIssuesReferences"])
+		reviews, ok := pullRequest["reviews"].(map[string]any)
+		if !ok {
+			continue
+		}
+		reviewNodes, ok := reviews["nodes"].([]any)
+		if !ok {
+			continue
+		}
+		for _, rawReview := range reviewNodes {
+			review, ok := rawReview.(map[string]any)
+			if !ok {
+				continue
+			}
+			reviewAuthorLogin := parseActorLogin(review["author"])
+			if reviewAuthorLogin == nil || strings.ToLower(*reviewAuthorLogin) == expectedAuthorLogin {
+				continue
+			}
+			submittedAt, ok := review["submittedAt"].(string)
+			if !ok || strings.TrimSpace(submittedAt) == "" {
+				continue
+			}
+			eventID, eventIDErr := requireString(review["id"], "review.id")
+			reviewState, reviewStateErr := requireString(review["state"], "review.state")
+			reviewURL, reviewURLErr := requireString(review["url"], "review.url")
+			reviewCreatedAt, reviewCreatedAtErr := parseEventTime(submittedAt)
+			reviewCommentCount, reviewCommentCountErr := parseTotalCount(review["comments"], "review.comments.totalCount")
+			if eventIDErr != nil || reviewStateErr != nil || reviewURLErr != nil || reviewCreatedAtErr != nil || reviewCommentCountErr != nil {
+				continue
+			}
+			reviewBody, _ := review["body"].(string)
+			events = append(events, PullRequestReviewEvent{
+				EventID:                 eventID,
+				EventCreatedAt:          reviewCreatedAt,
+				RepositoryID:            repositoryID,
+				RepositoryNameWithOwner: repositoryNameWithOwner,
+				PullRequestID:           pullRequestID,
+				PullRequestNumber:       pullRequestNumber,
+				PullRequestTitle:        pullRequestTitle,
+				PullRequestBody:         pullRequestBody,
+				PullRequestURL:          pullRequestURL,
+				PullRequestAuthorLogin:  *pullRequestAuthorLogin,
+				ReviewAuthorLogin:       *reviewAuthorLogin,
+				ReviewState:             reviewState,
+				ReviewBody:              reviewBody,
+				ReviewURL:               reviewURL,
+				ReviewCommentCount:      reviewCommentCount,
+				ClosingIssueRefs:        closingIssueRefs,
+			})
+		}
+	}
+	return events, nil
+}
+
+func ParseRepoSlug(value string) (string, string, error) {
+	parts := strings.SplitN(strings.TrimSpace(value), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", errors.New("repository slug must be owner/repo")
+	}
+	return parts[0], parts[1], nil
+}
+
+func parseRepositoryPattern(value string) (string, string, error) {
+	parts := strings.SplitN(strings.TrimSpace(value), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", errors.New("repository selector must be owner/repo or owner/*")
+	}
+	if parts[1] != "*" && strings.Contains(parts[1], "*") {
+		return "", "", errors.New("repository selector must be owner/repo or owner/*")
+	}
+	return parts[0], parts[1], nil
+}
+
+func repositoryPayload(payload map[string]any) (map[string]any, error) {
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		return nil, errors.New("github_graphql_missing_data")
+	}
+	repository, ok := data["repository"].(map[string]any)
+	if !ok {
+		if data["repository"] == nil {
+			return nil, nil
+		}
+		return nil, errors.New("github_graphql_invalid_repository")
+	}
+	return repository, nil
+}
+
+func parseLabels(raw any) []string {
+	rawLabels, ok := raw.(map[string]any)
+	if !ok {
+		return []string{}
+	}
+	nodes, ok := rawLabels["nodes"].([]any)
+	if !ok {
+		return []string{}
+	}
+	labels := []string{}
+	for _, rawNode := range nodes {
+		node, ok := rawNode.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, ok := node["name"].(string)
+		if ok && strings.TrimSpace(name) != "" {
+			labels = append(labels, strings.TrimSpace(name))
+		}
+	}
+	return labels
+}
+
+func parseActorLogin(raw any) *string {
+	actor, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	login, ok := actor["login"].(string)
+	if !ok || strings.TrimSpace(login) == "" {
+		return nil
+	}
+	return &login
+}
+
+func parseIssueReferenceSummaries(raw any) []string {
+	references, ok := raw.(map[string]any)
+	if !ok {
+		return []string{}
+	}
+	nodes, ok := references["nodes"].([]any)
+	if !ok {
+		return []string{}
+	}
+	result := []string{}
+	for _, rawNode := range nodes {
+		node, ok := rawNode.(map[string]any)
+		if !ok {
+			continue
+		}
+		number, err := positiveInt(node["number"])
+		if err != nil {
+			continue
+		}
+		title, ok := node["title"].(string)
+		if ok && strings.TrimSpace(title) != "" {
+			result = append(result, fmt.Sprintf("#%d %s", number, strings.TrimSpace(title)))
+		} else {
+			result = append(result, fmt.Sprintf("#%d", number))
+		}
+	}
+	return result
+}
+
+func parseTotalCount(raw any, fieldName string) (int, error) {
+	connection, ok := raw.(map[string]any)
+	if !ok {
+		return 0, fmt.Errorf("%s must be an object", fieldName)
+	}
+	totalCount, err := positiveIntAllowZero(connection["totalCount"])
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a non-negative integer", fieldName)
+	}
+	return totalCount, nil
+}
+
+func requireString(value any, fieldName string) (string, error) {
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", fmt.Errorf("%s must be a non-empty string", fieldName)
+	}
+	return text, nil
+}
+
+func requirePositiveInt(value any, fieldName string) (int, error) {
+	result, err := positiveInt(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a positive integer", fieldName)
+	}
+	return result, nil
+}
+
+func positiveInt(value any) (int, error) {
+	result, err := positiveIntAllowZero(value)
+	if err != nil || result <= 0 {
+		return 0, errors.New("positive integer required")
+	}
+	return result, nil
+}
+
+func positiveIntAllowZero(value any) (int, error) {
+	switch typed := value.(type) {
+	case int:
+		if typed < 0 {
+			return 0, errors.New("non-negative integer required")
+		}
+		return typed, nil
+	case int64:
+		if typed < 0 {
+			return 0, errors.New("non-negative integer required")
+		}
+		return int(typed), nil
+	case float64:
+		if typed < 0 || typed != float64(int(typed)) {
+			return 0, errors.New("non-negative integer required")
+		}
+		return int(typed), nil
+	case json.Number:
+		parsed, err := strconv.Atoi(typed.String())
+		if err != nil || parsed < 0 {
+			return 0, errors.New("non-negative integer required")
+		}
+		return parsed, nil
+	default:
+		return 0, errors.New("non-negative integer required")
+	}
+}
+
+func hasGraphQLErrors(payload map[string]any) bool {
+	errorsValue, ok := payload["errors"]
+	if !ok || errorsValue == nil {
+		return false
+	}
+	if list, ok := errorsValue.([]any); ok {
+		return len(list) > 0
+	}
+	return true
+}
+
+func parseEventTime(value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parsed.UTC(), nil
+}
+
+func formatEventTime(value time.Time) string {
+	return value.UTC().Format("2006-01-02T15:04:05Z")
+}

--- a/go/handler/internal/connectors/github/github_test.go
+++ b/go/handler/internal/connectors/github/github_test.go
@@ -1,0 +1,403 @@
+package github
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type memoryCheckpointStore struct {
+	checkpoints map[string]AssignmentCheckpoint
+}
+
+func newMemoryCheckpointStore() *memoryCheckpointStore {
+	return &memoryCheckpointStore{checkpoints: map[string]AssignmentCheckpoint{}}
+}
+
+func (store *memoryCheckpointStore) GetGitHubCheckpoint(_ context.Context, scopeKey string) (*AssignmentCheckpoint, error) {
+	checkpoint, ok := store.checkpoints[scopeKey]
+	if !ok {
+		return nil, nil
+	}
+	return &checkpoint, nil
+}
+
+func (store *memoryCheckpointStore) SetGitHubCheckpoint(_ context.Context, scopeKey string, checkpoint AssignmentCheckpoint) error {
+	store.checkpoints[scopeKey] = checkpoint
+	return nil
+}
+
+func TestFetchAssignmentEventsForRepositoryFiltersByAssigneeLogin(t *testing.T) {
+	payload := map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"id":            "R_123",
+				"nameWithOwner": "brokensbone/chatting",
+				"issues": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"id":     "I_1",
+							"number": 12,
+							"title":  "Plan milestone 5",
+							"body":   "Body text",
+							"url":    "https://github.com/brokensbone/chatting/issues/12",
+							"labels": map[string]any{"nodes": []any{map[string]any{"name": "enhancement"}, map[string]any{"name": "ai"}}},
+							"timelineItems": map[string]any{"nodes": []any{
+								map[string]any{
+									"id":        "AE_1",
+									"createdAt": "2026-03-07T10:47:35Z",
+									"actor":     map[string]any{"login": "BillyAcachofa"},
+									"assignee":  map[string]any{"__typename": "User", "login": "BillyAcachofa"},
+								},
+								map[string]any{
+									"id":        "AE_2",
+									"createdAt": "2026-03-07T10:49:35Z",
+									"actor":     map[string]any{"login": "BillyAcachofa"},
+									"assignee":  map[string]any{"__typename": "User", "login": "someoneelse"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	events, err := FetchAssignmentEventsForRepository(
+		context.Background(),
+		"brokensbone",
+		"chatting",
+		"billyacachofa",
+		20,
+		10,
+		func(_ context.Context, _ string, _ map[string]any) (map[string]any, error) {
+			return payload, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].EventID != "AE_1" {
+		t.Fatalf("EventID = %q", events[0].EventID)
+	}
+	if !reflect.DeepEqual(events[0].Labels, []string{"enhancement", "ai"}) {
+		t.Fatalf("Labels = %#v", events[0].Labels)
+	}
+}
+
+func TestFetchPullRequestReviewEventsForRepositoryFiltersByAuthorLogin(t *testing.T) {
+	payload := map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"id":            "R_123",
+				"nameWithOwner": "brokensbone/chatting",
+				"pullRequests": map[string]any{"nodes": []any{
+					map[string]any{
+						"id":     "PR_1",
+						"number": 60,
+						"title":  "Add ingress from GitHub reviews",
+						"body":   "Implements the review ingress flow.",
+						"url":    "https://github.com/brokensbone/chatting/pull/60",
+						"author": map[string]any{"login": "BillyAcachofa"},
+						"closingIssuesReferences": map[string]any{"nodes": []any{
+							map[string]any{"number": 60, "title": "Add ingress from GitHub reviews", "url": "https://github.com/brokensbone/chatting/issues/60"},
+						}},
+						"reviews": map[string]any{"nodes": []any{
+							map[string]any{
+								"id":          "PRR_1",
+								"submittedAt": "2026-03-07T12:00:00Z",
+								"state":       "CHANGES_REQUESTED",
+								"body":        "Please wire this into ingress.",
+								"url":         "https://github.com/brokensbone/chatting/pull/60#pullrequestreview-1",
+								"author":      map[string]any{"login": "brokensbone"},
+								"comments":    map[string]any{"totalCount": 2},
+							},
+							map[string]any{
+								"id":          "PRR_2",
+								"submittedAt": "2026-03-07T12:05:00Z",
+								"state":       "COMMENTED",
+								"body":        "Self review should be ignored.",
+								"url":         "https://github.com/brokensbone/chatting/pull/60#pullrequestreview-2",
+								"author":      map[string]any{"login": "BillyAcachofa"},
+								"comments":    map[string]any{"totalCount": 0},
+							},
+						}},
+					},
+					map[string]any{
+						"id":                      "PR_2",
+						"number":                  61,
+						"title":                   "Other author's PR",
+						"body":                    "",
+						"url":                     "https://github.com/brokensbone/chatting/pull/61",
+						"author":                  map[string]any{"login": "someoneelse"},
+						"closingIssuesReferences": map[string]any{"nodes": []any{}},
+						"reviews":                 map[string]any{"nodes": []any{}},
+					},
+				}},
+			},
+		},
+	}
+
+	events, err := FetchPullRequestReviewEventsForRepository(
+		context.Background(),
+		"brokensbone",
+		"chatting",
+		"billyacachofa",
+		20,
+		10,
+		func(_ context.Context, _ string, _ map[string]any) (map[string]any, error) {
+			return payload, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].EventID != "PRR_1" {
+		t.Fatalf("EventID = %q", events[0].EventID)
+	}
+	if !reflect.DeepEqual(events[0].ClosingIssueRefs, []string{"#60 Add ingress from GitHub reviews"}) {
+		t.Fatalf("ClosingIssueRefs = %#v", events[0].ClosingIssueRefs)
+	}
+}
+
+func TestExpandRepositoryPatternsExpandsOwnerWildcard(t *testing.T) {
+	calls := 0
+	repositories, err := ExpandRepositoryPatterns(
+		context.Background(),
+		[]string{"brokensbone/chatting", "brokensbone/*", "brokensbone/chatting"},
+		func(_ context.Context, query string, variables map[string]any) (map[string]any, error) {
+			calls++
+			if query != OwnerRepositoriesQuery {
+				t.Fatalf("query = %q", query)
+			}
+			if variables["owner"] != "brokensbone" {
+				t.Fatalf("variables = %#v", variables)
+			}
+			return map[string]any{
+				"data": map[string]any{
+					"organization": map[string]any{
+						"repositories": map[string]any{
+							"nodes":    []any{map[string]any{"nameWithOwner": "brokensbone/chatting"}, map[string]any{"nameWithOwner": "brokensbone/bbmb"}},
+							"pageInfo": map[string]any{"hasNextPage": false, "endCursor": nil},
+						},
+					},
+					"user": nil,
+				},
+			}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d", calls)
+	}
+	if !reflect.DeepEqual(repositories, []string{"brokensbone/chatting", "brokensbone/bbmb"}) {
+		t.Fatalf("repositories = %#v", repositories)
+	}
+}
+
+func TestIssueAssignmentConnectorPollNormalizesAndCheckpoints(t *testing.T) {
+	responses := []map[string]any{
+		assignmentPayload("AE_1"),
+		assignmentPayload("AE_1"),
+	}
+	store := newMemoryCheckpointStore()
+	connector, err := NewIssueAssignmentConnector(IssueAssignmentConfig{
+		RepositoryPatterns: []string{"brokensbone/chatting"},
+		AssigneeLogin:      "BillyAcachofa",
+		ContextRefs:        []string{"repo:/home/edward/chatting"},
+		CheckpointStore:    store,
+		GraphQLRunner: func(_ context.Context, _ string, variables map[string]any) (map[string]any, error) {
+			if variables["repoOwner"] != "brokensbone" || variables["repoName"] != "chatting" {
+				t.Fatalf("variables = %#v", variables)
+			}
+			response := responses[0]
+			responses = responses[1:]
+			return response, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPoll, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPoll, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(firstPoll) != 1 {
+		t.Fatalf("firstPoll = %#v", firstPoll)
+	}
+	envelope := firstPoll[0]
+	if envelope.ID != "github-assignment:brokensbone/chatting:12:AE_1" {
+		t.Fatalf("envelope.ID = %q", envelope.ID)
+	}
+	if envelope.ReplyChannel.Type != "github" || envelope.ReplyChannel.Target != "https://github.com/brokensbone/chatting/issues/12" {
+		t.Fatalf("reply channel = %#v", envelope.ReplyChannel)
+	}
+	if !reflect.DeepEqual(envelope.ContextRefs, []string{"repo:/home/edward/chatting"}) {
+		t.Fatalf("context refs = %#v", envelope.ContextRefs)
+	}
+	if envelope.DedupeKey != "github:R_1:I_1:AE_1" {
+		t.Fatalf("dedupe key = %q", envelope.DedupeKey)
+	}
+	if len(secondPoll) != 0 {
+		t.Fatalf("secondPoll = %#v", secondPoll)
+	}
+}
+
+func TestPullRequestReviewConnectorPollNormalizesAndCheckpoints(t *testing.T) {
+	responses := []map[string]any{
+		reviewPayload("PRR_1"),
+		reviewPayload("PRR_1"),
+	}
+	store := newMemoryCheckpointStore()
+	connector, err := NewPullRequestReviewConnector(PullRequestReviewConfig{
+		RepositoryPatterns: []string{"brokensbone/chatting"},
+		AuthorLogin:        "BillyAcachofa",
+		ContextRefs:        []string{"repo:/home/edward/chatting"},
+		CheckpointStore:    store,
+		GraphQLRunner: func(_ context.Context, _ string, variables map[string]any) (map[string]any, error) {
+			if variables["pullRequestLimit"] != 25 || variables["reviewLimit"] != 10 {
+				t.Fatalf("variables = %#v", variables)
+			}
+			response := responses[0]
+			responses = responses[1:]
+			return response, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPoll, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPoll, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(firstPoll) != 1 {
+		t.Fatalf("firstPoll = %#v", firstPoll)
+	}
+	envelope := firstPoll[0]
+	if envelope.ID != "github-review:brokensbone/chatting:60:PRR_1" {
+		t.Fatalf("envelope.ID = %q", envelope.ID)
+	}
+	if envelope.ReplyChannel.Target != "https://github.com/brokensbone/chatting/pull/60" {
+		t.Fatalf("reply target = %q", envelope.ReplyChannel.Target)
+	}
+	if envelope.DedupeKey != "github-review:R_1:PR_1:PRR_1" {
+		t.Fatalf("dedupe key = %q", envelope.DedupeKey)
+	}
+	if !strings.Contains(envelope.Content, "Linked issues: #60 Add ingress from GitHub reviews") {
+		t.Fatalf("content = %q", envelope.Content)
+	}
+	if len(secondPoll) != 0 {
+		t.Fatalf("secondPoll = %#v", secondPoll)
+	}
+}
+
+func assignmentPayload(eventID string) map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"id":            "R_1",
+				"nameWithOwner": "brokensbone/chatting",
+				"issues": map[string]any{"nodes": []any{
+					map[string]any{
+						"id":     "I_1",
+						"number": 12,
+						"title":  "Plan milestone 5",
+						"body":   "Body text",
+						"url":    "https://github.com/brokensbone/chatting/issues/12",
+						"labels": map[string]any{"nodes": []any{map[string]any{"name": "enhancement"}}},
+						"timelineItems": map[string]any{"nodes": []any{
+							map[string]any{
+								"id":        eventID,
+								"createdAt": "2026-03-07T10:47:35Z",
+								"actor":     map[string]any{"login": "edward"},
+								"assignee":  map[string]any{"__typename": "User", "login": "BillyAcachofa"},
+							},
+						}},
+					},
+				}},
+			},
+		},
+	}
+}
+
+func reviewPayload(eventID string) map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"id":            "R_1",
+				"nameWithOwner": "brokensbone/chatting",
+				"pullRequests": map[string]any{"nodes": []any{
+					map[string]any{
+						"id":     "PR_1",
+						"number": 60,
+						"title":  "Add ingress from GitHub reviews",
+						"body":   "PR body",
+						"url":    "https://github.com/brokensbone/chatting/pull/60",
+						"author": map[string]any{"login": "BillyAcachofa"},
+						"closingIssuesReferences": map[string]any{"nodes": []any{
+							map[string]any{"number": 60, "title": "Add ingress from GitHub reviews", "url": "https://github.com/brokensbone/chatting/issues/60"},
+						}},
+						"reviews": map[string]any{"nodes": []any{
+							map[string]any{
+								"id":          eventID,
+								"submittedAt": "2026-03-07T12:00:00Z",
+								"state":       "CHANGES_REQUESTED",
+								"body":        "Please address the comments.",
+								"url":         "https://github.com/brokensbone/chatting/pull/60#pullrequestreview-1",
+								"author":      map[string]any{"login": "brokensbone"},
+								"comments":    map[string]any{"totalCount": 2},
+							},
+						}},
+					},
+				}},
+			},
+		},
+	}
+}
+
+func TestSelectEventsAfterCheckpointUsesUTCBoundary(t *testing.T) {
+	first := mustTime(t, "2026-03-07T10:47:35Z")
+	second := mustTime(t, "2026-03-07T10:48:35Z")
+	events := []IssueAssignmentEvent{
+		{EventID: "AE_2", EventCreatedAt: second},
+		{EventID: "AE_1", EventCreatedAt: first},
+	}
+	selected := SelectEventsAfterCheckpoint(events, &AssignmentCheckpoint{
+		EventCreatedAt: first,
+		EventID:        "AE_1",
+	})
+	if len(selected) != 1 || selected[0].EventID != "AE_2" {
+		t.Fatalf("selected = %#v", selected)
+	}
+}
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}


### PR DESCRIPTION
## Summary
- add Go GitHub polling connector for issue assignments and pull request reviews
- wire github_repositories config into the Go handler with gh viewer fallback and SQLite checkpoint adapter
- cover wildcard expansion, normalization, GraphQL variables, and checkpointed second polls

## Tests
- go test ./...
- uv run python -m unittest discover -s tests
