### PR TITLE
Auto-reply on non-approved Telegram channels

### DIFF
--- a/app/internal_notices.py
+++ b/app/internal_notices.py
@@ -1,0 +1,53 @@
+"""Shared helpers for deterministic internal notice tasks."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.broker import EgressQueueMessage, TaskQueueMessage
+from app.models import OutboundMessage, TaskEnvelope
+
+INTERNAL_NOTICE_METADATA_KEY = "internal_notice"
+TELEGRAM_CHANNEL_NOT_ENABLED_NOTICE = "telegram_channel_not_enabled"
+
+
+def is_internal_telegram_channel_not_enabled_envelope(
+    envelope: TaskEnvelope,
+) -> bool:
+    return (
+        envelope.source == "internal"
+        and envelope.reply_channel.type == "telegram"
+        and envelope.reply_channel.metadata.get(INTERNAL_NOTICE_METADATA_KEY)
+        == TELEGRAM_CHANNEL_NOT_ENABLED_NOTICE
+    )
+
+
+def build_internal_telegram_channel_not_enabled_egress(
+    *,
+    task_message: TaskQueueMessage,
+    emitted_at: datetime,
+) -> EgressQueueMessage:
+    current_time = _ensure_utc(emitted_at)
+    return EgressQueueMessage(
+        task_id=task_message.task_id,
+        envelope_id=task_message.envelope.id,
+        trace_id=task_message.trace_id,
+        event_index=0,
+        event_count=2,
+        message=OutboundMessage(
+            channel=task_message.envelope.reply_channel.type,
+            target=task_message.envelope.reply_channel.target,
+            body=task_message.envelope.content,
+        ),
+        emitted_at=current_time,
+        event_id=f"evt:{task_message.task_id}:0:message:telegram-channel-not-enabled",
+        sequence=0,
+        event_kind="message",
+        message_type="chatting.egress.v2",
+    )
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError("datetime must be timezone-aware")
+    return value.astimezone(timezone.utc)

--- a/app/worker/runtime.py
+++ b/app/worker/runtime.py
@@ -14,6 +14,10 @@ from app.internal_heartbeat import (
     build_internal_heartbeat_egress,
     is_internal_heartbeat_envelope,
 )
+from app.internal_notices import (
+    build_internal_telegram_channel_not_enabled_egress,
+    is_internal_telegram_channel_not_enabled_envelope,
+)
 from app.models import AuditEvent, OutboundMessage, RunRecord
 from app.state import SQLiteStateStore
 
@@ -46,6 +50,11 @@ def process_task_message(
         raise ValueError("max_attempts must be positive")
 
     envelope = task_message.envelope
+    if is_internal_telegram_channel_not_enabled_envelope(envelope):
+        return _process_internal_telegram_channel_not_enabled_notice(
+            store=store,
+            task_message=task_message,
+        )
     if is_internal_heartbeat_envelope(envelope):
         return _process_internal_heartbeat(
             store=store,
@@ -258,6 +267,69 @@ def _process_internal_heartbeat(
         dead_lettered=False,
         attempt_count=1,
         reason_codes=["internal_heartbeat"],
+        error_summary=None,
+    )
+
+
+def _process_internal_telegram_channel_not_enabled_notice(
+    *,
+    store: SQLiteStateStore,
+    task_message: TaskQueueMessage,
+) -> WorkerProcessResult:
+    emitted_at = datetime.now(timezone.utc)
+    visible_egress_message = build_internal_telegram_channel_not_enabled_egress(
+        task_message=task_message,
+        emitted_at=emitted_at,
+    )
+    completion_egress_message = build_internal_completion_egress(
+        task_message=task_message,
+        sequence=1,
+        emitted_at=emitted_at,
+    )
+    run_record = RunRecord(
+        run_id=f"run:{task_message.task_id}:{time.time_ns()}",
+        envelope_id=task_message.envelope.id,
+        source=task_message.envelope.source,
+        workflow="default",
+        latency_ms=0,
+        result_status="success",
+        created_at=emitted_at,
+    )
+    store.append_run(run_record)
+    store.append_audit_event(
+        AuditEvent(
+            run_id=run_record.run_id,
+            envelope_id=run_record.envelope_id,
+            source=run_record.source,
+            workflow=run_record.workflow,
+            result_status=run_record.result_status,
+            detail={
+                "trace_id": task_message.trace_id,
+                "task_id": task_message.task_id,
+                "reason_codes": ["internal_notice"],
+                "attempt_count": 1,
+                "max_attempts": 1,
+                "last_error": None,
+                "last_error_stage": None,
+                "execution_result": {
+                    "errors": [],
+                },
+                "incremental_reply_send_requested_count": 0,
+                "incremental_reply_send_published_count": 0,
+                "egress_message_count": 2,
+                "internal_notice": (
+                    task_message.envelope.reply_channel.metadata.get("internal_notice")
+                ),
+            },
+            created_at=run_record.created_at,
+        )
+    )
+    return WorkerProcessResult(
+        run_record=run_record,
+        egress_messages=[visible_egress_message, completion_egress_message],
+        dead_lettered=False,
+        attempt_count=1,
+        reason_codes=["internal_notice"],
         error_summary=None,
     )
 

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -42,8 +42,8 @@ Matching CLI flags exist (`--telegram-enabled`, `--telegram-bot-token-env`, etc.
 - Photo-only messages are accepted with synthesized content `[photo attached]`.
 - Location-only messages are accepted with synthesized content that includes latitude, longitude, and a map URL.
 - When a message includes both text and a Telegram `location`, the location block is appended to the text so the worker can reason over both in one prompt.
-- `channel_post` updates are ignored unless the channel ID is present in `telegram_allowed_channel_ids`.
-- Ignored `channel_post` updates log `update_id`, `channel_id`, and an explicit reason so new channel IDs can be copied from logs.
+- `channel_post` updates from allowlisted channel IDs are ingested normally.
+- `channel_post` updates from other channel IDs still update `telegram_chat_registry`, then trigger an automatic Telegram reply that includes the channel ID so it can be copied into `telegram_allowed_channel_ids`.
 - Each observed `message`, `channel_post`, and `my_chat_member` chat is upserted into the handler SQLite table `telegram_chat_registry` before allowlist filtering. Query that table to discover new DM/group/supergroup/channel IDs, titles, usernames, and the latest retrieval timestamp.
 - Offset is advanced as `highest_update_id + 1` each poll.
 - The message handler tracks downloaded Telegram attachments in its SQLite DB and only makes them cleanup-eligible after the task reaches terminal completion.

--- a/go/handler/internal/connectors/telegram/telegram.go
+++ b/go/handler/internal/connectors/telegram/telegram.go
@@ -21,6 +21,9 @@ import (
 
 const Source = "im"
 
+const internalNoticeKey = "internal_notice"
+const telegramChannelNotEnabledNotice = "telegram_channel_not_enabled"
+
 type ChatObservation struct {
 	ChatID      string
 	ChatType    *string
@@ -197,10 +200,37 @@ func (connector *Connector) normalizeChannelPost(ctx context.Context, updateID i
 	if err := connector.observeChat(ctx, updateID, "channel_post", message.Chat, messageDate); err != nil {
 		return nil, err
 	}
-	if message.Chat.Type != "channel" || len(connector.allowedChannelIDs) == 0 || !connector.allowedChannelIDs[chatID] {
+	if message.Chat.Type != "channel" {
 		return nil, nil
 	}
+	if len(connector.allowedChannelIDs) == 0 || !connector.allowedChannelIDs[chatID] {
+		return connector.buildDisallowedChannelNoticeEnvelope(updateID, message, chatID), nil
+	}
 	return connector.buildEnvelope(updateID, message, chatID, connector.actorFromChat(message.SenderChat))
+}
+
+func (connector *Connector) buildDisallowedChannelNoticeEnvelope(updateID int64, message telegramMessage, chatID string) *contracts.TaskEnvelope {
+	eventID := "telegram-disallowed-channel:" + strconv.FormatInt(updateID, 10)
+	actor := "message-handler"
+	return &contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            eventID,
+		Source:        "internal",
+		ReceivedAt:    contracts.NewTimestamp(parseTelegramDate(message.Date, connector.now())),
+		Actor:         &actor,
+		Content:       fmt.Sprintf("Not enabled in channel %s. Add this id to telegram_allowed_channel_ids to enable replies here.", chatID),
+		Attachments:   []contracts.AttachmentRef{},
+		ContextRefs:   []string{},
+		ReplyChannel: contracts.ReplyChannel{
+			Type:   "telegram",
+			Target: chatID,
+			Metadata: map[string]any{
+				"message_id":      message.MessageID,
+				internalNoticeKey: telegramChannelNotEnabledNotice,
+			},
+		},
+		DedupeKey: eventID,
+	}
 }
 
 func (connector *Connector) buildEnvelope(updateID int64, message telegramMessage, chatID string, actor *string) (*contracts.TaskEnvelope, error) {

--- a/go/handler/internal/connectors/telegram/telegram_test.go
+++ b/go/handler/internal/connectors/telegram/telegram_test.go
@@ -182,6 +182,68 @@ func TestPollNormalizesAllowedChannelPostAndMyChatMemberObservation(t *testing.T
 	}
 }
 
+func TestPollBuildsInternalNoticeForDisallowedChannelPost(t *testing.T) {
+	client := &fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(`{
+			"ok": true,
+			"result": [
+				{
+					"update_id": 2101,
+					"channel_post": {
+						"message_id": 19,
+						"date": 1779345600,
+						"chat": {"id": -100777, "type": "channel", "title": "Ops"},
+						"sender_chat": {"id": -100777, "type": "channel", "title": "Ops"},
+						"text": "hello"
+					}
+				}
+			]
+		}`), nil
+	}}
+	observed := []ChatObservation{}
+	connector, err := New(Config{
+		BotToken:          "token",
+		AllowedChannelIDs: []string{"-100999"},
+		HTTPClient:        client,
+		ObserveChat: func(ctx context.Context, observation ChatObservation) error {
+			observed = append(observed, observation)
+			return nil
+		},
+		Now: func() time.Time { return mustTime(t, "2026-05-21T06:40:00Z") },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	envelope := envelopes[0]
+	if envelope.Source != "internal" {
+		t.Fatalf("source = %q", envelope.Source)
+	}
+	if envelope.ReplyChannel.Type != "telegram" || envelope.ReplyChannel.Target != "-100777" {
+		t.Fatalf("reply channel = %#v", envelope.ReplyChannel)
+	}
+	if envelope.Content != "Not enabled in channel -100777. Add this id to telegram_allowed_channel_ids to enable replies here." {
+		t.Fatalf("content = %q", envelope.Content)
+	}
+	if envelope.ReplyChannel.Metadata["internal_notice"] != "telegram_channel_not_enabled" {
+		t.Fatalf("metadata = %#v", envelope.ReplyChannel.Metadata)
+	}
+	if envelope.ReplyChannel.Metadata["message_id"] != float64(19) && envelope.ReplyChannel.Metadata["message_id"] != int64(19) {
+		t.Fatalf("metadata = %#v", envelope.ReplyChannel.Metadata)
+	}
+	if len(observed) != 1 || observed[0].ChatID != "-100777" || observed[0].UpdateKind != "channel_post" {
+		t.Fatalf("observed = %#v", observed)
+	}
+}
+
 func TestPollDownloadsPhotoAttachmentAndUsesCaptionAsContent(t *testing.T) {
 	attachmentDir := t.TempDir()
 	requestedURLs := []string{}

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -7,6 +7,10 @@ import json
 
 from app.broker import TaskQueueMessage
 from app.internal_heartbeat import build_internal_heartbeat_envelope
+from app.internal_notices import (
+    INTERNAL_NOTICE_METADATA_KEY,
+    TELEGRAM_CHANNEL_NOT_ENABLED_NOTICE,
+)
 from app.models import (
     ExecutionResult,
     ReplyChannel,
@@ -109,6 +113,35 @@ class WorkerRuntimeTests(unittest.TestCase):
                 now=datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc),
             ),
             trace_id="trace:internal:heartbeat:1",
+        )
+
+    def _build_internal_channel_notice_task_message(self) -> TaskQueueMessage:
+        envelope = TaskEnvelope(
+            id="telegram-disallowed-channel:2101",
+            source="internal",
+            received_at=datetime(2026, 6, 25, 8, 0, tzinfo=timezone.utc),
+            actor="message-handler",
+            content=(
+                "Not enabled in channel -100777. "
+                "Add this id to telegram_allowed_channel_ids to enable replies here."
+            ),
+            attachments=[],
+            context_refs=[],
+            reply_channel=ReplyChannel(
+                type="telegram",
+                target="-100777",
+                metadata={
+                    INTERNAL_NOTICE_METADATA_KEY: (
+                        TELEGRAM_CHANNEL_NOT_ENABLED_NOTICE
+                    ),
+                    "message_id": 19,
+                },
+            ),
+            dedupe_key="telegram-disallowed-channel:2101",
+        )
+        return TaskQueueMessage.from_envelope(
+            envelope,
+            trace_id="trace:internal:telegram-disallowed-channel:2101",
         )
 
     def test_process_task_message_emits_completion_only_for_successful_task(
@@ -326,6 +359,42 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertEqual(terminal.message.channel, "internal")
             self.assertEqual(terminal.message.target, "task")
             self.assertEqual(terminal.sequence, 0)
+
+    def test_process_task_message_handles_internal_channel_notice_without_executor(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            result = process_task_message(
+                store=store,
+                task_message=self._build_internal_channel_notice_task_message(),
+                executor_impl=AlwaysFailExecutor(),
+                max_attempts=2,
+                activity_monitor=self._build_monitor(store),
+            )
+
+            self.assertEqual(result.run_record.result_status, "success")
+            self.assertEqual(result.run_record.source, "internal")
+            self.assertEqual(len(result.egress_messages), 2)
+            visible_egress_message = result.egress_messages[0]
+            completion_egress_message = result.egress_messages[1]
+            self.assertEqual(visible_egress_message.event_kind, "message")
+            self.assertEqual(visible_egress_message.message.channel, "telegram")
+            self.assertEqual(visible_egress_message.message.target, "-100777")
+            self.assertEqual(
+                visible_egress_message.message.body,
+                "Not enabled in channel -100777. Add this id to telegram_allowed_channel_ids to enable replies here.",
+            )
+            self.assertEqual(completion_egress_message.event_kind, "completion")
+            self.assertEqual(completion_egress_message.sequence, 1)
+            self.assertEqual(result.reason_codes, ["internal_notice"])
+            self.assertIsNone(result.error_summary)
+            audit_event = store.list_audit_events()[0]
+            self.assertEqual(audit_event.detail["reason_codes"], ["internal_notice"])
+            self.assertEqual(
+                audit_event.detail["internal_notice"],
+                "telegram_channel_not_enabled",
+            )
 
     def test_build_error_summary_prefers_execution_error_then_last_error_then_fallback(
         self,


### PR DESCRIPTION
## Summary

- reply to disallowed Telegram channel posts with a stock message containing the channel id
- route those notices through an internal task so the worker can emit the Telegram reply without invoking Codex
- add focused worker and Telegram connector coverage plus connector docs updates

Closes #220
