### PR TITLE
Build and publish Go handler binary on main

### DIFF
--- a/.github/workflows/handler-release.yml
+++ b/.github/workflows/handler-release.yml
@@ -1,0 +1,90 @@
+name: Handler Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build And Publish Handler Binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go/handler/go.mod
+          cache-dependency-path: go/handler/go.mod
+
+      - name: Run Go handler tests
+        working-directory: go/handler
+        run: go test ./...
+
+      - name: Check gofmt
+        working-directory: go/handler
+        run: |
+          files="$(gofmt -l .)"
+          if [ -n "$files" ]; then
+            echo "Go files need gofmt:"
+            echo "$files"
+            exit 1
+          fi
+
+      - name: Run go vet
+        working-directory: go/handler
+        run: go vet ./...
+
+      - name: Build Linux amd64 handler binary
+        run: |
+          mkdir -p dist
+          cd go/handler
+          GOOS=linux GOARCH=amd64 \
+            go build -trimpath -ldflags="-s -w" \
+            -o ../../dist/chatting-handler-linux-amd64 \
+            ./cmd/chatting-handler
+
+      - name: Package release assets
+        run: |
+          cd dist
+          sha256sum chatting-handler-linux-amd64 > chatting-handler-linux-amd64.sha256
+          tar -czf chatting-handler-linux-amd64.tar.gz \
+            chatting-handler-linux-amd64 \
+            chatting-handler-linux-amd64.sha256
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chatting-handler-linux-amd64
+          path: |
+            dist/chatting-handler-linux-amd64
+            dist/chatting-handler-linux-amd64.sha256
+            dist/chatting-handler-linux-amd64.tar.gz
+          retention-days: 30
+
+      - name: Compute release metadata
+        id: metadata
+        run: |
+          release_number="${GITHUB_RUN_NUMBER}"
+          echo "tag=handler-v${release_number}" >> "$GITHUB_OUTPUT"
+          echo "name=Chatting Handler v${release_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.metadata.outputs.tag }}
+          name: ${{ steps.metadata.outputs.name }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          files: |
+            dist/chatting-handler-linux-amd64
+            dist/chatting-handler-linux-amd64.sha256
+            dist/chatting-handler-linux-amd64.tar.gz

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 ## CI
 
 - [GitHub Actions CI Workflow](../.github/workflows/ci.yml)
+- [GitHub Actions Handler Release Workflow](../.github/workflows/handler-release.yml)
 
 ## Connectors
 

--- a/docs/debug-and-test.md
+++ b/docs/debug-and-test.md
@@ -45,8 +45,8 @@ CHATTING_E2E_HANDLER_IMPLEMENTATION=python uv run python -m unittest tests.test_
 ```
 
 Supported values are `python` and `go`. The default is `python`. Selecting `go`
-currently fails clearly because the Go handler runtime is not implemented yet.
-This skips locally unless `CHATTING_BBMB_SERVER_BIN` points to a built `bbmb-server`.
+uses the Go handler entrypoint. This still skips locally unless
+`CHATTING_BBMB_SERVER_BIN` points to a built `bbmb-server`.
 
 ## Useful runtime inspection commands
 
@@ -116,3 +116,6 @@ Use these with DB queries to correlate outcomes.
 - Triggers: push to `main`, and pull requests targeting `main`
 - Python version: `3.13`
 - CI installs `uv`, locks/syncs the project environment, downloads the latest BBMB release binary, verifies its published SHA256, and sets `CHATTING_BBMB_SERVER_BIN` before running the test suite.
+- Go handler release workflow: `.github/workflows/handler-release.yml`
+- Handler release trigger: push to `main` or manual dispatch
+- Handler release outputs: `chatting-handler-linux-amd64`, `.sha256`, and `.tar.gz` uploaded both as workflow artifacts and GitHub release assets

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -162,3 +162,51 @@ docker compose run --rm worker claude login
 ```
 
 The compose stack publishes the worker activity UI on `9465`.
+
+## 8) Switch the handler from Python to Go
+
+The Go handler is a drop-in replacement at the message-handler boundary:
+- same handler JSON config
+- same handler env file / secrets
+- same BBMB queues and worker
+- same rollback path: switch the handler command back to Python
+
+Download the latest released binary and verify it:
+
+```bash
+curl -fsSL \
+  -o /usr/local/bin/chatting-handler \
+  https://github.com/EdwardSalkeld/chatting/releases/latest/download/chatting-handler-linux-amd64
+curl -fsSL \
+  -o /tmp/chatting-handler-linux-amd64.sha256 \
+  https://github.com/EdwardSalkeld/chatting/releases/latest/download/chatting-handler-linux-amd64.sha256
+(
+  cd /tmp
+  sha256sum -c chatting-handler-linux-amd64.sha256
+)
+chmod +x /usr/local/bin/chatting-handler
+```
+
+Then replace the Python handler command:
+
+```bash
+python -m app.main_message_handler --config /config/handler.json
+```
+
+with:
+
+```bash
+chatting-handler --config /config/handler.json
+```
+
+If your process manager is Docker Compose or systemd, make the same command
+swap there and keep the existing handler config file, env file, and DB path.
+
+Recommended cutover order:
+1. Stop the running Python `message-handler`.
+2. Leave `worker` and `bbmb-server` running.
+3. Start `chatting-handler` with the same config/env.
+4. Watch handler logs and `:9464/metrics` for a few minutes.
+
+Rollback is immediate: stop `chatting-handler` and restart the previous Python
+handler command against the same config and DB.


### PR DESCRIPTION
## Summary
- add a main-branch handler release workflow that tests, vets, builds, packages, and publishes the Go handler binary
- upload the handler binary, sha256, and tarball as workflow artifacts and GitHub release assets
- document the Python->Go handler cutover and rollback path for operators

## Testing
- git diff --check
