### PR TITLE
Normalize Telegram attachment captions before send

### DIFF
--- a/go/handler/internal/dispatch/dispatch_test.go
+++ b/go/handler/internal/dispatch/dispatch_test.go
@@ -338,6 +338,86 @@ func TestTelegramMessageSenderSendsPhotoAttachment(t *testing.T) {
 	}
 }
 
+func TestTelegramMessageSenderNormalizesAttachmentCaptionBeforeMarkdownEscape(t *testing.T) {
+	tempDir := t.TempDir()
+	photoPath := filepath.Join(tempDir, "plant.png")
+	if err := os.WriteFile(photoPath, []byte("png bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var multipartCall telegramMultipartCall
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		multipartCall = recordTelegramMultipartCall(t, request)
+		_ = json.NewEncoder(writer).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+	sender := newTestTelegramSender(t, server.URL)
+	body := `Heading\n\n- Item \(note\)`
+
+	if err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{
+		Channel: "telegram",
+		Target:  "12345",
+		Body:    &body,
+		Attachment: &contracts.AttachmentRef{
+			URI: photoPath,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if multipartCall.fields["caption"] != "Heading\n\n- Item \\(note\\)" {
+		t.Fatalf("caption = %#v", multipartCall.fields["caption"])
+	}
+	if multipartCall.fields["parse_mode"] != "Markdown" {
+		t.Fatalf("parse_mode = %#v", multipartCall.fields["parse_mode"])
+	}
+}
+
+func TestTelegramMessageSenderRetriesAttachmentWithNormalizedPlainCaptionAfterParseError(t *testing.T) {
+	tempDir := t.TempDir()
+	documentPath := filepath.Join(tempDir, "report.txt")
+	if err := os.WriteFile(documentPath, []byte("report"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var calls []telegramMultipartCall
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		call := recordTelegramMultipartCall(t, request)
+		calls = append(calls, call)
+		if len(calls) == 1 {
+			_ = json.NewEncoder(writer).Encode(map[string]any{"ok": false, "description": "Bad Request: can't parse entities"})
+			return
+		}
+		_ = json.NewEncoder(writer).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+	sender := newTestTelegramSender(t, server.URL)
+	body := `Heading\n\n- Item \(note\)`
+
+	if err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{
+		Channel: "telegram",
+		Target:  "12345",
+		Body:    &body,
+		Attachment: &contracts.AttachmentRef{
+			URI: documentPath,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls = %#v", calls)
+	}
+	if calls[0].fields["caption"] != "Heading\n\n- Item \\(note\\)" {
+		t.Fatalf("first caption = %#v", calls[0].fields["caption"])
+	}
+	if calls[0].fields["parse_mode"] != "Markdown" {
+		t.Fatalf("first parse_mode = %#v", calls[0].fields["parse_mode"])
+	}
+	if _, ok := calls[1].fields["parse_mode"]; ok {
+		t.Fatalf("fallback still has parse_mode: %#v", calls[1].fields)
+	}
+	if calls[1].fields["caption"] != "Heading\n\n- Item (note)" {
+		t.Fatalf("fallback caption = %#v", calls[1].fields["caption"])
+	}
+}
+
 func TestTelegramMessageSenderSendsDocumentAttachmentFromFileURI(t *testing.T) {
 	tempDir := t.TempDir()
 	documentPath := filepath.Join(tempDir, "report.txt")

--- a/go/handler/internal/dispatch/telegram.go
+++ b/go/handler/internal/dispatch/telegram.go
@@ -91,7 +91,8 @@ func (sender *TelegramMessageSender) Send(ctx context.Context, target string, me
 	}
 	payload := map[string]string{"chat_id": target}
 	if message.Body != nil {
-		payload["caption"] = normalizeTelegramTextForParseMode(*message.Body, sender.parseMode)
+		normalizedBody := normalizeTelegramOutboundText(*message.Body)
+		payload["caption"] = normalizeTelegramTextForParseMode(normalizedBody, sender.parseMode)
 		if sender.parseMode != nil {
 			payload["parse_mode"] = *sender.parseMode
 		}
@@ -101,7 +102,7 @@ func (sender *TelegramMessageSender) Send(ctx context.Context, target string, me
 		return nil
 	}
 	if err == nil && sender.parseMode != nil && message.Body != nil && isTelegramParseModeError(response) {
-		fallback := map[string]string{"chat_id": target, "caption": *message.Body}
+		fallback := map[string]string{"chat_id": target, "caption": normalizeTelegramOutboundText(*message.Body)}
 		response, err = sender.postMultipart(ctx, method, fallback, fileField, filePath)
 		if err == nil && response.OK {
 			return nil


### PR DESCRIPTION
## Summary
- normalize Telegram attachment captions before parse-mode escaping in the Go handler sender
- reuse the normalized plain caption on parse-mode fallback and add regression coverage for attachment captions

## Testing
- uv run ruff check app tests
- uv run python -m unittest tests.test_telegram_text tests.test_main_reply
- cd go/handler && go test ./...
