### PR TITLE
Drop and report egress dispatch failures instead of crashing

### DIFF
--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -5,9 +5,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -100,11 +102,12 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 	if err != nil {
 		return nil, err
 	}
-	dispatcher, err := buildDispatcher(config)
+	dispatcher, emailSender, err := buildDispatcher(config)
 	if err != nil {
 		_ = store.Close()
 		return nil, err
 	}
+	errorEmailRecipient := resolveErrorEmailRecipient(config)
 	egressOptions := []egress.Option{
 		egress.WithAllowedChannels(config.AllowedEgressChannels),
 		egress.WithCompletionHook(func(ctx context.Context, message contracts.EgressQueueMessage) error {
@@ -114,6 +117,11 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 			eligibleAfter := time.Now().UTC().Add(time.Duration(config.TelegramAttachmentCleanupGraceSeconds) * time.Second)
 			_, err := store.MarkTelegramTaskAttachmentsEligible(ctx, message.TaskID, eligibleAfter)
 			return err
+		}),
+		egress.WithDispatchFailureHook(func(ctx context.Context, message contracts.EgressQueueMessage, reasonCode string) {
+			log.Printf("egress_dispatch_failed task_id=%s event_id=%s channel=%s target=%s reason=%s",
+				message.TaskID, message.EventID, message.Message.Channel, message.Message.Target, reasonCode)
+			sendEgressDispatchErrorEmail(ctx, emailSender, errorEmailRecipient, message, reasonCode)
 		}),
 	}
 	engine, err := egress.New(
@@ -365,14 +373,14 @@ func (store githubCheckpointStore) SetGitHubCheckpoint(ctx context.Context, scop
 	})
 }
 
-func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, error) {
+func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, dispatch.EmailSender, error) {
 	dispatcher := dispatch.Dispatcher{}
 	if config.SMTPHost != "" {
 		password := ""
 		if config.SMTPUsername != "" {
 			password = os.Getenv(config.SMTPPasswordEnv)
 			if password == "" {
-				return nil, fmt.Errorf("missing SMTP password env var: %s", config.SMTPPasswordEnv)
+				return nil, nil, fmt.Errorf("missing SMTP password env var: %s", config.SMTPPasswordEnv)
 			}
 		}
 		sender, err := dispatch.NewSMTPEmailSender(dispatch.SMTPConfig{
@@ -386,14 +394,14 @@ func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, error) {
 			Timeout:     10 * time.Second,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		dispatcher.EmailSender = sender
 	}
 	if config.TelegramEnabled {
 		token := os.Getenv(config.TelegramBotTokenEnv)
 		if token == "" {
-			return nil, fmt.Errorf("missing Telegram bot token env var: %s", config.TelegramBotTokenEnv)
+			return nil, nil, fmt.Errorf("missing Telegram bot token env var: %s", config.TelegramBotTokenEnv)
 		}
 		sender, err := dispatch.NewTelegramMessageSender(dispatch.TelegramConfig{
 			BotToken:   token,
@@ -401,14 +409,53 @@ func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, error) {
 			Timeout:    10 * time.Second,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		dispatcher.TelegramSender = sender
 	}
 	if _, err := ghLookPath("gh"); err == nil {
 		dispatcher.GitHubSender = dispatch.NewGitHubIssueCommentSender(nil)
 	}
-	return dispatcher, nil
+	return dispatcher, dispatcher.EmailSender, nil
+}
+
+func resolveErrorEmailRecipient(config handlerconfig.Config) string {
+	for _, candidate := range []string{config.ErrorEmailTo, config.SMTPUsername, config.IMAPUsername} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// sendEgressDispatchErrorEmail notifies the operator that a single egress event could
+// not be delivered. The event has already been dropped so the handler keeps running;
+// this is the visibility half of that trade-off.
+func sendEgressDispatchErrorEmail(ctx context.Context, sender dispatch.EmailSender, recipient string, message contracts.EgressQueueMessage, reasonCode string) {
+	if sender == nil || strings.TrimSpace(recipient) == "" {
+		return
+	}
+	sequence := "None"
+	if message.Sequence != nil {
+		sequence = strconv.Itoa(*message.Sequence)
+	}
+	subject := "Chatting handler dispatch error: " + reasonCode
+	body := strings.Join([]string{
+		"Message-handler egress dispatch failed.",
+		"task_id: " + message.TaskID,
+		"envelope_id: " + message.EnvelopeID,
+		"trace_id: " + message.TraceID,
+		"event_id: " + message.EventID,
+		"sequence: " + sequence,
+		"event_kind: " + message.EventKind,
+		"channel: " + message.Message.Channel,
+		"target: " + message.Message.Target,
+		"reason_code: " + reasonCode,
+	}, "\n")
+	if err := sender.Send(ctx, recipient, body, &subject); err != nil {
+		log.Printf("egress_dispatch_error_email_failed task_id=%s event_id=%s reason=%s recipient=%s err=%v",
+			message.TaskID, message.EventID, reasonCode, recipient, err)
+	}
 }
 
 type egressHandlerFunc func(context.Context, []byte) error

--- a/go/handler/cmd/chatting-handler/main_test.go
+++ b/go/handler/cmd/chatting-handler/main_test.go
@@ -162,7 +162,7 @@ func TestUnsupportedDispatcherAcceptsInternalHeartbeatLogPong(t *testing.T) {
 
 func TestBuildDispatcherRequiresSMTPPasswordEnvWhenUsernameConfigured(t *testing.T) {
 	t.Setenv("MISSING_SMTP_PASSWORD", "")
-	_, err := buildDispatcher(handlerconfig.Config{
+	_, _, err := buildDispatcher(handlerconfig.Config{
 		SMTPHost:        "smtp.example.com",
 		SMTPPort:        587,
 		SMTPUsername:    "bot@example.com",
@@ -179,7 +179,7 @@ func TestBuildDispatcherRequiresSMTPPasswordEnvWhenUsernameConfigured(t *testing
 
 func TestBuildDispatcherRequiresTelegramTokenWhenEnabled(t *testing.T) {
 	t.Setenv("MISSING_TELEGRAM_TOKEN", "")
-	_, err := buildDispatcher(handlerconfig.Config{
+	_, _, err := buildDispatcher(handlerconfig.Config{
 		TelegramEnabled:     true,
 		TelegramBotTokenEnv: "MISSING_TELEGRAM_TOKEN",
 		TelegramAPIBaseURL:  "https://api.telegram.org",
@@ -204,7 +204,7 @@ func TestBuildDispatcherConfiguresGitHubWhenGHAvailable(t *testing.T) {
 		ghLookPath = originalLookPath
 	}()
 
-	dispatcher, err := buildDispatcher(handlerconfig.Config{})
+	dispatcher, _, err := buildDispatcher(handlerconfig.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func TestBuildDispatcherSkipsGitHubWhenGHUnavailable(t *testing.T) {
 		ghLookPath = originalLookPath
 	}()
 
-	dispatcher, err := buildDispatcher(handlerconfig.Config{})
+	dispatcher, _, err := buildDispatcher(handlerconfig.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -105,6 +105,7 @@ type Config struct {
 	SMTPFrom              string
 	SMTPStartTLS          bool
 	SMTPUseSSL            bool
+	ErrorEmailTo          string
 
 	TelegramEnabled                       bool
 	TelegramBotTokenEnv                   string
@@ -159,6 +160,7 @@ func Defaults() Config {
 		SMTPFrom:              "",
 		SMTPStartTLS:          false,
 		SMTPUseSSL:            true,
+		ErrorEmailTo:          "",
 
 		TelegramEnabled:                       false,
 		TelegramBotTokenEnv:                   "CHATTING_TELEGRAM_BOT_TOKEN",
@@ -399,6 +401,12 @@ func Load(raw []byte) (Config, error) {
 		}
 		if _, ok := payload["smtp_use_ssl"]; !ok {
 			config.SMTPUseSSL = !config.SMTPStartTLS
+		}
+	}
+	if rawValue, ok := payload["error_email_to"]; ok && !isNull(rawValue) {
+		config.ErrorEmailTo, err = decodeNonEmptyString(rawValue, "error_email_to")
+		if err != nil {
+			return Config{}, err
 		}
 	}
 	if rawValue, ok := payload["smtp_use_ssl"]; ok && !isNull(rawValue) {

--- a/go/handler/internal/dispatch/dispatch.go
+++ b/go/handler/internal/dispatch/dispatch.go
@@ -77,7 +77,7 @@ func (dispatcher Dispatcher) Dispatch(ctx context.Context, message contracts.Out
 			return nil, MessageDispatchError{ReasonCode: "telegram_dispatch_failed"}
 		}
 		if err := dispatcher.TelegramSender.React(ctx, target, messageID, *message.Body); err != nil {
-			return nil, MessageDispatchError{ReasonCode: "telegram_dispatch_failed"}
+			return nil, MessageDispatchError{ReasonCode: telegramDispatchReasonCode(message, err)}
 		}
 		return &normalized, nil
 	case "github":

--- a/go/handler/internal/dispatch/dispatch_test.go
+++ b/go/handler/internal/dispatch/dispatch_test.go
@@ -308,6 +308,27 @@ func TestTelegramMessageSenderSendsReaction(t *testing.T) {
 	}
 }
 
+func TestTelegramMessageSenderReactionFailurePreservesDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(writer).Encode(map[string]any{
+			"ok":          false,
+			"error_code":  400,
+			"description": "Bad Request: REACTION_INVALID",
+		})
+	}))
+	defer server.Close()
+	sender := newTestTelegramSender(t, server.URL)
+
+	err := sender.React(context.Background(), "12345", 99, "🙂")
+	if err == nil {
+		t.Fatal("expected reaction error")
+	}
+	if got, want := err.Error(), "telegram_reaction_failed description=Bad Request: REACTION_INVALID"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
 func TestTelegramMessageSenderSendsPhotoAttachment(t *testing.T) {
 	tempDir := t.TempDir()
 	photoPath := filepath.Join(tempDir, "plant.png")

--- a/go/handler/internal/dispatch/telegram.go
+++ b/go/handler/internal/dispatch/telegram.go
@@ -107,7 +107,7 @@ func (sender *TelegramMessageSender) Send(ctx context.Context, target string, me
 			return nil
 		}
 	}
-	return errors.New("telegram_attachment_send_failed")
+	return errors.New(describeTelegramResponseError("telegram_attachment_send_failed", response))
 }
 
 func (sender *TelegramMessageSender) React(ctx context.Context, target string, messageID int64, emoji string) error {
@@ -129,7 +129,7 @@ func (sender *TelegramMessageSender) React(ctx context.Context, target string, m
 	}
 	response, err := sender.postJSON(ctx, "setMessageReaction", payload)
 	if err != nil || !response.OK {
-		return errors.New("telegram_reaction_failed")
+		return errors.New(describeTelegramResponseError("telegram_reaction_failed", response))
 	}
 	return nil
 }
@@ -154,7 +154,7 @@ func (sender *TelegramMessageSender) sendText(ctx context.Context, target string
 			return nil
 		}
 	}
-	return errors.New("telegram_send_failed")
+	return errors.New(describeTelegramResponseError("telegram_send_failed", response))
 }
 
 type telegramAPIResponse struct {
@@ -278,6 +278,16 @@ func telegramAPIMethodForAttachment(filePath string) string {
 
 func isTelegramParseModeError(response telegramAPIResponse) bool {
 	return strings.Contains(strings.ToLower(response.Description), "parse entities")
+}
+
+// describeTelegramResponseError appends the Telegram API description (for example
+// "Bad Request: REACTION_INVALID") to the reason code so dispatch failures are
+// diagnosable from the logged/emailed reason rather than an opaque code.
+func describeTelegramResponseError(prefix string, response telegramAPIResponse) string {
+	if description := strings.TrimSpace(response.Description); description != "" {
+		return prefix + " description=" + description
+	}
+	return prefix
 }
 
 func normalizeTelegramTextForParseMode(text string, parseMode *string) string {

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/dispatch"
 )
 
 type TaskRecord struct {
@@ -52,10 +53,11 @@ func (fn DispatcherFunc) Dispatch(ctx context.Context, message contracts.Outboun
 }
 
 type Engine struct {
-	state           State
-	dispatcher      Dispatcher
-	allowedChannels map[string]bool
-	onCompletion    func(context.Context, contracts.EgressQueueMessage) error
+	state             State
+	dispatcher        Dispatcher
+	allowedChannels   map[string]bool
+	onCompletion      func(context.Context, contracts.EgressQueueMessage) error
+	onDispatchFailure func(context.Context, contracts.EgressQueueMessage, string)
 }
 
 type Option func(*Engine)
@@ -72,6 +74,15 @@ func WithAllowedChannels(channels []string) Option {
 func WithCompletionHook(hook func(context.Context, contracts.EgressQueueMessage) error) Option {
 	return func(engine *Engine) {
 		engine.onCompletion = hook
+	}
+}
+
+// WithDispatchFailureHook registers a callback invoked when a single egress event
+// fails to dispatch. The event is dropped (acked) rather than crashing the handler,
+// so the hook is responsible for making the failure visible (log + operator email).
+func WithDispatchFailureHook(hook func(context.Context, contracts.EgressQueueMessage, string)) Option {
+	return func(engine *Engine) {
+		engine.onDispatchFailure = hook
 	}
 }
 
@@ -152,6 +163,9 @@ func (engine *Engine) Handle(ctx context.Context, message contracts.EgressQueueM
 			return Result{Status: StatusDropped, Reason: "invalid_payload"}, nil
 		}
 		if err := engine.dispatchAndMark(ctx, task, message); err != nil {
+			if reason, ok := dispatchFailureReason(err); ok {
+				return engine.dropFailedDispatch(ctx, message, reason)
+			}
 			return Result{}, err
 		}
 		return Result{Status: StatusDispatched}, nil
@@ -228,13 +242,49 @@ func (engine *Engine) Flush(ctx context.Context, taskID string) (Result, error) 
 			return Result{}, fmt.Errorf("staged event %s has disallowed channel %q", staged.EventID, message.Message.Channel)
 		}
 		if err := engine.dispatchAndMark(ctx, task, message); err != nil {
-			return Result{}, err
+			reason, ok := dispatchFailureReason(err)
+			if !ok {
+				return Result{}, err
+			}
+			if _, err := engine.dropFailedDispatch(ctx, message, reason); err != nil {
+				return Result{}, err
+			}
+			if err := engine.state.MarkStagedEventDispatched(ctx, taskID, staged.EventID, staged.Sequence); err != nil {
+				return Result{}, err
+			}
+			last = Result{Status: StatusDropped, Reason: "dispatch_failed"}
+			continue
 		}
 		if err := engine.state.MarkStagedEventDispatched(ctx, taskID, staged.EventID, staged.Sequence); err != nil {
 			return Result{}, err
 		}
 		last = Result{Status: StatusDispatched}
 	}
+}
+
+// dropFailedDispatch handles a permanent per-message dispatch failure: it surfaces
+// the failure (log + operator email via the hook), records the event as dispatched so
+// it is not retried, and reports the event as dropped. The egress message is acked by
+// the caller, so a single bad event no longer crash-loops the handler.
+func (engine *Engine) dropFailedDispatch(ctx context.Context, message contracts.EgressQueueMessage, reasonCode string) (Result, error) {
+	if engine.onDispatchFailure != nil {
+		engine.onDispatchFailure(ctx, message, reasonCode)
+	}
+	if err := engine.state.MarkDispatchedEventID(ctx, message.TaskID, message.EventID); err != nil {
+		return Result{}, err
+	}
+	return Result{Status: StatusDropped, Reason: "dispatch_failed"}, nil
+}
+
+// dispatchFailureReason reports whether err is a per-message dispatch failure (as
+// opposed to an infrastructure error that should still abort the run) and returns the
+// reason code, which carries any upstream API description.
+func dispatchFailureReason(err error) (string, bool) {
+	var dispatchErr dispatch.MessageDispatchError
+	if errors.As(err, &dispatchErr) {
+		return dispatchErr.ReasonCode, true
+	}
+	return "", false
 }
 
 func (engine *Engine) dispatchAndMark(ctx context.Context, task *TaskRecord, message contracts.EgressQueueMessage) error {

--- a/go/handler/internal/egress/egress_test.go
+++ b/go/handler/internal/egress/egress_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/dispatch"
 	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
 )
 
@@ -282,6 +283,63 @@ func TestHandleReturnsDispatchErrorWithoutMarkingEvent(t *testing.T) {
 	}
 	if state.dispatched[task.TaskID]["evt:incremental:1"] {
 		t.Fatal("failed dispatch was marked dispatched")
+	}
+}
+
+func TestHandleDropsAndNotifiesOnUnsequencedDispatchFailure(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	reason := "telegram_reaction_failed description=Bad Request: REACTION_INVALID"
+	dispatcher := &recordingDispatcher{err: dispatch.MessageDispatchError{ReasonCode: reason}}
+	var notified []string
+	engine := newTestEngineWithState(t, state, dispatcher,
+		WithAllowedChannels([]string{"email"}),
+		WithDispatchFailureHook(func(_ context.Context, message contracts.EgressQueueMessage, reasonCode string) {
+			notified = append(notified, message.EventID+"|"+reasonCode)
+		}),
+	)
+
+	result, err := engine.Handle(context.Background(), testEgressMessage(t, task, nil, "evt:incremental:1", "incremental"))
+	if err != nil {
+		t.Fatalf("dispatch failure must not crash the handler: %v", err)
+	}
+	if result.Status != StatusDropped || result.Reason != "dispatch_failed" {
+		t.Fatalf("result = %#v", result)
+	}
+	if want := []string{"evt:incremental:1|" + reason}; !reflect.DeepEqual(notified, want) {
+		t.Fatalf("notified = %#v, want %#v", notified, want)
+	}
+	if !state.dispatched[task.TaskID]["evt:incremental:1"] {
+		t.Fatal("dropped event should be marked dispatched to avoid reprocessing")
+	}
+}
+
+func TestFlushDropsAndContinuesOnSequencedDispatchFailure(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{err: dispatch.MessageDispatchError{ReasonCode: "telegram_send_failed description=Bad Request: chat not found"}}
+	notified := 0
+	engine := newTestEngineWithState(t, state, dispatcher,
+		WithAllowedChannels([]string{"email"}),
+		WithDispatchFailureHook(func(_ context.Context, _ contracts.EgressQueueMessage, _ string) { notified++ }),
+	)
+	first := testEgressMessage(t, task, intPtr(0), "evt:0", "message")
+	first.Message.Body = stringPtr("first")
+
+	result, err := engine.Handle(context.Background(), first)
+	if err != nil {
+		t.Fatalf("sequenced dispatch failure must not crash the handler: %v", err)
+	}
+	if result.Status != StatusDropped || result.Reason != "dispatch_failed" {
+		t.Fatalf("result = %#v", result)
+	}
+	if notified != 1 {
+		t.Fatalf("notified = %d, want 1", notified)
+	}
+	if got, _ := state.ExpectedSequence(context.Background(), task.TaskID); got != 1 {
+		t.Fatalf("expected sequence = %d, want 1 (must advance past the dropped event)", got)
 	}
 }
 


### PR DESCRIPTION
A single egress event Telegram rejected (a queued reaction with emoji that Telegram refuses, returning `400 Bad Request: REACTION_INVALID`) made the Go handler treat the dispatch failure as fatal and exit. Docker (`restart: unless-stopped`) restarted it, it re-read the same event from the head of the in-memory bbmb egress queue, and crash-looped — 1000+ restarts overnight, never draining the backlog and flapping the Grafana scrape-target-down alert for blink:9464. The failure was also invisible: the handler only logged an opaque `runtime error: telegram_dispatch_failed`, and the egress-failure-to-operator email that existed in the old Python handler was lost in the Python->Go rewrite.

Now a per-message `dispatch.MessageDispatchError` is acked, marked dispatched, and reported via a hook (log line plus operator email) instead of aborting the run, so one bad event can't take the process down or block everything queued behind it. Infrastructure errors (DB/bbmb) still propagate and abort as before. The Telegram sender preserves the API description in the reason code (e.g. `telegram_reaction_failed description=Bad Request: REACTION_INVALID`) where the reaction path previously discarded the underlying error.

The dispatch-failure email is restored to match the old Python behaviour (subject `Chatting handler dispatch error: <reason>`, structured body). Recipient resolves from new optional config `error_email_to`, falling back to `smtp_username` then `imap_username`, so no handler.json change is required in prod to get the failure emails — it defaults to the configured smtp/imap username.

Tests added: reaction failure preserves the description; unsequenced and sequenced dispatch failures drop and notify without crashing and advance past the bad event.

Validated locally: `go build ./...`, `go vet ./...`, `go test ./...` all pass, gofmt clean.