### PR TITLE
Add chatting deploy automation via fourth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows:
+      - Publish Docker Image
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-chatting
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: deploy-blink
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: resolve target sha
+        id: target
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
+            target_sha="${{ github.event.workflow_run.head_sha }}"
+          else
+            target_sha="${{ github.sha }}"
+          fi
+
+          case "$target_sha" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+              ;;
+            *)
+              echo "unexpected target sha: $target_sha" >&2
+              exit 64
+              ;;
+          esac
+
+          echo "sha=$target_sha" >> "$GITHUB_OUTPUT"
+
+      - name: tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: fourth.ts.alcachofa.faith
+
+      - name: install ssh key
+        run: |
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "${{ secrets.FOURTH_DEPLOY_SSH_KEY }}" > ~/.ssh/deploy
+          chmod 0600 ~/.ssh/deploy
+
+      - name: trigger blink deploy on the orchestrator
+        run: |
+          ssh \
+            -i ~/.ssh/deploy \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new \
+            deploy@fourth.ts.alcachofa.faith \
+            "blink ${{ steps.target.outputs.sha }}"

--- a/deploy/blink.sh
+++ b/deploy/blink.sh
@@ -20,5 +20,8 @@ ssh \
   -i "$KEY" \
   -o IdentitiesOnly=yes \
   -o StrictHostKeyChecking=accept-new \
-  root@blink.int.alcachofa.faith \
-  "chatting-deploy $TARGET_SHA"
+  edward@blink.int.alcachofa.faith \
+  "cd /home/edward/develop/chatting && \
+   export CHATTING_RUNTIME_IMAGE=ghcr.io/edwardsalkeld/chatting:sha-$SHORT_SHA && \
+   docker compose pull && \
+   docker compose up -d"

--- a/deploy/blink.sh
+++ b/deploy/blink.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEY="${ONWARD_SSH_KEY:?dispatcher must set ONWARD_SSH_KEY}"
+TARGET_SHA="${1:-}"
+
+if [[ -z "$TARGET_SHA" ]]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  TARGET_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+fi
+
+[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "usage: deploy/blink.sh <40-char commit sha>" >&2
+  exit 64
+}
+
+SHORT_SHA="${TARGET_SHA:0:7}"
+echo "==> deploy chatting@$SHORT_SHA to blink"
+ssh \
+  -i "$KEY" \
+  -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=accept-new \
+  root@blink.int.alcachofa.faith \
+  "chatting-deploy $TARGET_SHA"


### PR DESCRIPTION
## Summary

- add a deploy workflow that triggers from a successful `Publish Docker Image` run on `main`
- pass the exact target commit SHA through to `fourth` so deploys do not race a newer `main`
- add `deploy/blink.sh` as the repo-owned deploy entrypoint for the `fourth` orchestrator

## Notes

- depends on the matching house and lab PRs to be fully live
- manual `workflow_dispatch` still works and deploys the selected GitHub ref SHA
