### PR TITLE
Default handler metrics bind to 0.0.0.0 in host runtime renderer

### DIFF
--- a/deploy/host_runtime/README.md
+++ b/deploy/host_runtime/README.md
@@ -46,7 +46,8 @@ Useful overrides:
 - `--worker-state-dir`
 - `--config-dir`
 - `--bbmb-address`
-- `--metrics-host`
+- `--metrics-host` (defaults to `0.0.0.0` so an external Prometheus can scrape
+  the handler; firewall-gated. Pass `127.0.0.1` for local-only metrics.)
 
 This rewrites:
 

--- a/deploy/host_runtime/render_runtime_config.py
+++ b/deploy/host_runtime/render_runtime_config.py
@@ -50,8 +50,13 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--metrics-host",
-        default="127.0.0.1",
-        help="Metrics bind host for the rendered handler config.",
+        default="0.0.0.0",
+        help=(
+            "Metrics bind host for the rendered handler config. Defaults to "
+            "0.0.0.0 so an external Prometheus can scrape the handler; the host "
+            "firewall is expected to gate access. Use 127.0.0.1 to keep metrics "
+            "local-only."
+        ),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
The host_runtime renderer produces /etc/chatting/handler.json, and its --metrics-host defaulted to 127.0.0.1. On the new magpie NixOS host that made the handler's Prometheus endpoint (:9464) bind localhost-only, so partridge's Prometheus couldn't scrape it and the billy dashboard job had no data. On blink this was masked because Docker port-forwarded the port.

Defaulting to 0.0.0.0 means a plain re-render produces a scrapable handler; the host firewall gates actual exposure (magpie only opens 9464/9877 to the LAN). Operators can still pass --metrics-host 127.0.0.1 for local-only metrics. This makes the fix already live on magpie survive a future re-render.

Default-only change. tests/test_host_runtime_render_config.py calls render_runtime_config() with an explicit metrics_host, so covered behaviour is unchanged and it still passes.