### PR TITLE
Persist gh-backed git auth across redeploys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu ripgrep sqlite3 \
     && npm install -g @openai/codex @anthropic-ai/claude-code \
+    && git config --system credential.helper '!/usr/bin/gh auth git-credential' \
     && npm cache clean --force \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -86,9 +86,14 @@ When using real executor mode, authenticate the CLIs once inside the worker cont
 persisted in Docker volumes.
 
 ```bash
+docker compose run --rm worker gh auth login
 docker compose run --rm worker codex login
 docker compose run --rm worker claude login
 ```
+
+The runtime image already configures Git to use `gh auth git-credential`, so you do not need a
+separate `gh auth setup-git` step after redeploys. The `gh-auth` Docker volume persists the GitHub
+CLI login itself.
 
 ## 7) Run tests
 

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -171,12 +171,18 @@ volumes.
 The compose file mounts:
 - `codex-auth` -> `/home/chatting/.codex`
 - `claude-auth` -> `/home/chatting/.claude`
+- `gh-auth` -> `/home/chatting/.config/gh`
 
 One-time bootstrap:
 
 ```bash
+docker compose run --rm worker gh auth login
 docker compose run --rm worker codex login
 docker compose run --rm worker claude login
 ```
 
 The compose stack publishes the worker activity UI on `9465`.
+
+The runtime image already sets Git's credential helper to `gh auth git-credential` at the system
+level, so plain `git push` keeps working after container replacement as long as the `gh-auth`
+volume still contains a valid `gh` login.


### PR DESCRIPTION
## Summary
- configure the runtime image's system git credential helper to use 'gh auth git-credential'
- remove the need for per-container 'gh auth setup-git' after redeploys
- document that the existing gh-auth volume is enough to keep plain git push working

## Problem
The existing compose setup already persists /home/chatting/.config/gh, so gh auth login survives redeploys. But gh auth setup-git writes Git's credential helper wiring to ~/.gitconfig, which is not on a persisted volume. After a fresh container, 'gh auth status' can still show a valid login while plain 'git push' loses the helper configuration.

## Testing
- not run (Dockerfile/docs change only)
