### PR TITLE
Install Nix in worker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,14 @@ FROM python:3.13-slim AS base
 ARG GO_VERSION=1.26.1
 ARG GO_ARCHIVE_SHA256=031f088e5d955bab8657ede27ad4e3bc5b7c1ba281f05f245bcc304f327c987a
 ARG GO_ARCHIVE=go${GO_VERSION}.linux-amd64.tar.gz
+ARG NIX_VERSION=2.34.0
+ARG NIX_ARCHIVE_SHA256=5676b0887f1274e62edd175b6611af49aa8170c69c16877aa9bc6cebceb19855
+ARG NIX_ARCHIVE=nix-${NIX_VERSION}-x86_64-linux.tar.xz
 
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu ripgrep sqlite3 \
+    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu ripgrep sqlite3 xz-utils \
     && npm install -g @openai/codex @anthropic-ai/claude-code \
     && npm cache clean --force \
     && rm -rf /var/lib/apt/lists/*
@@ -26,6 +29,36 @@ RUN set -eux; \
     ln -sf /usr/local/go/bin/* /usr/local/bin/
 
 ENV PATH=/usr/local/go/bin:${PATH}
+ENV HOME=/home/chatting
+
+RUN useradd -m -d /home/chatting -s /bin/sh chatting \
+    && mkdir -p /nix \
+    && chown chatting:chatting /nix
+
+USER chatting
+
+RUN set -eux; \
+    archive_url="https://releases.nixos.org/nix/nix-${NIX_VERSION}/${NIX_ARCHIVE}"; \
+    archive_path="/tmp/${NIX_ARCHIVE}"; \
+    curl -fsSL "${archive_url}" -o "${archive_path}"; \
+    printf '%s  %s\n' "${NIX_ARCHIVE_SHA256}" "${archive_path}" | sha256sum -c -; \
+    tar -xJf "${archive_path}" -C /tmp; \
+    rm -f "${archive_path}"; \
+    cd "/tmp/nix-${NIX_VERSION}-x86_64-linux"; \
+    ./install --no-daemon --yes --no-channel-add --no-modify-profile; \
+    rm -rf "/tmp/nix-${NIX_VERSION}-x86_64-linux"
+
+USER root
+
+RUN mkdir -p /etc/nix \
+    && printf '%s\n%s\n' \
+      'experimental-features = nix-command flakes' \
+      'accept-flake-config = true' \
+      > /etc/nix/nix.conf \
+    && ln -sf /home/chatting/.nix-profile/bin/* /usr/local/bin/
+
+ENV PATH=/home/chatting/.nix-profile/bin:/usr/local/go/bin:${PATH}
+ENV NIX_SSL_CERT_FILE=/home/chatting/.nix-profile/etc/ssl/certs/ca-bundle.crt
 
 COPY pyproject.toml uv.lock .python-version ./
 RUN uv sync --locked --no-dev --no-install-project
@@ -36,8 +69,7 @@ COPY go/handler/ go/handler/
 RUN cd go/handler \
     && go build -trimpath -o /usr/local/bin/chatting-handler ./cmd/chatting-handler
 
-ENV HOME=/home/chatting
-RUN mkdir -p /home/chatting && chmod 755 /home/chatting
+RUN chmod 755 /home/chatting
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -79,6 +79,7 @@ The compose stack starts:
 The message handler exposes Prometheus-style metrics at `http://127.0.0.1:9464/metrics`.
 The worker exposes a read-only activity page at `http://127.0.0.1:9465/`, with matching JSON at
 `http://127.0.0.1:9465/activity.json`.
+The worker image also includes `nix` with flakes enabled.
 
 ## 6) Bootstrap CLI auth
 


### PR DESCRIPTION
## Summary

- install Nix in the worker runtime image using the upstream pinned x86_64 Linux tarball
- expose the Nix CLI on PATH and enable flakes by default
- mention the bundled Nix tooling in quick-start docs

## Image size

- The upstream nix-2.34.0 x86_64 Linux archive is 24.5 MiB compressed and contains about 98.5 MiB of store content before apt overhead.
- In practice I would expect roughly a ~100 MiB uncompressed layer increase and something in the ballpark of ~25-40 MiB extra when the image is registry-compressed.
- I could not run a literal docker build in this environment because no container runtime is installed here, so that sizing is an evidence-based estimate rather than a measured final image diff.
