### PR TITLE
Improve worker failure logs

### DIFF
--- a/app/worker/main.py
+++ b/app/worker/main.py
@@ -52,6 +52,29 @@ ALLOWED_WORKER_CONFIG_KEYS = frozenset(
 BBMB_PICKUP_WAIT_SECONDS = 10
 
 
+def _log_worker_processed(*, task_id: str, result) -> None:
+    if result.run_record.result_status in {"execution_error", "dead_letter"}:
+        LOGGER.warning(
+            "worker_processed run_id=%s task_id=%s egress_messages=%s result_status=%s "
+            "reason_codes=%s attempt_count=%s error_summary=%s",
+            result.run_record.run_id,
+            task_id,
+            len(result.egress_messages),
+            result.run_record.result_status,
+            ",".join(result.reason_codes) if result.reason_codes else "none",
+            result.attempt_count,
+            result.error_summary or "unknown_error",
+        )
+        return
+    LOGGER.info(
+        "worker_processed run_id=%s task_id=%s egress_messages=%s result_status=%s",
+        result.run_record.run_id,
+        task_id,
+        len(result.egress_messages),
+        result.run_record.result_status,
+    )
+
+
 def _configure_logging() -> None:
     if logging.getLogger().handlers:
         return
@@ -409,13 +432,7 @@ def main() -> int:
                         activity_monitor=activity_monitor,
                     )
                 broker.ack(TASK_QUEUE_NAME, picked.guid)
-                LOGGER.info(
-                    "worker_processed run_id=%s task_id=%s egress_messages=%s result_status=%s",
-                    result.run_record.run_id,
-                    task_message.task_id,
-                    len(result.egress_messages),
-                    result.run_record.result_status,
-                )
+                _log_worker_processed(task_id=task_message.task_id, result=result)
             except Exception:  # noqa: BLE001
                 LOGGER.exception("worker_processing_failed guid=%s", picked.guid)
 

--- a/app/worker/runtime.py
+++ b/app/worker/runtime.py
@@ -28,6 +28,9 @@ class WorkerProcessResult:
     run_record: RunRecord
     egress_messages: list[EgressQueueMessage]
     dead_lettered: bool
+    attempt_count: int
+    reason_codes: list[str]
+    error_summary: str | None
 
 
 def process_task_message(
@@ -173,10 +176,25 @@ def process_task_message(
         latency_ms=latency_ms,
     )
 
+    error_summary = None
+    if run_record.result_status in {"execution_error", "dead_letter"}:
+        execution_errors = []
+        if execution_payload is not None:
+            raw_errors = execution_payload.get("errors")
+            if isinstance(raw_errors, list):
+                execution_errors = [error for error in raw_errors if isinstance(error, str)]
+        error_summary = _build_error_summary(
+            execution_errors=execution_errors,
+            last_error=last_error,
+        )
+
     return WorkerProcessResult(
         run_record=run_record,
         egress_messages=egress_messages,
         dead_lettered=dead_lettered,
+        attempt_count=attempt_count,
+        reason_codes=list(reason_codes),
+        error_summary=error_summary,
     )
 
 
@@ -238,6 +256,9 @@ def _process_internal_heartbeat(
         run_record=run_record,
         egress_messages=[visible_egress_message, completion_egress_message],
         dead_lettered=False,
+        attempt_count=1,
+        reason_codes=["internal_heartbeat"],
+        error_summary=None,
     )
 
 
@@ -361,6 +382,30 @@ def _build_credit_exhausted_visible_error(
     return None
 
 
+def _build_error_summary(
+    *,
+    execution_errors: list[str],
+    last_error: str | None,
+    max_length: int = 240,
+) -> str:
+    candidate = next(
+        (
+            error
+            for error in execution_errors
+            if isinstance(error, str) and error.strip()
+        ),
+        None,
+    )
+    if candidate is None and last_error is not None and last_error.strip():
+        candidate = last_error
+    if candidate is None:
+        candidate = "unknown_error"
+    normalized = " ".join(candidate.split())
+    if len(normalized) <= max_length:
+        return normalized
+    return normalized[: max_length - 3].rstrip() + "..."
+
+
 def _looks_like_credit_exhaustion(error: str) -> bool:
     lowered = error.lower()
     return any(
@@ -390,5 +435,6 @@ def _event_id_for_sequence(
 
 __all__ = [
     "WorkerProcessResult",
+    "_build_error_summary",
     "process_task_message",
 ]

--- a/tests/test_main_worker.py
+++ b/tests/test_main_worker.py
@@ -1,14 +1,19 @@
 import json
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
+from app.broker import EgressQueueMessage
+from app.models import OutboundMessage, RunRecord
 from app.worker.main import (
     WORKER_CONFIG_PATH_ENV_VAR,
     _build_executor_env,
+    _log_worker_processed,
     _load_config,
     _resolve_non_negative_int,
 )
+from app.worker.runtime import WorkerProcessResult
 
 
 class MainWorkerTests(unittest.TestCase):
@@ -63,6 +68,109 @@ class MainWorkerTests(unittest.TestCase):
     def test_build_executor_env_skips_override_without_cli_config(self) -> None:
         self.assertIsNone(
             _build_executor_env(None, {WORKER_CONFIG_PATH_ENV_VAR: "/tmp/worker.json"})
+        )
+
+    def test_log_worker_processed_keeps_success_terse(self) -> None:
+        result = self._build_result(
+            result_status="success",
+            reason_codes=[],
+            attempt_count=1,
+            error_summary=None,
+        )
+
+        with self.assertLogs("app.worker.main", level="INFO") as captured:
+            _log_worker_processed(task_id="task:1", result=result)
+
+        self.assertEqual(len(captured.output), 1)
+        log_line = captured.output[0]
+        self.assertIn("INFO:app.worker.main:worker_processed", log_line)
+        self.assertIn("result_status=success", log_line)
+        self.assertNotIn("reason_codes=", log_line)
+        self.assertNotIn("attempt_count=", log_line)
+        self.assertNotIn("error_summary=", log_line)
+
+    def test_log_worker_processed_includes_failure_context_for_execution_error(
+        self,
+    ) -> None:
+        result = self._build_result(
+            result_status="execution_error",
+            reason_codes=["executor_reported_errors"],
+            attempt_count=1,
+            error_summary="executor_exit_nonzero:1:model unsupported",
+        )
+
+        with self.assertLogs("app.worker.main", level="WARNING") as captured:
+            _log_worker_processed(task_id="task:1", result=result)
+
+        self.assertEqual(len(captured.output), 1)
+        log_line = captured.output[0]
+        self.assertIn("WARNING:app.worker.main:worker_processed", log_line)
+        self.assertIn("result_status=execution_error", log_line)
+        self.assertIn("reason_codes=executor_reported_errors", log_line)
+        self.assertIn("attempt_count=1", log_line)
+        self.assertIn(
+            "error_summary=executor_exit_nonzero:1:model unsupported",
+            log_line,
+        )
+
+    def test_log_worker_processed_includes_failure_context_for_dead_letter(self) -> None:
+        result = self._build_result(
+            result_status="dead_letter",
+            reason_codes=["retry_exhausted"],
+            attempt_count=2,
+            error_summary="RuntimeError: executor down",
+        )
+
+        with self.assertLogs("app.worker.main", level="WARNING") as captured:
+            _log_worker_processed(task_id="task:1", result=result)
+
+        log_line = captured.output[0]
+        self.assertIn("result_status=dead_letter", log_line)
+        self.assertIn("reason_codes=retry_exhausted", log_line)
+        self.assertIn("attempt_count=2", log_line)
+        self.assertIn("error_summary=RuntimeError: executor down", log_line)
+
+    def _build_result(
+        self,
+        *,
+        result_status: str,
+        reason_codes: list[str],
+        attempt_count: int,
+        error_summary: str | None,
+    ) -> WorkerProcessResult:
+        return WorkerProcessResult(
+            run_record=RunRecord(
+                run_id="run:task:1:123",
+                envelope_id="email:1",
+                source="email",
+                workflow="default",
+                latency_ms=12,
+                result_status=result_status,
+                created_at=datetime(2026, 6, 7, 22, 30, tzinfo=timezone.utc),
+            ),
+            egress_messages=[
+                EgressQueueMessage(
+                    task_id="task:1",
+                    envelope_id="email:1",
+                    trace_id="trace:1",
+                    event_index=0,
+                    event_count=1,
+                    message=OutboundMessage(
+                        channel="internal",
+                        target="task",
+                        body="done",
+                    ),
+                    emitted_at=datetime(2026, 6, 7, 22, 30, tzinfo=timezone.utc),
+                    event_id="evt:task:1:0:completion",
+                    sequence=0,
+                    event_kind="completion",
+                    message_type="chatting.egress.v2",
+                )
+            ],
+            dead_lettered=result_status == "dead_letter",
+            attempt_count=attempt_count,
+            reason_codes=reason_codes,
+            error_summary=error_summary,
         )
 
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -14,7 +14,7 @@ from app.models import (
 )
 from app.state import SQLiteStateStore
 from app.worker.activity import WorkerActivityMonitor
-from app.worker.runtime import process_task_message
+from app.worker.runtime import _build_error_summary, process_task_message
 
 
 @dataclass(frozen=True)
@@ -46,6 +46,18 @@ class ExecutionErrorExecutor:
         del task
         return ExecutionResult(
             errors=["executor_exit_nonzero:1:insufficient credits"],
+        )
+
+
+@dataclass(frozen=True)
+class LongExecutionErrorExecutor:
+    def execute(self, task):
+        del task
+        return ExecutionResult(
+            errors=[
+                "executor_exit_nonzero:1:"
+                + "permission denied\nconfig.toml " * 30
+            ],
         )
 
 
@@ -142,6 +154,9 @@ class WorkerRuntimeTests(unittest.TestCase):
 
             self.assertEqual(result.run_record.result_status, "dead_letter")
             self.assertEqual(result.dead_lettered, True)
+            self.assertEqual(result.attempt_count, 2)
+            self.assertEqual(result.reason_codes, ["retry_exhausted"])
+            self.assertEqual(result.error_summary, "RuntimeError: executor down")
             self.assertEqual(
                 store.list_dead_letters()[0].reason_codes, ["retry_exhausted"]
             )
@@ -184,10 +199,34 @@ class WorkerRuntimeTests(unittest.TestCase):
 
             self.assertEqual(result.run_record.result_status, "execution_error")
             self.assertEqual(len(result.egress_messages), 2)
+            self.assertEqual(result.reason_codes, ["executor_reported_errors"])
+            self.assertEqual(
+                result.error_summary, "executor_exit_nonzero:1:insufficient credits"
+            )
             visible = result.egress_messages[0]
             self.assertEqual(visible.event_kind, "message")
             self.assertEqual(visible.message.target, "alice@example.com")
             self.assertIn("ran out of credits or quota", visible.message.body)
+
+    def test_process_task_message_builds_bounded_single_line_error_summary(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            result = process_task_message(
+                store=store,
+                task_message=self._build_task_message(),
+                executor_impl=LongExecutionErrorExecutor(),
+                max_attempts=1,
+                activity_monitor=self._build_monitor(store),
+            )
+
+            self.assertEqual(result.run_record.result_status, "execution_error")
+            self.assertIsNotNone(result.error_summary)
+            assert result.error_summary is not None
+            self.assertNotIn("\n", result.error_summary)
+            self.assertLessEqual(len(result.error_summary), 240)
+            self.assertTrue(result.error_summary.endswith("..."))
 
     def test_process_task_message_emits_completion_even_when_executor_does_no_actions(
         self,
@@ -260,6 +299,8 @@ class WorkerRuntimeTests(unittest.TestCase):
                 "heartbeat_pong",
             )
             self.assertEqual(completion_egress_message.event_kind, "completion")
+            self.assertEqual(result.reason_codes, ["internal_heartbeat"])
+            self.assertIsNone(result.error_summary)
             audit_event = store.list_audit_events()[0]
             self.assertEqual(audit_event.workflow, "default")
             self.assertEqual(audit_event.detail["reason_codes"], ["internal_heartbeat"])
@@ -285,6 +326,25 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertEqual(terminal.message.channel, "internal")
             self.assertEqual(terminal.message.target, "task")
             self.assertEqual(terminal.sequence, 0)
+
+    def test_build_error_summary_prefers_execution_error_then_last_error_then_fallback(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _build_error_summary(
+                execution_errors=["executor_exit_nonzero:1: boom"],
+                last_error="RuntimeError: ignored",
+            ),
+            "executor_exit_nonzero:1: boom",
+        )
+        self.assertEqual(
+            _build_error_summary(execution_errors=[], last_error="RuntimeError:\n boom"),
+            "RuntimeError: boom",
+        )
+        self.assertEqual(
+            _build_error_summary(execution_errors=[], last_error=None),
+            "unknown_error",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add bounded worker failure summaries derived from executor errors or last_error
- log execution_error and dead_letter worker completions with reason_codes and attempt_count
- add runtime and entrypoint tests for terse success logs and actionable failure logs

## Testing
- uv run python -m unittest tests.test_worker_runtime
- uv run python -m unittest tests.test_main_worker
- uv run ruff check app/worker/main.py app/worker/runtime.py tests/test_worker_runtime.py tests/test_main_worker.py
