### PR TITLE
Restore Go Telegram conversation history enrichment

### DIFF
--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -291,7 +291,7 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 			metricRecorder.RecordEgressResult(result.Status, result.Reason)
 		}
 		return err
-	}), handlerruntime.WithIngress(store, connectors...), handlerruntime.WithMetrics(metricRecorder))
+	}), handlerruntime.WithIngress(handlerIngressState{store: store}, connectors...), handlerruntime.WithMetrics(metricRecorder))
 	if err != nil {
 		_ = metricsServer.Close()
 		_ = store.Close()
@@ -302,6 +302,49 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 
 type githubCheckpointStore struct {
 	store *sqlitestate.Store
+}
+
+type handlerIngressState struct {
+	store *sqlitestate.Store
+}
+
+func (state handlerIngressState) Seen(ctx context.Context, source string, dedupeKey string) (bool, error) {
+	return state.store.Seen(ctx, source, dedupeKey)
+}
+
+func (state handlerIngressState) MarkSeen(ctx context.Context, source string, dedupeKey string) error {
+	return state.store.MarkSeen(ctx, source, dedupeKey)
+}
+
+func (state handlerIngressState) RecordTask(ctx context.Context, taskMessage contracts.TaskQueueMessage) error {
+	return state.store.RecordTask(ctx, taskMessage)
+}
+
+func (state handlerIngressState) RecordTelegramTaskAttachments(ctx context.Context, taskMessage contracts.TaskQueueMessage, attachmentRootDir string) (int, error) {
+	return state.store.RecordTelegramTaskAttachments(ctx, taskMessage, attachmentRootDir)
+}
+
+func (state handlerIngressState) CleanupTelegramAttachmentsForRuntime(ctx context.Context, attachmentRootDir string, notAfter time.Time, maxAgeCutoff time.Time) error {
+	return state.store.CleanupTelegramAttachmentsForRuntime(ctx, attachmentRootDir, notAfter, maxAgeCutoff)
+}
+
+func (state handlerIngressState) AppendConversationTurn(ctx context.Context, channel string, target string, role string, content string, runID string) error {
+	return state.store.AppendConversationTurn(ctx, channel, target, role, content, runID)
+}
+
+func (state handlerIngressState) ListRecentConversationTurns(ctx context.Context, channel string, target string, limit int) ([]handlerruntime.ConversationTurn, error) {
+	turns, err := state.store.ListRecentConversationTurns(ctx, channel, target, limit)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]handlerruntime.ConversationTurn, 0, len(turns))
+	for _, turn := range turns {
+		result = append(result, handlerruntime.ConversationTurn{
+			Role:    turn.Role,
+			Content: turn.Content,
+		})
+	}
+	return result, nil
 }
 
 func (store githubCheckpointStore) GetGitHubCheckpoint(ctx context.Context, scopeKey string) (*githubconnector.AssignmentCheckpoint, error) {

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
@@ -33,6 +35,10 @@ type State interface {
 	ExpectedSequence(ctx context.Context, taskID string) (int, error)
 	GetStagedEventBySequence(ctx context.Context, taskID string, sequence int) (*StagedRecord, error)
 	MarkStagedEventDispatched(ctx context.Context, taskID string, eventID string, sequence int) error
+}
+
+type TelegramConversationState interface {
+	AppendConversationTurn(ctx context.Context, channel string, target string, role string, content string, runID string) error
 }
 
 type Dispatcher interface {
@@ -232,8 +238,14 @@ func (engine *Engine) Flush(ctx context.Context, taskID string) (Result, error) 
 }
 
 func (engine *Engine) dispatchAndMark(ctx context.Context, task *TaskRecord, message contracts.EgressQueueMessage) error {
-	if _, err := engine.dispatcher.Dispatch(ctx, message.Message, task.TaskMessage.Envelope); err != nil {
+	dispatched, err := engine.dispatcher.Dispatch(ctx, message.Message, task.TaskMessage.Envelope)
+	if err != nil {
 		return err
+	}
+	if memoryState, ok := engine.state.(TelegramConversationState); ok {
+		if err := maybeRecordTelegramConversationTurn(ctx, memoryState, task, dispatched, message.TaskID); err != nil {
+			return err
+		}
 	}
 	return engine.state.MarkDispatchedEventID(ctx, message.TaskID, message.EventID)
 }
@@ -249,4 +261,44 @@ func (engine *Engine) channelAllowed(message contracts.EgressQueueMessage, task 
 		return engine.allowedChannels[task.TaskMessage.Envelope.ReplyChannel.Type]
 	}
 	return engine.allowedChannels[message.Message.Channel]
+}
+
+func maybeRecordTelegramConversationTurn(ctx context.Context, state TelegramConversationState, task *TaskRecord, dispatched *contracts.OutboundMessage, runID string) error {
+	if task == nil || dispatched == nil {
+		return nil
+	}
+	if task.TaskMessage.Envelope.ReplyChannel.Type != "telegram" {
+		return nil
+	}
+	if dispatched.Channel != "telegram" || dispatched.Target != task.TaskMessage.Envelope.ReplyChannel.Target {
+		return nil
+	}
+	content, ok := telegramConversationContent(*dispatched)
+	if !ok {
+		return nil
+	}
+	return state.AppendConversationTurn(ctx, "telegram", dispatched.Target, "assistant", content, runID)
+}
+
+func telegramConversationContent(message contracts.OutboundMessage) (string, bool) {
+	if message.Body != nil {
+		trimmed := strings.TrimSpace(*message.Body)
+		if trimmed != "" {
+			return trimmed, true
+		}
+	}
+	if message.Attachment == nil {
+		return "", false
+	}
+	name := ""
+	if message.Attachment.Name != nil {
+		name = strings.TrimSpace(*message.Attachment.Name)
+	}
+	if name == "" {
+		name = filepath.Base(message.Attachment.URI)
+	}
+	if name == "" || name == "." || name == "/" {
+		name = message.Attachment.URI
+	}
+	return "[Attachment sent: " + name + "]", true
 }

--- a/go/handler/internal/egress/egress_test.go
+++ b/go/handler/internal/egress/egress_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -148,6 +149,62 @@ func TestHandleDispatchesUnsequencedIncrementalAndDedupesReplay(t *testing.T) {
 	}
 }
 
+func TestHandlePersistsTelegramAssistantTurnAfterDispatch(t *testing.T) {
+	task := telegramTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{
+		result: &contracts.OutboundMessage{
+			Channel: "telegram",
+			Target:  "12345",
+			Body:    stringPtr("reply-1"),
+		},
+	}
+	engine := newTestEngineWithState(t, state, dispatcher, WithAllowedChannels([]string{"telegram"}))
+	message := testEgressMessage(t, task, nil, "evt:incremental:1", "incremental")
+	message.Message.Channel = "telegram"
+	message.Message.Target = "12345"
+
+	result, err := engine.Handle(context.Background(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDispatched {
+		t.Fatalf("result = %#v", result)
+	}
+	if got, want := state.turns["12345"], []conversationTurnRecord{{Role: "assistant", Content: "reply-1", RunID: task.TaskID}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("turns = %#v, want %#v", got, want)
+	}
+}
+
+func TestHandlePersistsTelegramAttachmentOnlyDispatchAsAssistantTurn(t *testing.T) {
+	task := telegramTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatchName := "menu.pdf"
+	dispatcher := &recordingDispatcher{
+		result: &contracts.OutboundMessage{
+			Channel: "telegram",
+			Target:  "12345",
+			Attachment: &contracts.AttachmentRef{
+				URI:  "file:///tmp/menu.pdf",
+				Name: &dispatchName,
+			},
+		},
+	}
+	engine := newTestEngineWithState(t, state, dispatcher, WithAllowedChannels([]string{"telegram"}))
+	message := testEgressMessage(t, task, nil, "evt:incremental:1", "incremental")
+	message.Message.Channel = "telegram"
+	message.Message.Target = "12345"
+
+	if _, err := engine.Handle(context.Background(), message); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := state.turns["12345"], []conversationTurnRecord{{Role: "assistant", Content: "[Attachment sent: menu.pdf]", RunID: task.TaskID}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("turns = %#v, want %#v", got, want)
+	}
+}
+
 func TestHandleStagesAndFlushesSequencedEventsInOrder(t *testing.T) {
 	task := testTaskMessage(t)
 	state := newFakeState()
@@ -282,6 +339,13 @@ type fakeState struct {
 	dispatched map[string]map[string]bool
 	staged     map[string]map[int]StagedRecord
 	expected   map[string]int
+	turns      map[string][]conversationTurnRecord
+}
+
+type conversationTurnRecord struct {
+	Role    string
+	Content string
+	RunID   string
 }
 
 func newFakeState() *fakeState {
@@ -291,6 +355,7 @@ func newFakeState() *fakeState {
 		dispatched: map[string]map[string]bool{},
 		staged:     map[string]map[int]StagedRecord{},
 		expected:   map[string]int{},
+		turns:      map[string][]conversationTurnRecord{},
 	}
 }
 
@@ -368,9 +433,22 @@ func (state *fakeState) MarkStagedEventDispatched(_ context.Context, taskID stri
 	return nil
 }
 
+func (state *fakeState) AppendConversationTurn(_ context.Context, channel string, target string, role string, content string, runID string) error {
+	if channel != "telegram" {
+		return nil
+	}
+	state.turns[target] = append(state.turns[target], conversationTurnRecord{
+		Role:    role,
+		Content: content,
+		RunID:   runID,
+	})
+	return nil
+}
+
 type recordingDispatcher struct {
 	messages []contracts.OutboundMessage
 	err      error
+	result   *contracts.OutboundMessage
 }
 
 func (dispatcher *recordingDispatcher) Dispatch(_ context.Context, message contracts.OutboundMessage, _ contracts.TaskEnvelope) (*contracts.OutboundMessage, error) {
@@ -378,6 +456,9 @@ func (dispatcher *recordingDispatcher) Dispatch(_ context.Context, message contr
 		return nil, dispatcher.err
 	}
 	dispatcher.messages = append(dispatcher.messages, message)
+	if dispatcher.result != nil {
+		return dispatcher.result, nil
+	}
 	return &message, nil
 }
 
@@ -402,9 +483,12 @@ func newTestEngine(t *testing.T, state *fakeState, dispatcher *recordingDispatch
 	return newTestEngineWithState(t, state, dispatcher)
 }
 
-func newTestEngineWithState(t *testing.T, state State, dispatcher *recordingDispatcher) *Engine {
+func newTestEngineWithState(t *testing.T, state State, dispatcher *recordingDispatcher, options ...Option) *Engine {
 	t.Helper()
-	engine, err := New(state, dispatcher, WithAllowedChannels([]string{"email"}))
+	if len(options) == 0 {
+		options = []Option{WithAllowedChannels([]string{"email"})}
+	}
+	engine, err := New(state, dispatcher, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,6 +511,24 @@ func testTaskMessage(t *testing.T) contracts.TaskQueueMessage {
 		},
 		DedupeKey: "email:1",
 	}, "trace:email:1", mustTime(t, "2026-03-06T11:00:01Z"))
+}
+
+func telegramTaskMessage(t *testing.T) contracts.TaskQueueMessage {
+	t.Helper()
+	actor := "8605042448"
+	return contracts.NewTaskQueueMessage(contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            "telegram:1",
+		Source:        "im",
+		ReceivedAt:    contracts.NewTimestamp(mustTime(t, "2026-03-06T11:00:00Z")),
+		Actor:         &actor,
+		Content:       "hello from telegram",
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   "telegram",
+			Target: "12345",
+		},
+		DedupeKey: "telegram:1",
+	}, "trace:telegram:1", mustTime(t, "2026-03-06T11:00:01Z"))
 }
 
 func testEgressMessage(t *testing.T, task contracts.TaskQueueMessage, sequence *int, eventID string, eventKind string) contracts.EgressQueueMessage {

--- a/go/handler/internal/egress/sqlite_state.go
+++ b/go/handler/internal/egress/sqlite_state.go
@@ -68,3 +68,7 @@ func (state *SQLiteState) GetStagedEventBySequence(ctx context.Context, taskID s
 func (state *SQLiteState) MarkStagedEventDispatched(ctx context.Context, taskID string, eventID string, sequence int) error {
 	return state.store.MarkStagedEventDispatched(ctx, taskID, eventID, sequence)
 }
+
+func (state *SQLiteState) AppendConversationTurn(ctx context.Context, channel string, target string, role string, content string, runID string) error {
+	return state.store.AppendConversationTurn(ctx, channel, target, role, content, runID)
+}

--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/bbmb"
@@ -18,6 +19,7 @@ const (
 	EgressQueueName         = "chatting.egress.v1"
 	egressPickupWaitSeconds = 5
 	egressDrainWaitSeconds  = 0
+	telegramMemoryTurnLimit = 30
 )
 
 type Broker interface {
@@ -43,6 +45,16 @@ type TelegramAttachmentIngressState interface {
 
 type TelegramAttachmentCleanupState interface {
 	CleanupTelegramAttachmentsForRuntime(ctx context.Context, attachmentRootDir string, notAfter time.Time, maxAgeCutoff time.Time) error
+}
+
+type ConversationTurn struct {
+	Role    string
+	Content string
+}
+
+type TelegramConversationState interface {
+	AppendConversationTurn(ctx context.Context, channel string, target string, role string, content string, runID string) error
+	ListRecentConversationTurns(ctx context.Context, channel string, target string, limit int) ([]ConversationTurn, error)
 }
 
 type Connector interface {
@@ -198,6 +210,13 @@ func (runner *Runner) PublishIngress(ctx context.Context) (int, error) {
 				"trace:"+envelope.ID,
 				runner.now(),
 			)
+			if conversationState, ok := runner.ingressState.(TelegramConversationState); ok {
+				enriched, err := prepareTelegramEnvelope(ctx, conversationState, taskMessage.TaskID, envelope)
+				if err != nil {
+					return published, err
+				}
+				taskMessage.Envelope = enriched
+			}
 			if err := runner.ingressState.RecordTask(ctx, taskMessage); err != nil {
 				return published, err
 			}
@@ -223,6 +242,30 @@ func (runner *Runner) PublishIngress(ctx context.Context) (int, error) {
 		}
 	}
 	return published, nil
+}
+
+func prepareTelegramEnvelope(ctx context.Context, state TelegramConversationState, runID string, envelope contracts.TaskEnvelope) (contracts.TaskEnvelope, error) {
+	if envelope.ReplyChannel.Type != "telegram" {
+		return envelope, nil
+	}
+	turns, err := state.ListRecentConversationTurns(ctx, "telegram", envelope.ReplyChannel.Target, telegramMemoryTurnLimit)
+	if err != nil {
+		return contracts.TaskEnvelope{}, err
+	}
+	enriched := envelope
+	if len(turns) > 0 {
+		lines := make([]string, 0, len(turns)+3)
+		lines = append(lines, "Recent conversation context (oldest first):")
+		for _, turn := range turns {
+			lines = append(lines, turn.Role+": "+turn.Content)
+		}
+		lines = append(lines, "", "Current user message:", envelope.Content)
+		enriched.Content = strings.Join(lines, "\n")
+	}
+	if err := state.AppendConversationTurn(ctx, "telegram", envelope.ReplyChannel.Target, "user", envelope.Content, runID); err != nil {
+		return contracts.TaskEnvelope{}, err
+	}
+	return enriched, nil
 }
 
 func ackEnvelope(ctx context.Context, connector Connector, envelopeID string) error {

--- a/go/handler/internal/runtime/runtime_test.go
+++ b/go/handler/internal/runtime/runtime_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,6 +226,65 @@ func TestPublishIngressAcksAckingConnectorAfterPublish(t *testing.T) {
 	}
 }
 
+func TestPublishIngressEnrichesTelegramEnvelopeWithRecentConversation(t *testing.T) {
+	broker := &fakeBroker{}
+	state := newFakeIngressState()
+	for index := 0; index < 35; index++ {
+		state.turns["12345"] = append(state.turns["12345"], ConversationTurn{
+			Role:    "user",
+			Content: fmt.Sprintf("turn-%d", index),
+		})
+	}
+	envelope := contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            "telegram:100",
+		Source:        "im",
+		ReceivedAt:    contracts.NewTimestamp(mustTime(t, "2026-03-09T12:00:00Z")),
+		Content:       "latest-turn",
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   "telegram",
+			Target: "12345",
+		},
+		DedupeKey: "telegram:100",
+	}
+	connector := &fakeAckingConnector{envelopes: []contracts.TaskEnvelope{envelope}}
+	runner, err := NewRunner(
+		handlerconfig.Defaults(),
+		broker,
+		&fakeEgressHandler{},
+		WithIngress(state, connector),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	published, err := runner.PublishIngress(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if published != 1 {
+		t.Fatalf("published = %d", published)
+	}
+	recorded := state.tasks["task:telegram:100"]
+	if !strings.Contains(recorded.Envelope.Content, "Recent conversation context (oldest first):") {
+		t.Fatalf("content = %q", recorded.Envelope.Content)
+	}
+	if !strings.Contains(recorded.Envelope.Content, "user: turn-5") || !strings.Contains(recorded.Envelope.Content, "user: turn-34") {
+		t.Fatalf("content = %q", recorded.Envelope.Content)
+	}
+	if strings.Contains(recorded.Envelope.Content, "user: turn-4") {
+		t.Fatalf("content = %q", recorded.Envelope.Content)
+	}
+	if !strings.Contains(recorded.Envelope.Content, "Current user message:\nlatest-turn") {
+		t.Fatalf("content = %q", recorded.Envelope.Content)
+	}
+	lastTurn := state.turns["12345"][len(state.turns["12345"])-1]
+	if lastTurn.Role != "user" || lastTurn.Content != "latest-turn" {
+		t.Fatalf("stored turn = %#v", lastTurn)
+	}
+}
+
 func TestPublishIngressAcksSeenEnvelopeFromAckingConnector(t *testing.T) {
 	broker := &fakeBroker{}
 	state := newFakeIngressState()
@@ -382,12 +443,14 @@ func (handler *fakeEgressHandler) HandleRaw(ctx context.Context, raw []byte) err
 type fakeIngressState struct {
 	seen  map[string]map[string]bool
 	tasks map[string]contracts.TaskQueueMessage
+	turns map[string][]ConversationTurn
 }
 
 func newFakeIngressState() *fakeIngressState {
 	return &fakeIngressState{
 		seen:  map[string]map[string]bool{},
 		tasks: map[string]contracts.TaskQueueMessage{},
+		turns: map[string][]ConversationTurn{},
 	}
 }
 
@@ -406,6 +469,25 @@ func (state *fakeIngressState) MarkSeen(ctx context.Context, source string, dedu
 func (state *fakeIngressState) RecordTask(ctx context.Context, taskMessage contracts.TaskQueueMessage) error {
 	state.tasks[taskMessage.TaskID] = taskMessage
 	return nil
+}
+
+func (state *fakeIngressState) AppendConversationTurn(ctx context.Context, channel string, target string, role string, content string, runID string) error {
+	if channel != "telegram" {
+		return nil
+	}
+	state.turns[target] = append(state.turns[target], ConversationTurn{Role: role, Content: content})
+	return nil
+}
+
+func (state *fakeIngressState) ListRecentConversationTurns(ctx context.Context, channel string, target string, limit int) ([]ConversationTurn, error) {
+	if channel != "telegram" {
+		return nil, nil
+	}
+	turns := state.turns[target]
+	if len(turns) <= limit {
+		return append([]ConversationTurn{}, turns...), nil
+	}
+	return append([]ConversationTurn{}, turns[len(turns)-limit:]...), nil
 }
 
 func mustTime(t *testing.T, raw string) time.Time {

--- a/go/handler/internal/state/sqlite/sqlite.go
+++ b/go/handler/internal/state/sqlite/sqlite.go
@@ -85,6 +85,11 @@ type TelegramAttachmentCleanupResult struct {
 	ReclaimedBytes int64
 }
 
+type ConversationTurn struct {
+	Role    string
+	Content string
+}
+
 type GitHubAssignmentCheckpoint struct {
 	EventCreatedAt time.Time
 	EventID        string
@@ -176,6 +181,15 @@ func (store *Store) initialize(ctx context.Context) error {
 			deleted_at TEXT,
 			cleanup_attempts INTEGER NOT NULL,
 			last_cleanup_error TEXT
+		)`,
+		`CREATE TABLE IF NOT EXISTS conversation_turns (
+			turn_id INTEGER PRIMARY KEY AUTOINCREMENT,
+			channel TEXT NOT NULL,
+			target TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT NOT NULL,
+			run_id TEXT,
+			created_at TEXT NOT NULL
 		)`,
 		`CREATE TABLE IF NOT EXISTS github_assignment_checkpoints (
 			scope_key TEXT PRIMARY KEY,
@@ -561,6 +575,86 @@ func (store *Store) ListTelegramChats(ctx context.Context) ([]TelegramChatRecord
 		records = append(records, record)
 	}
 	return records, rows.Err()
+}
+
+func (store *Store) AppendConversationTurn(ctx context.Context, channel string, target string, role string, content string, runID string) error {
+	if strings.TrimSpace(channel) == "" {
+		return errors.New("channel is required")
+	}
+	if strings.TrimSpace(target) == "" {
+		return errors.New("target is required")
+	}
+	if role != "user" && role != "assistant" {
+		return errors.New("role must be user or assistant")
+	}
+	if strings.TrimSpace(content) == "" {
+		return errors.New("content is required")
+	}
+	if runID != "" && strings.TrimSpace(runID) == "" {
+		return errors.New("run_id must not be empty")
+	}
+	_, err := store.db.ExecContext(
+		ctx,
+		`INSERT INTO conversation_turns (
+			channel,
+			target,
+			role,
+			content,
+			run_id,
+			created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		channel,
+		target,
+		role,
+		content,
+		nullIfEmpty(runID),
+		formatTimestamp(time.Now()),
+	)
+	return err
+}
+
+func (store *Store) ListRecentConversationTurns(ctx context.Context, channel string, target string, limit int) ([]ConversationTurn, error) {
+	if strings.TrimSpace(channel) == "" {
+		return nil, errors.New("channel is required")
+	}
+	if strings.TrimSpace(target) == "" {
+		return nil, errors.New("target is required")
+	}
+	if limit <= 0 {
+		return nil, errors.New("limit must be positive")
+	}
+	rows, err := store.db.QueryContext(
+		ctx,
+		`SELECT role, content
+		FROM conversation_turns
+		WHERE channel = ? AND target = ?
+		ORDER BY turn_id DESC
+		LIMIT ?`,
+		channel,
+		target,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	reversed := make([]ConversationTurn, 0, limit)
+	for rows.Next() {
+		turn := ConversationTurn{}
+		if err := rows.Scan(&turn.Role, &turn.Content); err != nil {
+			return nil, err
+		}
+		reversed = append(reversed, turn)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	turns := make([]ConversationTurn, 0, len(reversed))
+	for index := len(reversed) - 1; index >= 0; index-- {
+		turns = append(turns, reversed[index])
+	}
+	return turns, nil
 }
 
 func (store *Store) Seen(ctx context.Context, source string, dedupeKey string) (bool, error) {
@@ -966,6 +1060,13 @@ func nullableString(value *string) any {
 		return nil
 	}
 	return *value
+}
+
+func nullIfEmpty(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
 }
 
 func nullStringPointer(value sql.NullString) *string {

--- a/go/handler/internal/state/sqlite/sqlite_test.go
+++ b/go/handler/internal/state/sqlite/sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -137,6 +138,35 @@ func TestGitHubAssignmentCheckpointRoundTripUsesPythonCompatibleTable(t *testing
 	}
 
 	assertGitHubAssignmentCheckpointSchemaAndPayload(t, dbPath, scopeKey, checkpoint)
+}
+
+func TestConversationTurnsRoundTripScopedByChannelAndTarget(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	if err := store.AppendConversationTurn(ctx, "telegram", "12345", "user", "hello", "task:1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AppendConversationTurn(ctx, "telegram", "12345", "assistant", "hi there", "task:1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AppendConversationTurn(ctx, "telegram", "67890", "user", "wrong chat", "task:2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AppendConversationTurn(ctx, "email", "12345", "user", "wrong channel", "task:3"); err != nil {
+		t.Fatal(err)
+	}
+
+	turns, err := store.ListRecentConversationTurns(ctx, "telegram", "12345", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := turns, []ConversationTurn{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi there"},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("turns = %#v, want %#v", got, want)
+	}
 }
 
 func TestRecordTaskRoundTripsAndUsesPythonCompatibleTable(t *testing.T) {


### PR DESCRIPTION
## Summary
- restore Python-style Telegram conversation history enrichment in the Go handler before ingress tasks are recorded and published
- persist Telegram conversation turns in the Go SQLite state for both inbound user messages and dispatched assistant replies, including attachment-only replies
- add regression coverage for Telegram history enrichment and assistant-turn persistence across runtime, egress, and SQLite state tests

## Testing
- go test ./...

Closes #216
