### PR TITLE
Harden Go handler E2E shakeout tests

### DIFF
--- a/docs/porting/handler-go.md
+++ b/docs/porting/handler-go.md
@@ -729,6 +729,11 @@ Validation:
 
 ### 19. GitHub Dispatch
 
+Status: complete. The Go handler now parses both GitHub issue or pull request
+URLs and `owner/repo#number` targets, dispatches issue comments through `gh
+issue comment`, and applies the same handler-level failure semantics as the
+Python implementation.
+
 Implement GitHub comment dispatch.
 
 Validation:
@@ -737,6 +742,11 @@ Validation:
 - GitHub egress failure handling matches Python at the handler level
 
 ### 20. Go Handler Drop-In E2E
+
+Status: in progress. All handler-oriented E2E scenarios now route through the
+implementation selector, and the split-mode smoke test now uses reserved BBMB
+ports so it can run against both Python and Go handlers without fixed-port
+collisions.
 
 Run the full handler-oriented E2E suite with:
 - Go handler
@@ -756,5 +766,7 @@ Validation:
 
 ## Immediate Next Steps
 
-1. Add GitHub comment dispatch.
-2. Continue closing remaining Python handler parity gaps before a side-by-side dry run.
+1. Run the selector-based handler E2E suite in an environment with the full
+   external dependencies available for both Python and Go handler modes.
+2. Decide whether the Go handler should ship first behind a deploy/config
+   switch or as the direct default once the drop-in E2E pass is clean.

--- a/tests/e2e/test_email_e2e.py
+++ b/tests/e2e/test_email_e2e.py
@@ -13,10 +13,14 @@ from email.message import EmailMessage
 from pathlib import Path
 
 from tests.e2e.handler_selector import message_handler_command
+
+
 def _is_port_open(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         probe.settimeout(0.2)
         return probe.connect_ex((host, port)) == 0
+
+
 def _wait_for_port(host: str, port: int, timeout_seconds: float) -> None:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
@@ -24,7 +28,18 @@ def _wait_for_port(host: str, port: int, timeout_seconds: float) -> None:
             return
         time.sleep(0.05)
     raise TimeoutError(f"timed out waiting for {host}:{port}")
-def _send_test_email(from_addr: str, to_addr: str, subject: str, body: str, *, port: int = 3025) -> None:
+
+
+def _reserve_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen()
+        return int(listener.getsockname()[1])
+
+
+def _send_test_email(
+    from_addr: str, to_addr: str, subject: str, body: str, *, port: int = 3025
+) -> None:
     msg = EmailMessage()
     msg["From"] = from_addr
     msg["To"] = to_addr
@@ -40,6 +55,8 @@ def _send_test_email(from_addr: str, to_addr: str, subject: str, body: str, *, p
             last_error = exc
             time.sleep(1)
     raise RuntimeError(f"failed to send email after retries: {last_error}")
+
+
 class EmailE2ETests(unittest.TestCase):
     def test_email_roundtrip_with_real_codex_executor_and_greenmail(self) -> None:
         server_bin_raw = os.environ.get("CHATTING_BBMB_SERVER_BIN", "").strip()
@@ -49,9 +66,6 @@ class EmailE2ETests(unittest.TestCase):
         if not server_bin.exists():
             self.skipTest(f"bbmb server binary not found: {server_bin}")
 
-        if _is_port_open("127.0.0.1", 9876):
-            self.skipTest("127.0.0.1:9876 already in use")
-
         # GreenMail IMAP (3143) and SMTP (3025) must be running
         if not _is_port_open("127.0.0.1", 3143):
             self.skipTest("GreenMail IMAP not available on 127.0.0.1:3143")
@@ -60,6 +74,9 @@ class EmailE2ETests(unittest.TestCase):
 
         repo_root = Path(__file__).resolve().parent.parent.parent
         fake_codex = str(repo_root / "tests" / "e2e" / "fake_codex.py")
+        bbmb_port = _reserve_port()
+        bbmb_metrics_port = _reserve_port()
+        bbmb_address = f"127.0.0.1:{bbmb_port}"
 
         server_proc = None
         worker_proc = None
@@ -82,7 +99,7 @@ class EmailE2ETests(unittest.TestCase):
                 json.dumps(
                     {
                         "db_path": str(handler_db),
-                        "bbmb_address": "127.0.0.1:9876",
+                        "bbmb_address": bbmb_address,
                         "poll_interval_seconds": 0.5,
                         "poll_timeout_seconds": 2,
                         "max_loops": 200,
@@ -106,7 +123,7 @@ class EmailE2ETests(unittest.TestCase):
                 json.dumps(
                     {
                         "db_path": str(worker_db),
-                        "bbmb_address": "127.0.0.1:9876",
+                        "bbmb_address": bbmb_address,
                         "max_attempts": 2,
                         "poll_timeout_seconds": 2,
                         "sleep_seconds": 0.2,
@@ -127,13 +144,17 @@ class EmailE2ETests(unittest.TestCase):
 
             try:
                 server_proc = subprocess.Popen(
-                    [str(server_bin)],
+                    [
+                        str(server_bin),
+                        f"--port={bbmb_port}",
+                        f"--metrics-port={bbmb_metrics_port}",
+                    ],
                     cwd=repo_root,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
                 )
-                _wait_for_port("127.0.0.1", 9876, timeout_seconds=5.0)
+                _wait_for_port("127.0.0.1", bbmb_port, timeout_seconds=5.0)
 
                 worker_proc = subprocess.Popen(
                     [
@@ -179,8 +200,17 @@ class EmailE2ETests(unittest.TestCase):
                     time.sleep(1)
 
                 if not prompt_file.exists():
-                    self._dump_diagnostics(handler_proc, worker_proc, handler_log, worker_log, handler_log_fh, worker_log_fh)
-                    self.fail("prompt file never appeared - task never reached the executor")
+                    self._dump_diagnostics(
+                        handler_proc,
+                        worker_proc,
+                        handler_log,
+                        worker_log,
+                        handler_log_fh,
+                        worker_log_fh,
+                    )
+                    self.fail(
+                        "prompt file never appeared - task never reached the executor"
+                    )
 
                 # Now wait for the reply email to arrive back in GreenMail
                 # Check via IMAP directly
@@ -204,7 +234,14 @@ class EmailE2ETests(unittest.TestCase):
                     time.sleep(1)
 
                 if not reply_found:
-                    self._dump_diagnostics(handler_proc, worker_proc, handler_log, worker_log, handler_log_fh, worker_log_fh)
+                    self._dump_diagnostics(
+                        handler_proc,
+                        worker_proc,
+                        handler_log,
+                        worker_log,
+                        handler_log_fh,
+                        worker_log_fh,
+                    )
                     self.fail("reply email not found in GreenMail within 30s")
 
                 # Validate the captured prompt
@@ -217,9 +254,7 @@ class EmailE2ETests(unittest.TestCase):
                 self.assertIn("Please do the e2e test thing", task["content"])
                 self.assertEqual(task["source"], "email")
                 self.assertEqual(task["reply_channel"]["type"], "email")
-                self.assertEqual(
-                    task["reply_channel"]["target"], "sender@test.local"
-                )
+                self.assertEqual(task["reply_channel"]["target"], "sender@test.local")
                 self.assertIn("current_time", prompt)
                 self.assertIn("reply_contract", prompt)
 
@@ -234,12 +269,24 @@ class EmailE2ETests(unittest.TestCase):
                         except subprocess.TimeoutExpired:
                             proc.kill()
                             proc.wait(timeout=5)
+                    if proc.stdout is not None:
+                        proc.stdout.close()
+                    if proc.stderr is not None:
+                        proc.stderr.close()
                 if not handler_log_fh.closed:
                     handler_log_fh.close()
                 if not worker_log_fh.closed:
                     worker_log_fh.close()
 
-    def _dump_diagnostics(self, handler_proc, worker_proc, handler_log, worker_log, handler_log_fh, worker_log_fh):
+    def _dump_diagnostics(
+        self,
+        handler_proc,
+        worker_proc,
+        handler_log,
+        worker_log,
+        handler_log_fh,
+        worker_log_fh,
+    ):
         for proc in (handler_proc, worker_proc):
             if proc is not None and proc.poll() is None:
                 proc.terminate()
@@ -259,5 +306,7 @@ class EmailE2ETests(unittest.TestCase):
             diag.append(f"\n--- {name} log (last 3000 chars) ---")
             diag.append(log_content[-3000:] if log_content else "(empty)")
         print("\n".join(diag), file=sys.stderr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_split_mode_e2e.py
+++ b/tests/test_split_mode_e2e.py
@@ -10,10 +10,14 @@ from pathlib import Path
 
 from app.state import SQLiteStateStore
 from tests.e2e.handler_selector import message_handler_command
+
+
 def _is_port_open(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         probe.settimeout(0.2)
         return probe.connect_ex((host, port)) == 0
+
+
 def _wait_for_port(host: str, port: int, timeout_seconds: float) -> None:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
@@ -21,6 +25,15 @@ def _wait_for_port(host: str, port: int, timeout_seconds: float) -> None:
             return
         time.sleep(0.05)
     raise TimeoutError(f"timed out waiting for {host}:{port}")
+
+
+def _reserve_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen()
+        return int(listener.getsockname()[1])
+
+
 class SplitModeE2ETests(unittest.TestCase):
     def test_split_mode_roundtrip_with_real_bbmb_server(self) -> None:
         server_bin_raw = os.environ.get("CHATTING_BBMB_SERVER_BIN", "").strip()
@@ -31,11 +44,11 @@ class SplitModeE2ETests(unittest.TestCase):
         if not server_bin.exists():
             self.skipTest(f"bbmb server binary not found: {server_bin}")
 
-        if _is_port_open("127.0.0.1", 9876):
-            self.skipTest("127.0.0.1:9876 already in use")
-
         repo_root = Path(__file__).resolve().parent.parent
         fake_codex = str(repo_root / "tests" / "e2e" / "fake_codex.py")
+        bbmb_port = _reserve_port()
+        bbmb_metrics_port = _reserve_port()
+        bbmb_address = f"127.0.0.1:{bbmb_port}"
         server_proc: subprocess.Popen[str] | None = None
         worker_proc: subprocess.Popen[str] | None = None
         handler_proc: subprocess.Popen[str] | None = None
@@ -52,7 +65,7 @@ class SplitModeE2ETests(unittest.TestCase):
                     "job_name": "ci-split-smoke",
                     "content": "CI smoke task",
                     "cron": "* * * * *",
-                    "context_refs": ["repo:/workspace/chatting"],
+                    "context_refs": [f"repo:{repo_root}"],
                     "reply_channel_type": "log",
                     "reply_channel_target": "ci-split-smoke",
                 }
@@ -63,7 +76,7 @@ class SplitModeE2ETests(unittest.TestCase):
                 json.dumps(
                     {
                         "db_path": str(handler_db_path),
-                        "bbmb_address": "127.0.0.1:9876",
+                        "bbmb_address": bbmb_address,
                         "poll_interval_seconds": 0.1,
                         "poll_timeout_seconds": 1,
                         "max_loops": 20,
@@ -77,7 +90,7 @@ class SplitModeE2ETests(unittest.TestCase):
                 json.dumps(
                     {
                         "db_path": str(worker_db_path),
-                        "bbmb_address": "127.0.0.1:9876",
+                        "bbmb_address": bbmb_address,
                         "max_attempts": 2,
                         "poll_timeout_seconds": 1,
                         "sleep_seconds": 0.05,
@@ -91,13 +104,17 @@ class SplitModeE2ETests(unittest.TestCase):
 
             try:
                 server_proc = subprocess.Popen(
-                    [str(server_bin)],
+                    [
+                        str(server_bin),
+                        f"--port={bbmb_port}",
+                        f"--metrics-port={bbmb_metrics_port}",
+                    ],
                     cwd=repo_root,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
                 )
-                _wait_for_port("127.0.0.1", 9876, timeout_seconds=5.0)
+                _wait_for_port("127.0.0.1", bbmb_port, timeout_seconds=5.0)
 
                 worker_proc = subprocess.Popen(
                     [
@@ -133,6 +150,10 @@ class SplitModeE2ETests(unittest.TestCase):
                         except subprocess.TimeoutExpired:
                             proc.kill()
                             proc.wait(timeout=5)
+                    if proc.stdout is not None:
+                        proc.stdout.close()
+                    if proc.stderr is not None:
+                        proc.stderr.close()
 
             self.assertEqual(
                 handler_proc.returncode,
@@ -148,7 +169,9 @@ class SplitModeE2ETests(unittest.TestCase):
             worker_store = SQLiteStateStore(str(worker_db_path))
             worker_runs = worker_store.list_runs()
             matching_worker_runs = [
-                run for run in worker_runs if run.envelope_id.startswith("cron:ci-split-smoke:")
+                run
+                for run in worker_runs
+                if run.envelope_id.startswith("cron:ci-split-smoke:")
             ]
             self.assertTrue(
                 matching_worker_runs,
@@ -157,7 +180,8 @@ class SplitModeE2ETests(unittest.TestCase):
             expected_envelope_id = matching_worker_runs[0].envelope_id
             self.assertTrue(
                 any(
-                    run.envelope_id == expected_envelope_id and run.result_status == "success"
+                    run.envelope_id == expected_envelope_id
+                    and run.result_status == "success"
                     for run in worker_runs
                 ),
                 msg=f"missing successful worker run for expected envelope_id={expected_envelope_id!r}",
@@ -166,12 +190,16 @@ class SplitModeE2ETests(unittest.TestCase):
             handler_store = SQLiteStateStore(str(handler_db_path))
             expected_task_id = f"task:{expected_envelope_id}"
             expected_event_id = f"evt:{expected_task_id}:0:completion:internal"
-            self.assertEqual(handler_store.list_dispatched_event_indices(run_id=expected_task_id), [])
+            self.assertEqual(
+                handler_store.list_dispatched_event_indices(run_id=expected_task_id), []
+            )
             self.assertTrue(
                 handler_store.has_dispatched_event_id(
                     task_id=expected_task_id,
                     event_id=expected_event_id,
                 )
             )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- make handler-oriented E2E tests reserve their own BBMB broker and metrics ports instead of assuming `127.0.0.1:9876` is free
- make the split-mode smoke test use the actual repo root for its `repo:` context ref and close subprocess pipes cleanly after the run
- update the Go handler porting note to mark GitHub dispatch complete and record the current drop-in E2E shakeout status

## Testing
- `cd /workspace/chatting-go-final/go/handler && go test ./...`
- `cd /workspace/chatting-go-final && CHATTING_BBMB_SERVER_BIN=/tmp/chatting-bbmb-server uv run python -m unittest tests.test_split_mode_e2e`
- `cd /workspace/chatting-go-final && CHATTING_BBMB_SERVER_BIN=/tmp/chatting-bbmb-server CHATTING_E2E_HANDLER_IMPLEMENTATION=go uv run python -m unittest tests.test_split_mode_e2e`
- `cd /workspace/chatting-go-final && CHATTING_BBMB_SERVER_BIN=/tmp/chatting-bbmb-server CHATTING_E2E_HANDLER_IMPLEMENTATION=go uv run python -m unittest tests.test_split_mode_e2e tests.e2e.test_auxiliary_ingress_e2e tests.e2e.test_email_e2e`
