### PR TITLE
Add SSH client to worker image

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           docker run --rm --entrypoint codex chatting:test --version
           docker run --rm --entrypoint claude chatting:test --version
-          docker run --rm chatting:test sh -lc 'uv --version && rg --version && go version'
+          docker run --rm chatting:test sh -lc 'uv --version && rg --version && go version && ssh -V'
 
       - name: Run unit tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GO_ARCHIVE=go${GO_VERSION}.linux-amd64.tar.gz
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu hugo ripgrep sqlite3 \
+    && apt-get install -y --no-install-recommends bubblewrap nodejs npm ca-certificates curl gh git gosu hugo openssh-client ripgrep sqlite3 \
     && npm install -g @openai/codex @anthropic-ai/claude-code \
     && git config --system credential.helper '!/usr/bin/gh auth git-credential' \
     && npm cache clean --force \


### PR DESCRIPTION
## Summary
- add openssh-client to the worker image packages
- verify ssh is bundled in Docker CI alongside the other expected CLIs

## Testing
- not run locally: docker is not installed in this worker
