### PR TITLE
Add workspace site preview service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - ./configs/worker:/config:ro
       - worker-data:/data
       - ${LOCAL_WORKSPACE}:/workspace
+      - ${LOCAL_WORKSPACE}/site:/site
       - shared-temp:/tmp
       - codex-auth:/home/chatting/.codex
       - claude-auth:/home/chatting/.claude
@@ -61,6 +62,21 @@ services:
         condition: service_healthy
     ports:
       - "9465:9465"
+    restart: unless-stopped
+
+  site:
+    image: node:22-alpine
+    working_dir: /site
+    command:
+      [
+        "sh",
+        "-lc",
+        "npm install -g browser-sync@3 && browser-sync start --server /site --files /site --host 0.0.0.0 --port 3000 --no-open --no-ui --no-notify"
+      ]
+    volumes:
+      - ${LOCAL_WORKSPACE}/site:/site
+    ports:
+      - "3000:3000"
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     volumes:
       - ./configs/worker:/config:ro
       - worker-data:/data
+      - ${LOCAL_WORKSPACE}:/workspace
       - html-output:/workspace/html
       - shared-temp:/tmp
       - codex-auth:/home/chatting/.codex

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,7 @@ services:
     volumes:
       - ./configs/worker:/config:ro
       - worker-data:/data
-      - ${LOCAL_WORKSPACE}:/workspace
-      - ${LOCAL_WORKSPACE}/site:/site
+      - html-output:/workspace/html
       - shared-temp:/tmp
       - codex-auth:/home/chatting/.codex
       - claude-auth:/home/chatting/.claude
@@ -71,17 +70,18 @@ services:
       [
         "sh",
         "-lc",
-        "npm install -g browser-sync@3 && browser-sync start --server /site --files /site --host 0.0.0.0 --port 3000 --no-open --no-ui --no-notify"
+        "npm install -g browser-sync@3 && browser-sync start --server /site --files /site --host 0.0.0.0 --port 9466 --no-open --no-ui --no-notify"
       ]
     volumes:
-      - ${LOCAL_WORKSPACE}/site:/site
+      - html-output:/site
     ports:
-      - "3000:3000"
+      - "9466:9466"
     restart: unless-stopped
 
 volumes:
   handler-data:
   worker-data:
+  html-output:
   shared-temp:
   codex-auth:
   claude-auth:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -75,10 +75,32 @@ The compose stack starts:
 - `bbmb`
 - `handler`
 - `worker`
+- `site` on port `3000`, serving files from `$LOCAL_WORKSPACE/site`
 
 The Go message handler exposes Prometheus-style metrics at `http://127.0.0.1:9464/metrics`.
 The worker exposes a read-only activity page at `http://127.0.0.1:9465/`, with matching JSON at
 `http://127.0.0.1:9465/activity.json`.
+
+If you want the static preview path to have content immediately, create a simple page in the
+mounted workspace before or after startup:
+
+```bash
+mkdir -p "$LOCAL_WORKSPACE/site"
+cat > "$LOCAL_WORKSPACE/site/index.html" <<'EOF'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Site Preview</title>
+  </head>
+  <body>
+    <h1>Site preview is live.</h1>
+    <p>Edit files in the workspace-mounted site directory and reload port 3000.</p>
+  </body>
+</html>
+EOF
+```
 
 ## 6) Bootstrap CLI auth
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -32,7 +32,7 @@ cp configs/worker.env.example configs/worker/worker.env
 Edit the copied files before starting the stack:
 - `configs/handler/handler.json`: connector settings, egress channels, metrics, and integration paths
 - `configs/handler/handler.env`: IMAP, SMTP, Telegram, and other integration secrets
-- `configs/worker/worker.json`: executor settings and mounted workspace path
+- `configs/worker/worker.json`: executor settings
 - `configs/worker/worker.env`: executor provider secrets
 
 The Docker examples use container paths and Docker DNS:
@@ -40,13 +40,7 @@ The Docker examples use container paths and Docker DNS:
 - worker DB: `/data/worker.db`
 - BBMB: `bbmb:9876`
 
-## 3) Set the workspace mount
-
-```bash
-export LOCAL_WORKSPACE=/absolute/path/to/the/workspace/codex-should-use
-```
-
-## 4) Choose the runtime image
+## 3) Choose the runtime image
 
 The default compose file pulls the published runtime image:
 
@@ -64,7 +58,7 @@ has package read access:
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 ```
 
-## 5) Start chatting
+## 4) Start chatting
 
 ```bash
 docker compose pull
@@ -75,18 +69,20 @@ The compose stack starts:
 - `bbmb`
 - `handler`
 - `worker`
-- `site` on port `3000`, serving files from `$LOCAL_WORKSPACE/site`
+- `site` on port `9466`, serving files from the shared `html-output` Docker volume
 
 The Go message handler exposes Prometheus-style metrics at `http://127.0.0.1:9464/metrics`.
 The worker exposes a read-only activity page at `http://127.0.0.1:9465/`, with matching JSON at
 `http://127.0.0.1:9465/activity.json`.
 
-If you want the static preview path to have content immediately, create a simple page in the
-mounted workspace before or after startup:
+The worker gets the same writable volume mounted at `/workspace/html`, so the agent can drop
+HTML reports there and you can open them through the preview service on `http://127.0.0.1:9466/`.
+
+If you want the static preview path to have content immediately, create a simple page from inside
+the worker container before or after startup:
 
 ```bash
-mkdir -p "$LOCAL_WORKSPACE/site"
-cat > "$LOCAL_WORKSPACE/site/index.html" <<'EOF'
+docker compose exec worker sh -lc 'cat > /workspace/html/index.html <<'"'"'EOF'"'"'
 <!doctype html>
 <html lang="en">
   <head>
@@ -96,13 +92,14 @@ cat > "$LOCAL_WORKSPACE/site/index.html" <<'EOF'
   </head>
   <body>
     <h1>Site preview is live.</h1>
-    <p>Edit files in the workspace-mounted site directory and reload port 3000.</p>
+    <p>Edit files in /workspace/html and reload port 9466.</p>
   </body>
 </html>
 EOF
+'
 ```
 
-## 6) Bootstrap CLI auth
+## 5) Bootstrap CLI auth
 
 When using real executor mode, authenticate the CLIs once inside the worker container. Auth state is
 persisted in Docker volumes.
@@ -112,7 +109,7 @@ docker compose run --rm worker codex login
 docker compose run --rm worker claude login
 ```
 
-## 7) Run tests
+## 6) Run tests
 
 Local tests are separate from the Docker runtime path and require Python 3.13+ plus `uv`.
 
@@ -121,7 +118,7 @@ uv sync
 uv run python -m unittest discover -s tests
 ```
 
-## 8) Query state and metrics
+## 7) Query state and metrics
 
 Use the worker page for a quick operator view, or query SQLite directly when you need deeper history:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -60,6 +60,12 @@ echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
 ## 4) Start chatting
 
+The worker still needs a real workspace bind for repo access. Set it before starting:
+
+```bash
+export LOCAL_WORKSPACE=/absolute/path/to/the/workspace/codex-should-use
+```
+
 ```bash
 docker compose pull
 docker compose up -d
@@ -75,7 +81,8 @@ The Go message handler exposes Prometheus-style metrics at `http://127.0.0.1:946
 The worker exposes a read-only activity page at `http://127.0.0.1:9465/`, with matching JSON at
 `http://127.0.0.1:9465/activity.json`.
 
-The worker gets the same writable volume mounted at `/workspace/html`, so the agent can drop
+The worker keeps your normal host workspace mounted at `/workspace` and also gets a writable
+Docker volume mounted at `/workspace/html`, so the agent can drop
 HTML reports there and you can open them through the preview service on `http://127.0.0.1:9466/`.
 
 If you want the static preview path to have content immediately, create a simple page from inside

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -89,6 +89,10 @@ The worker also serves a local read-only activity page by default at `http://127
 with JSON at `/activity.json`. The bind stays fixed at `9465`; use
 `activity_history_limit` to change the retention window.
 
+The default compose stack also runs a simple static preview service on `http://127.0.0.1:3000/`
+that serves the workspace-mounted directory at `$LOCAL_WORKSPACE/site`, so worker-generated output
+can live in the workspace instead of the `chatting` repo checkout.
+
 ## 4.5) Optional auxiliary webhook ingress
 
 ```bash

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -46,13 +46,7 @@ cp configs/worker.env.example configs/worker/worker.env
 
 Edit the copied configs and env files for the target integrations and executor provider secrets.
 
-## 2) Set the worker workspace mount
-
-```bash
-export LOCAL_WORKSPACE=/absolute/path/to/the/workspace/codex-should-use
-```
-
-## 3) Choose the runtime image
+## 2) Choose the runtime image
 
 The default compose stack pulls the published runtime image from GHCR:
 
@@ -69,7 +63,7 @@ has package read access:
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 ```
 
-## 4) Start the stack
+## 3) Start the stack
 
 ```bash
 docker compose pull
@@ -89,11 +83,12 @@ The worker also serves a local read-only activity page by default at `http://127
 with JSON at `/activity.json`. The bind stays fixed at `9465`; use
 `activity_history_limit` to change the retention window.
 
-The default compose stack also runs a simple static preview service on `http://127.0.0.1:3000/`
-that serves the workspace-mounted directory at `$LOCAL_WORKSPACE/site`, so worker-generated output
-can live in the workspace instead of the `chatting` repo checkout.
+The default compose stack also runs a simple static preview service on `http://127.0.0.1:9466/`.
+It serves a Docker-managed `html-output` volume that is mounted read-write into the worker at
+`/workspace/html`, so worker-generated reports can be written there without relying on a host bind
+mount or a checkout-specific path.
 
-## 4.5) Optional auxiliary webhook ingress
+## 3.5) Optional auxiliary webhook ingress
 
 ```bash
 uv run python -m app.main_auxiliary_ingress \
@@ -118,7 +113,7 @@ JSON bodies to `generic-post` and `new-service` respectively. To make the handle
 queues, add `auxiliary_ingress_queues: ["generic-post", "new-service"]` to the message-handler
 config.
 
-## 5) Security boundary expectations
+## 4) Security boundary expectations
 
 - `message-handler` owns integration secrets (`IMAP`, `SMTP`, `Telegram`).
 - `worker` does not read integration secrets and does not dispatch directly.
@@ -127,7 +122,7 @@ config.
   internal `completion` event so the Go `message-handler` can close the task and reject future egress.
 - Egress channel dispatch is allowlist-gated by `allowed_egress_channels`.
 
-## 6) Configure GitHub assignment polling (in message-handler)
+## 5) Configure GitHub assignment polling (in message-handler)
 
 Edit message-handler config:
 - `github_repositories` (`owner/repo` or `owner/*`)
@@ -135,7 +130,7 @@ Edit message-handler config:
 
 `gh` CLI must already be authenticated on the message-handler host for both polling and issue-comment egress.
 
-## 7) Publish a visible reply from worker side
+## 6) Publish a visible reply from worker side
 
 Use the worker-side CLI to push a visible egress event directly to BBMB. Executors should use this
 path for both quick acknowledgements and final user-visible answers instead of returning replies in
@@ -166,7 +161,7 @@ docker compose exec worker python -m app.main_reply task:telegram:53 \
 
 - If `--telegram-message-id` is omitted, `app.main_reply` looks up the inbound Telegram `message_id` from the task ledger in `db_path`.
 
-## 8) Docker worker CLI auth bootstrap
+## 7) Docker worker CLI auth bootstrap
 
 When running with `docker-compose.yml`, the worker image includes both `codex` and `claude` CLIs.
 Auth is still external to the app and must be completed once interactively, then persisted in Docker

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -65,6 +65,12 @@ echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
 ## 3) Start the stack
 
+The worker still needs a host workspace bind so the executor can operate on real repos:
+
+```bash
+export LOCAL_WORKSPACE=/absolute/path/to/the/workspace/codex-should-use
+```
+
 ```bash
 docker compose pull
 docker compose up -d
@@ -85,8 +91,9 @@ with JSON at `/activity.json`. The bind stays fixed at `9465`; use
 
 The default compose stack also runs a simple static preview service on `http://127.0.0.1:9466/`.
 It serves a Docker-managed `html-output` volume that is mounted read-write into the worker at
-`/workspace/html`, so worker-generated reports can be written there without relying on a host bind
-mount or a checkout-specific path.
+`/workspace/html`. The worker still uses the existing `${LOCAL_WORKSPACE}:/workspace` bind for its
+main working tree, and the extra volume just provides a stable place for worker-generated HTML
+reports without tying that output to a checkout-specific host path.
 
 ## 3.5) Optional auxiliary webhook ingress
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ if [ "$PUID" != "0" ] || [ "$PGID" != "0" ]; then
     fi
     chown -R "$PUID:$PGID" "$HOME"
     # Runtime state lives on mounted volumes; ensure they remain writable after dropping privileges.
-    for path in /data /tmp; do
+    for path in /data /tmp /workspace/html; do
         if [ -e "$path" ]; then
             chown -R "$PUID:$PGID" "$path"
         fi


### PR DESCRIPTION
## Summary
- mount a shared `${LOCAL_WORKSPACE}/site` volume into the worker at `/site`
- add a `site` container that serves that same directory on port `3000`
- document the preview path in the split-mode compose guides
