### PR TITLE
Hide heartbeat runs and slim the worker UI

### DIFF
--- a/app/state/sqlite_store.py
+++ b/app/state/sqlite_store.py
@@ -252,12 +252,18 @@ class SQLiteStateStore:
             for row in rows
         ]
 
-    def list_recent_runs(self, *, limit: int) -> list[RunRecord]:
+    def list_recent_runs(
+        self, *, limit: int, include_internal: bool = False
+    ) -> list[RunRecord]:
         if limit <= 0:
             raise ValueError("limit must be positive")
+        # Internal runs (heartbeats) dominate the table, so exclude them in SQL
+        # rather than after the limit — otherwise the limited window is almost
+        # entirely heartbeats and real runs never surface.
+        where = "" if include_internal else "WHERE source != 'internal'"
         with closing(self._connect()) as connection:
             rows = connection.execute(
-                "SELECT * FROM run_records ORDER BY created_at DESC LIMIT ?",
+                f"SELECT * FROM run_records {where} ORDER BY created_at DESC LIMIT ?",
                 (limit,),
             ).fetchall()
         return [

--- a/app/worker/activity.py
+++ b/app/worker/activity.py
@@ -238,7 +238,10 @@ class WorkerActivityMonitor:
                 else dict(self._active_executor)
             )
         runs = []
-        for run in self._store.list_recent_runs(limit=self._history_limit):
+        for run in self._store.list_recent_runs(
+            limit=self._history_limit,
+            include_internal=include_internal,
+        ):
             run_summary = self._build_run_summary(
                 run_id=run.run_id,
                 include_internal=include_internal,
@@ -545,7 +548,7 @@ def _render_runs_index_html(
     .run-card:hover {{ border-color: var(--accent); transform: translateY(-1px); }}
     .run-kicker {{ display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }}
     .run-title {{ margin: 10px 0 8px; font-size: 23px; line-height: 1.2; }}
-    .run-preview {{ margin: 0 0 12px; font-size: 16px; color: #2d2823; }}
+    .run-preview {{ margin: 0 0 12px; font-size: 16px; color: #2d2823; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }}
     .chips {{ display: flex; gap: 8px; flex-wrap: wrap; }}
     .chip {{ display: inline-flex; align-items: center; gap: 4px; border-radius: 999px; padding: 4px 9px; background: rgba(31, 111, 120, 0.08); font-size: 13px; color: var(--muted); }}
     .chip.status-success {{ background: rgba(47, 107, 59, 0.12); color: var(--success); }}
@@ -619,21 +622,18 @@ def _render_runs_index(runs: list[object], *, include_internal: bool) -> str:
         )
         preview = str(item.get("preview", "")).strip() or "No captured message preview."
         title = str(item.get("task_id", "")) or run_id
+        # Keep the row scannable: status/source/latency only; the rest is on the
+        # detail page.
         chips = [
             ("status", str(item.get("result_status", ""))),
             ("source", str(item.get("source", ""))),
-            ("events", str(item.get("event_count", ""))),
             ("latency", f"{item.get('latency_ms', 0)} ms"),
         ]
-        latest_phase = item.get("latest_phase")
-        if isinstance(latest_phase, str) and latest_phase:
-            chips.append(("phase", latest_phase))
         items.append(
             "<li>"
             f"<a class='run-card' href='{html.escape(href)}'>"
             "<div class='run-kicker'>"
             f"<span>{html.escape(_friendly_timestamp(item.get('created_at')))}</span>"
-            f"<span>{html.escape(run_id)}</span>"
             "</div>"
             f"<h2 class='run-title'>{html.escape(title)}</h2>"
             f"<p class='run-preview'>{html.escape(preview)}</p>"
@@ -728,7 +728,8 @@ def _render_run_detail_html(
     .timeline-item {{ border-radius: 18px; padding: 16px; }}
     .timeline-kicker {{ display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; }}
     .timeline-item h3 {{ margin-top: 8px; font-size: 21px; }}
-    .timeline-message {{ margin-top: 10px; padding: 12px 14px; background: rgba(154, 52, 18, 0.06); border-radius: 14px; white-space: pre-wrap; word-break: break-word; }}
+    .timeline-message {{ margin-top: 10px; padding: 12px 14px; background: rgba(154, 52, 18, 0.06); border-radius: 14px; white-space: pre-wrap; word-break: break-word; max-height: 320px; overflow: auto; }}
+    details summary {{ cursor: pointer; font-family: "Iowan Old Style", Georgia, serif; font-size: 21px; margin-bottom: 10px; }}
     pre, code {{ white-space: pre-wrap; word-break: break-word; font-size: 12px; }}
     @media (max-width: 720px) {{
       main {{ padding: 12px 12px 28px; }}
@@ -766,8 +767,10 @@ def _render_run_detail_html(
       {timeline_markup}
     </section>
     <section class="panel">
-      <h2>Audit Detail</h2>
-      <pre><code>{audit_json}</code></pre>
+      <details>
+        <summary>Audit detail (raw JSON)</summary>
+        <pre><code>{audit_json}</code></pre>
+      </details>
     </section>
   </main>
 </body>

--- a/tests/test_worker_activity.py
+++ b/tests/test_worker_activity.py
@@ -220,7 +220,7 @@ class WorkerActivityTests(unittest.TestCase):
                 self.assertIn("executor started (attempt 1)", detail_html)
                 self.assertIn("warning line", detail_html)
                 self.assertIn("all runs", detail_html)
-                self.assertIn("Audit Detail", detail_html)
+                self.assertIn("Audit detail (raw JSON)", detail_html)
             finally:
                 server.shutdown()
 
@@ -300,6 +300,50 @@ class WorkerActivityTests(unittest.TestCase):
                 )
             finally:
                 server.shutdown()
+
+    def test_list_runs_hides_internal_runs_unless_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            monitor = WorkerActivityMonitor(store=store, history_limit=50)
+            created = datetime(2026, 3, 31, 12, 5, tzinfo=timezone.utc)
+
+            def _seed(run_id: str, source: str, task_id: str) -> None:
+                store.append_run(
+                    RunRecord(
+                        run_id=run_id,
+                        envelope_id=f"env:{run_id}",
+                        source=source,
+                        workflow="default",
+                        latency_ms=1,
+                        result_status="success",
+                        created_at=created,
+                    )
+                )
+                store.append_audit_event(
+                    AuditEvent(
+                        run_id=run_id,
+                        envelope_id=f"env:{run_id}",
+                        source=source,
+                        workflow="default",
+                        result_status="success",
+                        detail={"task_id": task_id},
+                        created_at=created,
+                    )
+                )
+
+            _seed("run:internal:1", "internal", "task:internal-heartbeat:1")
+            _seed("run:im:1", "im", "task:im:1")
+
+            default_runs = monitor.list_runs_snapshot()["runs"]
+            self.assertEqual(
+                [run["run_id"] for run in default_runs], ["run:im:1"]
+            )
+
+            all_runs = monitor.list_runs_snapshot(include_internal=True)["runs"]
+            self.assertEqual(
+                {run["run_id"] for run in all_runs},
+                {"run:internal:1", "run:im:1"},
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The worker activity UI (served on :9465) was swamped by internal heartbeat runs - about 99% of the run_records table (32,419 of ~33,000 on magpie). The runs list never filtered them out; `include_internal` only trimmed activity within a run, not the runs themselves.

`list_recent_runs` now takes an `include_internal` param and filters `source='internal'` in SQL, with `list_runs_snapshot` passing the flag through. The filter has to be in SQL rather than after the LIMIT, otherwise the limited window is all heartbeats and no real runs show. The index page already has a "show internal traffic" toggle, so hiding-by-default plus the toggle now works. List rows are trimmed to status/source/latency chips with a CSS-clamped 2-line preview (dropped the noisy run-id kicker), and the detail view tucks the raw audit JSON behind a collapsed <details> and bounds long timeline messages with max-height and scroll.

UI-only. Added a test that the runs list hides internal runs unless requested, and updated the existing detail-HTML assertion for the collapsed audit section. Full suite passes locally: 110 pass, 3 pre-existing skips.

Deploying this is a separate lab PR (nix flake update chatting plus opening the worker UI port). No deploy here.