### PR TITLE
Install Hugo in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GO_ARCHIVE=go${GO_VERSION}.linux-amd64.tar.gz
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu ripgrep sqlite3 \
+    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu hugo ripgrep sqlite3 \
     && npm install -g @openai/codex @anthropic-ai/claude-code \
     && git config --system credential.helper '!/usr/bin/gh auth git-credential' \
     && npm cache clean --force \

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -106,10 +106,19 @@ EOF
 '
 ```
 
-## 5) Bootstrap CLI auth
+## 5) Bootstrap worker tools and CLI auth
 
-When using real executor mode, authenticate the CLIs once inside the worker container. Auth state is
-persisted in Docker volumes.
+The worker image includes `codex`, `claude`, and `hugo`.
+
+If you plan to build a Hugo site from the mounted workspace, you can sanity-check the bundled tool
+first:
+
+```bash
+docker compose run --rm worker hugo version
+```
+
+When using real executor mode, authenticate the CLIs once inside the worker container. Auth state
+is persisted in Docker volumes.
 
 ```bash
 docker compose run --rm worker gh auth login

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -170,9 +170,15 @@ docker compose exec worker python -m app.main_reply task:telegram:53 \
 
 ## 7) Docker worker CLI auth bootstrap
 
-When running with `docker-compose.yml`, the worker image includes both `codex` and `claude` CLIs.
-Auth is still external to the app and must be completed once interactively, then persisted in Docker
-volumes.
+When running with `docker-compose.yml`, the worker image includes `codex`, `claude`, and `hugo`.
+Auth is still external to the app and must be completed once interactively, then persisted in
+Docker volumes.
+
+If the mounted workspace contains a Hugo site, you can verify the tool is present with:
+
+```bash
+docker compose run --rm worker hugo version
+```
 
 The compose file mounts:
 - `codex-auth` -> `/home/chatting/.codex`


### PR DESCRIPTION
## Summary
- install Hugo in the published chatting runtime image so the worker can build Hugo sites from the mounted workspace
- document that the worker image now includes Hugo alongside Codex and Claude
- add a simple `hugo version` sanity-check step to the Docker docs

## Testing
- `git diff --check`
- Docker build not run in this worker because `docker` is not installed here
