### PR TITLE
Port GitHub dispatch to Go handler

### DIFF
--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
@@ -28,6 +29,8 @@ import (
 )
 
 const version = "go-handler-bootstrap"
+
+var ghLookPath = exec.LookPath
 
 type runner interface {
 	Run(ctx context.Context) error
@@ -358,6 +361,9 @@ func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, error) {
 			return nil, err
 		}
 		dispatcher.TelegramSender = sender
+	}
+	if _, err := ghLookPath("gh"); err == nil {
+		dispatcher.GitHubSender = dispatch.NewGitHubIssueCommentSender(nil)
 	}
 	return dispatcher, nil
 }

--- a/go/handler/cmd/chatting-handler/main_test.go
+++ b/go/handler/cmd/chatting-handler/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	handlerconfig "github.com/EdwardSalkeld/chatting/go/handler/internal/config"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/dispatch"
 )
 
 func TestRunPrintsVersion(t *testing.T) {
@@ -187,6 +189,56 @@ func TestBuildDispatcherRequiresTelegramTokenWhenEnabled(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing Telegram bot token env var: MISSING_TELEGRAM_TOKEN") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestBuildDispatcherConfiguresGitHubWhenGHAvailable(t *testing.T) {
+	originalLookPath := ghLookPath
+	ghLookPath = func(file string) (string, error) {
+		if file != "gh" {
+			t.Fatalf("unexpected binary lookup = %q", file)
+		}
+		return "/usr/bin/gh", nil
+	}
+	defer func() {
+		ghLookPath = originalLookPath
+	}()
+
+	dispatcher, err := buildDispatcher(handlerconfig.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	typed, ok := dispatcher.(dispatch.Dispatcher)
+	if !ok {
+		t.Fatalf("dispatcher type = %T", dispatcher)
+	}
+	if typed.GitHubSender == nil {
+		t.Fatal("GitHubSender was not configured")
+	}
+}
+
+func TestBuildDispatcherSkipsGitHubWhenGHUnavailable(t *testing.T) {
+	originalLookPath := ghLookPath
+	ghLookPath = func(file string) (string, error) {
+		if file != "gh" {
+			t.Fatalf("unexpected binary lookup = %q", file)
+		}
+		return "", exec.ErrNotFound
+	}
+	defer func() {
+		ghLookPath = originalLookPath
+	}()
+
+	dispatcher, err := buildDispatcher(handlerconfig.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	typed, ok := dispatcher.(dispatch.Dispatcher)
+	if !ok {
+		t.Fatalf("dispatcher type = %T", dispatcher)
+	}
+	if typed.GitHubSender != nil {
+		t.Fatal("GitHubSender should be nil when gh is unavailable")
 	}
 }
 

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -139,7 +139,7 @@ func Defaults() Config {
 		PollTimeoutSeconds:    DefaultPollTimeoutSeconds,
 		MetricsHost:           DefaultMetricsHost,
 		MetricsPort:           DefaultMetricsPort,
-		AllowedEgressChannels: []string{"email", "telegram", "telegram_reaction", "log"},
+		AllowedEgressChannels: []string{"email", "telegram", "telegram_reaction", "github", "log"},
 		GlobalPromptContext:   []string{},
 		CronPromptContext:     []string{},
 		EmailPromptContext:    []string{},

--- a/go/handler/internal/config/config_test.go
+++ b/go/handler/internal/config/config_test.go
@@ -18,6 +18,9 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("config = %#v, want %#v", config, expected)
 	}
+	if !reflect.DeepEqual(config.AllowedEgressChannels, []string{"email", "telegram", "telegram_reaction", "github", "log"}) {
+		t.Fatalf("AllowedEgressChannels = %#v", config.AllowedEgressChannels)
+	}
 }
 
 func TestLoadAcceptsMinimalRuntimeConfig(t *testing.T) {

--- a/go/handler/internal/dispatch/dispatch.go
+++ b/go/handler/internal/dispatch/dispatch.go
@@ -18,9 +18,14 @@ type TelegramSender interface {
 	React(ctx context.Context, target string, messageID int64, emoji string) error
 }
 
+type GitHubSender interface {
+	Send(ctx context.Context, target string, body string) error
+}
+
 type Dispatcher struct {
 	EmailSender    EmailSender
 	TelegramSender TelegramSender
+	GitHubSender   GitHubSender
 }
 
 type MessageDispatchError struct {
@@ -73,6 +78,17 @@ func (dispatcher Dispatcher) Dispatch(ctx context.Context, message contracts.Out
 		}
 		if err := dispatcher.TelegramSender.React(ctx, target, messageID, *message.Body); err != nil {
 			return nil, MessageDispatchError{ReasonCode: "telegram_dispatch_failed"}
+		}
+		return &normalized, nil
+	case "github":
+		if dispatcher.GitHubSender == nil {
+			return nil, nil
+		}
+		if message.Body == nil {
+			return nil, MessageDispatchError{ReasonCode: "github_dispatch_failed"}
+		}
+		if err := dispatcher.GitHubSender.Send(ctx, target, *message.Body); err != nil {
+			return nil, MessageDispatchError{ReasonCode: "github_dispatch_failed"}
 		}
 		return &normalized, nil
 	default:

--- a/go/handler/internal/dispatch/dispatch_test.go
+++ b/go/handler/internal/dispatch/dispatch_test.go
@@ -212,6 +212,45 @@ func TestDispatcherReturnsTelegramAttachmentFailureReason(t *testing.T) {
 	}
 }
 
+func TestDispatcherSendsGitHubComment(t *testing.T) {
+	body := "Done via GitHub."
+	sender := &recordingGitHubSender{}
+	message := contracts.OutboundMessage{
+		Channel: "github",
+		Target:  "brokensbone/chatting#13",
+		Body:    &body,
+	}
+
+	dispatched, err := (Dispatcher{GitHubSender: sender}).Dispatch(context.Background(), message, contracts.TaskEnvelope{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dispatched == nil || dispatched.Channel != "github" || dispatched.Target != "brokensbone/chatting#13" {
+		t.Fatalf("dispatched = %#v", dispatched)
+	}
+	if len(sender.messages) != 1 || sender.messages[0].target != "brokensbone/chatting#13" || sender.messages[0].body != "Done via GitHub." {
+		t.Fatalf("messages = %#v", sender.messages)
+	}
+}
+
+func TestDispatcherReturnsGitHubFailureReason(t *testing.T) {
+	body := "Done via GitHub."
+	message := contracts.OutboundMessage{
+		Channel: "github",
+		Target:  "brokensbone/chatting#13",
+		Body:    &body,
+	}
+
+	_, err := (Dispatcher{GitHubSender: &recordingGitHubSender{err: errors.New("boom")}}).Dispatch(context.Background(), message, contracts.TaskEnvelope{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var dispatchErr MessageDispatchError
+	if !errors.As(err, &dispatchErr) || dispatchErr.ReasonCode != "github_dispatch_failed" {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
 func TestTelegramMessageSenderSendsTextAndFallsBackWithoutParseMode(t *testing.T) {
 	var calls []telegramHTTPCall
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -390,6 +429,24 @@ func (sender *recordingTelegramSender) React(_ context.Context, target string, m
 		return sender.err
 	}
 	sender.reactions = append(sender.reactions, sentReaction{target: target, messageID: messageID, emoji: emoji})
+	return nil
+}
+
+type sentGitHub struct {
+	target string
+	body   string
+}
+
+type recordingGitHubSender struct {
+	messages []sentGitHub
+	err      error
+}
+
+func (sender *recordingGitHubSender) Send(_ context.Context, target string, body string) error {
+	if sender.err != nil {
+		return sender.err
+	}
+	sender.messages = append(sender.messages, sentGitHub{target: target, body: body})
 	return nil
 }
 

--- a/go/handler/internal/dispatch/github.go
+++ b/go/handler/internal/dispatch/github.go
@@ -1,0 +1,102 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type GitHubCommandRunner func(ctx context.Context, command []string) error
+
+type GitHubIssueCommentSender struct {
+	runCommand GitHubCommandRunner
+}
+
+func NewGitHubIssueCommentSender(commandRunner GitHubCommandRunner) *GitHubIssueCommentSender {
+	if commandRunner == nil {
+		commandRunner = defaultGitHubCommandRunner
+	}
+	return &GitHubIssueCommentSender{runCommand: commandRunner}
+}
+
+func (sender *GitHubIssueCommentSender) Send(ctx context.Context, target string, body string) error {
+	if strings.TrimSpace(target) == "" {
+		return errors.New("github_issue_target_invalid")
+	}
+	if strings.TrimSpace(body) == "" {
+		return errors.New("body is required")
+	}
+
+	repository, issueNumber, err := parseGitHubIssueTarget(target)
+	if err != nil {
+		return err
+	}
+	command := []string{
+		"gh",
+		"issue",
+		"comment",
+		strconv.Itoa(issueNumber),
+		"--repo",
+		repository,
+		"--body",
+		body,
+	}
+	if err := sender.runCommand(ctx, command); err != nil {
+		return errors.New("github_issue_comment_failed")
+	}
+	return nil
+}
+
+func defaultGitHubCommandRunner(ctx context.Context, command []string) error {
+	if len(command) == 0 {
+		return errors.New("missing command")
+	}
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	return cmd.Run()
+}
+
+func parseGitHubIssueTarget(target string) (string, int, error) {
+	stripped := strings.TrimSpace(target)
+	if stripped == "" {
+		return "", 0, errors.New("github_issue_target_invalid")
+	}
+
+	var repository string
+	var numberText string
+	if strings.HasPrefix(stripped, "http://") || strings.HasPrefix(stripped, "https://") {
+		parsed, err := url.Parse(stripped)
+		if err != nil || !strings.EqualFold(parsed.Host, "github.com") {
+			return "", 0, errors.New("github_issue_target_invalid")
+		}
+		parts := make([]string, 0, 4)
+		for _, part := range strings.Split(parsed.Path, "/") {
+			if part != "" {
+				parts = append(parts, part)
+			}
+		}
+		if len(parts) < 4 || (parts[2] != "issues" && parts[2] != "pull") {
+			return "", 0, errors.New("github_issue_target_invalid")
+		}
+		repository = parts[0] + "/" + parts[1]
+		numberText = parts[3]
+	} else {
+		repositoryPart, numberPart, ok := strings.Cut(stripped, "#")
+		if !ok {
+			return "", 0, errors.New("github_issue_target_invalid")
+		}
+		repository = strings.TrimSpace(repositoryPart)
+		numberText = strings.TrimSpace(numberPart)
+		if repository == "" || !strings.Contains(repository, "/") {
+			return "", 0, errors.New("github_issue_target_invalid")
+		}
+	}
+
+	issueNumber, err := strconv.Atoi(numberText)
+	if err != nil || issueNumber <= 0 {
+		return "", 0, errors.New("github_issue_target_invalid")
+	}
+	return repository, issueNumber, nil
+}

--- a/go/handler/internal/dispatch/github_test.go
+++ b/go/handler/internal/dispatch/github_test.go
@@ -1,0 +1,74 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestGitHubIssueCommentSenderUsesGHCLIForIssueURLTarget(t *testing.T) {
+	var seen [][]string
+	sender := NewGitHubIssueCommentSender(func(_ context.Context, command []string) error {
+		seen = append(seen, append([]string(nil), command...))
+		return nil
+	})
+
+	if err := sender.Send(context.Background(), "https://github.com/brokensbone/chatting/issues/12", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	expected := [][]string{{"gh", "issue", "comment", "12", "--repo", "brokensbone/chatting", "--body", "hello"}}
+	if !reflect.DeepEqual(seen, expected) {
+		t.Fatalf("commands = %#v", seen)
+	}
+}
+
+func TestGitHubIssueCommentSenderUsesGHCLIForSlugTarget(t *testing.T) {
+	var seen [][]string
+	sender := NewGitHubIssueCommentSender(func(_ context.Context, command []string) error {
+		seen = append(seen, append([]string(nil), command...))
+		return nil
+	})
+
+	if err := sender.Send(context.Background(), "brokensbone/chatting#13", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	expected := [][]string{{"gh", "issue", "comment", "13", "--repo", "brokensbone/chatting", "--body", "hello"}}
+	if !reflect.DeepEqual(seen, expected) {
+		t.Fatalf("commands = %#v", seen)
+	}
+}
+
+func TestGitHubIssueCommentSenderUsesGHCLIForPullRequestURLTarget(t *testing.T) {
+	var seen [][]string
+	sender := NewGitHubIssueCommentSender(func(_ context.Context, command []string) error {
+		seen = append(seen, append([]string(nil), command...))
+		return nil
+	})
+
+	if err := sender.Send(context.Background(), "https://github.com/brokensbone/chatting/pull/60", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	expected := [][]string{{"gh", "issue", "comment", "60", "--repo", "brokensbone/chatting", "--body", "hello"}}
+	if !reflect.DeepEqual(seen, expected) {
+		t.Fatalf("commands = %#v", seen)
+	}
+}
+
+func TestGitHubIssueCommentSenderRejectsInvalidTarget(t *testing.T) {
+	sender := NewGitHubIssueCommentSender(func(_ context.Context, _ []string) error { return nil })
+	err := sender.Send(context.Background(), "not-a-github-target", "hello")
+	if err == nil || err.Error() != "github_issue_target_invalid" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestGitHubIssueCommentSenderReturnsFailureWhenGHFails(t *testing.T) {
+	sender := NewGitHubIssueCommentSender(func(_ context.Context, _ []string) error {
+		return errors.New("boom")
+	})
+	err := sender.Send(context.Background(), "brokensbone/chatting#13", "hello")
+	if err == nil || err.Error() != "github_issue_comment_failed" {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go GitHub issue comment dispatch via `gh issue comment` for issue and pull request targets
- wire GitHub dispatch into the Go handler bootstrap when `gh` is available and include `github` in default allowed egress channels
- cover dispatcher wiring, sender parsing, command construction, and startup gating with Go tests

## Testing
- go test ./...
