### PR TITLE
Install sqlite3 in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GO_ARCHIVE=go${GO_VERSION}.linux-amd64.tar.gz
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu ripgrep \
+    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu ripgrep sqlite3 \
     && npm install -g @openai/codex @anthropic-ai/claude-code \
     && npm cache clean --force \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -87,6 +87,7 @@ Use the worker page for a quick operator view, or query SQLite directly when you
 docker compose exec handler sqlite3 /data/handler.db "select run_id, result_status, created_at from run_records order by created_at desc limit 20;"
 docker compose exec handler sqlite3 /data/handler.db "select run_id, result_status, created_at from audit_events order by created_at desc limit 20;"
 docker compose exec handler sqlite3 /data/handler.db "select result_status, count(*) from run_records group by result_status order by result_status;"
+docker compose exec worker sqlite3 /data/worker.db "select run_id, result_status, created_at from run_records order by created_at desc limit 20;"
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary
- install `sqlite3` in the shared runtime image so it is available in both handler and worker containers
- add a worker-side `docker compose exec ... sqlite3` example to keep the quick-start docs aligned with the runtime image

## Validation
- `python3 -m compileall app`
- Docker runtime validation was not possible in this executor because `docker` is not installed

Closes #196
