### PR TITLE
Add schedules table and CRUD API on the handler

### DIFF
--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -27,6 +28,7 @@ import (
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/egress"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/metrics"
 	handlerruntime "github.com/EdwardSalkeld/chatting/go/handler/internal/runtime"
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/schedules"
 	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
 )
 
@@ -288,7 +290,10 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		}
 	}
 	metricRecorder := metrics.New(time.Time{}, nil)
-	metricsServer, err := metrics.StartServer(metricRecorder, config.MetricsHost, config.MetricsPort)
+	scheduleService := schedules.NewService(store)
+	metricsServer, err := metrics.StartServer(metricRecorder, config.MetricsHost, config.MetricsPort, func(mux *http.ServeMux) {
+		schedules.RegisterRoutes(mux, scheduleService)
+	})
 	if err != nil {
 		_ = store.Close()
 		return nil, err

--- a/go/handler/internal/connectors/schedule/schedule.go
+++ b/go/handler/internal/connectors/schedule/schedule.go
@@ -239,6 +239,13 @@ func (connector *Connector) Poll(ctx context.Context) ([]contracts.TaskEnvelope,
 	return envelopes, nil
 }
 
+// Validate reports whether the job satisfies the schedule connector's requirements
+// without exposing the internal prepared job representation.
+func Validate(job Job) error {
+	_, err := prepareJob(job)
+	return err
+}
+
 func prepareJob(job Job) (Job, error) {
 	if strings.TrimSpace(job.JobName) == "" {
 		return Job{}, errors.New("job_name is required")

--- a/go/handler/internal/metrics/metrics.go
+++ b/go/handler/internal/metrics/metrics.go
@@ -165,7 +165,7 @@ type Server struct {
 	addr   string
 }
 
-func StartServer(recorder *Recorder, host string, port int) (*Server, error) {
+func StartServer(recorder *Recorder, host string, port int, routeRegistrars ...func(*http.ServeMux)) (*Server, error) {
 	if recorder == nil {
 		return nil, fmt.Errorf("metrics recorder is required")
 	}
@@ -184,6 +184,11 @@ func StartServer(recorder *Recorder, host string, port int) (*Server, error) {
 	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusNotFound)
 	})
+	for _, register := range routeRegistrars {
+		if register != nil {
+			register(mux)
+		}
+	}
 
 	listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {

--- a/go/handler/internal/schedules/schedules.go
+++ b/go/handler/internal/schedules/schedules.go
@@ -1,0 +1,236 @@
+package schedules
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/schedule"
+	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
+)
+
+const routePrefix = "/api/schedules"
+
+type Service struct {
+	store *sqlitestate.Store
+}
+
+func NewService(store *sqlitestate.Store) *Service {
+	return &Service{store: store}
+}
+
+func RegisterRoutes(mux *http.ServeMux, service *Service) {
+	mux.HandleFunc(routePrefix, service.handleCollection)
+	mux.HandleFunc(routePrefix+"/", service.handleItem)
+}
+
+type scheduleJSON struct {
+	ScheduleID         string   `json:"schedule_id"`
+	Version            int      `json:"version"`
+	Status             string   `json:"status"`
+	JobName            string   `json:"job_name"`
+	Content            string   `json:"content"`
+	Cron               string   `json:"cron"`
+	Timezone           string   `json:"timezone"`
+	ContextRefs        []string `json:"context_refs"`
+	PromptContext      []string `json:"prompt_context"`
+	ReplyChannelType   string   `json:"reply_channel_type"`
+	ReplyChannelTarget string   `json:"reply_channel_target"`
+	CreatedAt          string   `json:"created_at"`
+	CreatedBy          string   `json:"created_by"`
+}
+
+type scheduleRequest struct {
+	JobName            string   `json:"job_name"`
+	Content            string   `json:"content"`
+	Cron               string   `json:"cron"`
+	Timezone           string   `json:"timezone"`
+	ContextRefs        []string `json:"context_refs"`
+	PromptContext      []string `json:"prompt_context"`
+	ReplyChannelType   string   `json:"reply_channel_type"`
+	ReplyChannelTarget string   `json:"reply_channel_target"`
+	CreatedBy          string   `json:"created_by"`
+}
+
+func (service *Service) handleCollection(writer http.ResponseWriter, request *http.Request) {
+	switch request.Method {
+	case http.MethodGet:
+		service.listSchedules(writer, request)
+	case http.MethodPost:
+		service.createSchedule(writer, request)
+	default:
+		writeError(writer, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (service *Service) handleItem(writer http.ResponseWriter, request *http.Request) {
+	scheduleID := strings.TrimPrefix(request.URL.Path, routePrefix+"/")
+	if scheduleID == "" || strings.Contains(scheduleID, "/") {
+		writeError(writer, http.StatusNotFound, "schedule not found")
+		return
+	}
+	switch request.Method {
+	case http.MethodGet:
+		service.getSchedule(writer, request, scheduleID)
+	case http.MethodPut:
+		service.replaceSchedule(writer, request, scheduleID)
+	case http.MethodDelete:
+		service.deleteSchedule(writer, request, scheduleID)
+	default:
+		writeError(writer, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (service *Service) listSchedules(writer http.ResponseWriter, request *http.Request) {
+	records, err := service.store.ListActiveSchedules(request.Context())
+	if err != nil {
+		writeError(writer, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]any{"schedules": schedulesToJSON(records)})
+}
+
+func (service *Service) createSchedule(writer http.ResponseWriter, request *http.Request) {
+	input, ok := decodeScheduleInput(writer, request)
+	if !ok {
+		return
+	}
+	record, err := service.store.CreateSchedule(request.Context(), input)
+	if err != nil {
+		writeError(writer, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(writer, http.StatusCreated, map[string]any{"schedule": scheduleToJSON(record)})
+}
+
+func (service *Service) getSchedule(writer http.ResponseWriter, request *http.Request, scheduleID string) {
+	record, err := service.store.GetActiveSchedule(request.Context(), scheduleID)
+	if err != nil {
+		writeError(writer, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if record == nil {
+		writeError(writer, http.StatusNotFound, "schedule not found")
+		return
+	}
+	payload := map[string]any{"schedule": scheduleToJSON(*record)}
+	if request.URL.Query().Get("history") == "1" {
+		history, err := service.store.GetScheduleHistory(request.Context(), scheduleID)
+		if err != nil {
+			writeError(writer, http.StatusInternalServerError, err.Error())
+			return
+		}
+		payload["history"] = schedulesToJSON(history)
+	}
+	writeJSON(writer, http.StatusOK, payload)
+}
+
+func (service *Service) replaceSchedule(writer http.ResponseWriter, request *http.Request, scheduleID string) {
+	input, ok := decodeScheduleInput(writer, request)
+	if !ok {
+		return
+	}
+	record, err := service.store.ReplaceSchedule(request.Context(), scheduleID, input)
+	if errors.Is(err, sqlitestate.ErrScheduleNotFound) {
+		writeError(writer, http.StatusNotFound, "schedule not found")
+		return
+	}
+	if err != nil {
+		writeError(writer, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]any{"schedule": scheduleToJSON(record)})
+}
+
+func (service *Service) deleteSchedule(writer http.ResponseWriter, request *http.Request, scheduleID string) {
+	deleted, err := service.store.MarkScheduleDead(request.Context(), scheduleID)
+	if err != nil {
+		writeError(writer, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !deleted {
+		writeError(writer, http.StatusNotFound, "schedule not found")
+		return
+	}
+	writer.WriteHeader(http.StatusNoContent)
+}
+
+func decodeScheduleInput(writer http.ResponseWriter, request *http.Request) (sqlitestate.ScheduleInput, bool) {
+	var body scheduleRequest
+	decoder := json.NewDecoder(request.Body)
+	if err := decoder.Decode(&body); err != nil {
+		writeError(writer, http.StatusBadRequest, "malformed request body")
+		return sqlitestate.ScheduleInput{}, false
+	}
+	job := schedule.Job{
+		JobName:            body.JobName,
+		Content:            body.Content,
+		Cron:               body.Cron,
+		TimezoneName:       body.Timezone,
+		ContextRefs:        body.ContextRefs,
+		PromptContext:      body.PromptContext,
+		ReplyChannelType:   body.ReplyChannelType,
+		ReplyChannelTarget: body.ReplyChannelTarget,
+	}
+	if err := schedule.Validate(job); err != nil {
+		writeError(writer, http.StatusBadRequest, err.Error())
+		return sqlitestate.ScheduleInput{}, false
+	}
+	return sqlitestate.ScheduleInput{
+		JobName:            body.JobName,
+		Content:            body.Content,
+		Cron:               body.Cron,
+		Timezone:           body.Timezone,
+		ContextRefs:        body.ContextRefs,
+		PromptContext:      body.PromptContext,
+		ReplyChannelType:   body.ReplyChannelType,
+		ReplyChannelTarget: body.ReplyChannelTarget,
+		CreatedBy:          body.CreatedBy,
+	}, true
+}
+
+func schedulesToJSON(records []sqlitestate.ScheduleRecord) []scheduleJSON {
+	payload := make([]scheduleJSON, 0, len(records))
+	for _, record := range records {
+		payload = append(payload, scheduleToJSON(record))
+	}
+	return payload
+}
+
+func scheduleToJSON(record sqlitestate.ScheduleRecord) scheduleJSON {
+	contextRefs := record.ContextRefs
+	if contextRefs == nil {
+		contextRefs = []string{}
+	}
+	promptContext := record.PromptContext
+	if promptContext == nil {
+		promptContext = []string{}
+	}
+	return scheduleJSON{
+		ScheduleID:         record.ScheduleID,
+		Version:            record.Version,
+		Status:             record.Status,
+		JobName:            record.JobName,
+		Content:            record.Content,
+		Cron:               record.Cron,
+		Timezone:           record.Timezone,
+		ContextRefs:        contextRefs,
+		PromptContext:      promptContext,
+		ReplyChannelType:   record.ReplyChannelType,
+		ReplyChannelTarget: record.ReplyChannelTarget,
+		CreatedAt:          record.CreatedAt.UTC().Format(time.RFC3339),
+		CreatedBy:          record.CreatedBy,
+	}
+}
+
+func writeJSON(writer http.ResponseWriter, status int, payload any) {
+	writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+	writer.WriteHeader(status)
+	_ = json.NewEncoder(writer).Encode(payload)
+}
+
+func writeError(writer http.ResponseWriter, status int, message string) {
+	writeJSON(writer, status, map[string]string{"error": message})
+}

--- a/go/handler/internal/schedules/schedules_test.go
+++ b/go/handler/internal/schedules/schedules_test.go
@@ -1,0 +1,182 @@
+package schedules
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
+)
+
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	store, err := sqlitestate.Open(context.Background(), filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+	})
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewService(store))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func decodeSchedule(t *testing.T, body []byte) scheduleJSON {
+	t.Helper()
+	var wrapper struct {
+		Schedule scheduleJSON `json:"schedule"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		t.Fatalf("decode schedule: %v (body=%s)", err, body)
+	}
+	return wrapper.Schedule
+}
+
+func TestSchedulesAPILifecycle(t *testing.T) {
+	server := newTestServer(t)
+	client := server.Client()
+
+	createBody := `{"job_name":"daily","content":"do the thing","cron":"0 9 * * *","context_refs":["a"],"reply_channel_type":"telegram","reply_channel_target":"123"}`
+	response, err := client.Post(server.URL+"/api/schedules", "application/json", strings.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	if response.StatusCode != http.StatusCreated {
+		t.Fatalf("POST expected 201, got %d", response.StatusCode)
+	}
+	created := decodeSchedule(t, readBody(t, response))
+	if created.Version != 1 || created.Status != "active" {
+		t.Fatalf("unexpected created schedule: %+v", created)
+	}
+	if created.Timezone != "UTC" {
+		t.Fatalf("expected default timezone UTC, got %q", created.Timezone)
+	}
+
+	listResponse, err := client.Get(server.URL + "/api/schedules")
+	if err != nil {
+		t.Fatalf("GET list: %v", err)
+	}
+	if listResponse.StatusCode != http.StatusOK {
+		t.Fatalf("GET list expected 200, got %d", listResponse.StatusCode)
+	}
+	var listWrapper struct {
+		Schedules []scheduleJSON `json:"schedules"`
+	}
+	if err := json.Unmarshal(readBody(t, listResponse), &listWrapper); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listWrapper.Schedules) != 1 {
+		t.Fatalf("expected 1 schedule listed, got %d", len(listWrapper.Schedules))
+	}
+
+	getResponse, err := client.Get(server.URL + "/api/schedules/" + created.ScheduleID)
+	if err != nil {
+		t.Fatalf("GET one: %v", err)
+	}
+	if getResponse.StatusCode != http.StatusOK {
+		t.Fatalf("GET one expected 200, got %d", getResponse.StatusCode)
+	}
+	if got := decodeSchedule(t, readBody(t, getResponse)); got.ScheduleID != created.ScheduleID {
+		t.Fatalf("GET one returned wrong schedule: %+v", got)
+	}
+
+	putBody := `{"job_name":"daily","content":"do the newer thing","cron":"0 10 * * *"}`
+	putRequest, _ := http.NewRequest(http.MethodPut, server.URL+"/api/schedules/"+created.ScheduleID, strings.NewReader(putBody))
+	putResponse, err := client.Do(putRequest)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	if putResponse.StatusCode != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d", putResponse.StatusCode)
+	}
+	replaced := decodeSchedule(t, readBody(t, putResponse))
+	if replaced.Version != 2 {
+		t.Fatalf("PUT expected version 2, got %d", replaced.Version)
+	}
+
+	historyResponse, err := client.Get(server.URL + "/api/schedules/" + created.ScheduleID + "?history=1")
+	if err != nil {
+		t.Fatalf("GET history: %v", err)
+	}
+	var historyWrapper struct {
+		Schedule scheduleJSON   `json:"schedule"`
+		History  []scheduleJSON `json:"history"`
+	}
+	if err := json.Unmarshal(readBody(t, historyResponse), &historyWrapper); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if len(historyWrapper.History) != 2 {
+		t.Fatalf("expected 2 history entries, got %d", len(historyWrapper.History))
+	}
+
+	deleteRequest, _ := http.NewRequest(http.MethodDelete, server.URL+"/api/schedules/"+created.ScheduleID, nil)
+	deleteResponse, err := client.Do(deleteRequest)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	if deleteResponse.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE expected 204, got %d", deleteResponse.StatusCode)
+	}
+
+	afterDelete, err := client.Get(server.URL + "/api/schedules/" + created.ScheduleID)
+	if err != nil {
+		t.Fatalf("GET after delete: %v", err)
+	}
+	if afterDelete.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET after delete expected 404, got %d", afterDelete.StatusCode)
+	}
+}
+
+func TestSchedulesAPIValidationRejectsBadCron(t *testing.T) {
+	server := newTestServer(t)
+	body := `{"job_name":"daily","content":"x","cron":"not-a-cron"}`
+	response, err := server.Client().Post(server.URL+"/api/schedules", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid cron, got %d", response.StatusCode)
+	}
+	var wrapper struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(readBody(t, response), &wrapper); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if wrapper.Error == "" {
+		t.Fatal("expected an error message in the 400 response")
+	}
+}
+
+func TestSchedulesAPIReplaceMissingReturns404(t *testing.T) {
+	server := newTestServer(t)
+	body := `{"job_name":"daily","content":"x","cron":"0 9 * * *"}`
+	request, _ := http.NewRequest(http.MethodPut, server.URL+"/api/schedules/sched_missing", strings.NewReader(body))
+	response, err := server.Client().Do(request)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing schedule, got %d", response.StatusCode)
+	}
+}
+
+func readBody(t *testing.T, response *http.Response) []byte {
+	t.Helper()
+	defer response.Body.Close()
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return data
+}

--- a/go/handler/internal/state/sqlite/schedules_test.go
+++ b/go/handler/internal/state/sqlite/schedules_test.go
@@ -1,0 +1,169 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestScheduleLifecycle(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	created, err := store.CreateSchedule(ctx, ScheduleInput{
+		JobName:            "daily-report",
+		Content:            "summarise yesterday",
+		Cron:               "0 9 * * *",
+		ContextRefs:        []string{"ref-a"},
+		ReplyChannelType:   "telegram",
+		ReplyChannelTarget: "12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+	if created.Version != 1 {
+		t.Fatalf("expected version 1, got %d", created.Version)
+	}
+	if created.Status != "active" {
+		t.Fatalf("expected status active, got %q", created.Status)
+	}
+	if created.Timezone != "UTC" {
+		t.Fatalf("expected default timezone UTC, got %q", created.Timezone)
+	}
+	if created.CreatedBy != "api" {
+		t.Fatalf("expected default created_by api, got %q", created.CreatedBy)
+	}
+	if created.ScheduleID == "" {
+		t.Fatal("expected a generated schedule_id")
+	}
+
+	active, err := store.ListActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveSchedules: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("expected 1 active schedule, got %d", len(active))
+	}
+	if !reflect.DeepEqual(active[0].ContextRefs, []string{"ref-a"}) {
+		t.Fatalf("unexpected context_refs: %v", active[0].ContextRefs)
+	}
+	if active[0].PromptContext == nil || len(active[0].PromptContext) != 0 {
+		t.Fatalf("expected empty prompt_context slice, got %v", active[0].PromptContext)
+	}
+
+	got, err := store.GetActiveSchedule(ctx, created.ScheduleID)
+	if err != nil {
+		t.Fatalf("GetActiveSchedule: %v", err)
+	}
+	if got == nil || got.ScheduleID != created.ScheduleID {
+		t.Fatalf("GetActiveSchedule returned %+v", got)
+	}
+
+	replaced, err := store.ReplaceSchedule(ctx, created.ScheduleID, ScheduleInput{
+		JobName:   "daily-report",
+		Content:   "summarise the past week",
+		Cron:      "0 10 * * 1",
+		Timezone:  "Europe/London",
+		CreatedBy: "ed",
+	})
+	if err != nil {
+		t.Fatalf("ReplaceSchedule: %v", err)
+	}
+	if replaced.Version != 2 {
+		t.Fatalf("expected version 2, got %d", replaced.Version)
+	}
+	if replaced.Timezone != "Europe/London" {
+		t.Fatalf("expected timezone Europe/London, got %q", replaced.Timezone)
+	}
+	if replaced.CreatedBy != "ed" {
+		t.Fatalf("expected created_by ed, got %q", replaced.CreatedBy)
+	}
+
+	active, err = store.ListActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveSchedules after replace: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("expected exactly 1 active schedule after replace, got %d", len(active))
+	}
+	if active[0].Version != 2 {
+		t.Fatalf("expected active version 2, got %d", active[0].Version)
+	}
+
+	history, err := store.GetScheduleHistory(ctx, created.ScheduleID)
+	if err != nil {
+		t.Fatalf("GetScheduleHistory: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("expected 2 history rows, got %d", len(history))
+	}
+	if history[0].Version != 2 || history[1].Version != 1 {
+		t.Fatalf("expected history ordered version desc, got %d then %d", history[0].Version, history[1].Version)
+	}
+	if history[1].Status != "dead" {
+		t.Fatalf("expected superseded version to be dead, got %q", history[1].Status)
+	}
+	if history[1].SupersededAt == nil {
+		t.Fatal("expected superseded_at to be set on the dead version")
+	}
+
+	deleted, err := store.MarkScheduleDead(ctx, created.ScheduleID)
+	if err != nil {
+		t.Fatalf("MarkScheduleDead: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected MarkScheduleDead to report a change")
+	}
+
+	active, err = store.ListActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveSchedules after delete: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("expected no active schedules after delete, got %d", len(active))
+	}
+
+	gone, err := store.GetActiveSchedule(ctx, created.ScheduleID)
+	if err != nil {
+		t.Fatalf("GetActiveSchedule after delete: %v", err)
+	}
+	if gone != nil {
+		t.Fatalf("expected nil active schedule after delete, got %+v", gone)
+	}
+
+	history, err = store.GetScheduleHistory(ctx, created.ScheduleID)
+	if err != nil {
+		t.Fatalf("GetScheduleHistory after delete: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("expected history retained after delete, got %d rows", len(history))
+	}
+}
+
+func TestReplaceScheduleMissingReturnsSentinel(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	_, err := store.ReplaceSchedule(ctx, "sched_missing", ScheduleInput{
+		JobName: "x",
+		Content: "y",
+		Cron:    "0 9 * * *",
+	})
+	if !errors.Is(err, ErrScheduleNotFound) {
+		t.Fatalf("expected ErrScheduleNotFound, got %v", err)
+	}
+}
+
+func TestMarkScheduleDeadMissingReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	deleted, err := store.MarkScheduleDead(ctx, "sched_missing")
+	if err != nil {
+		t.Fatalf("MarkScheduleDead: %v", err)
+	}
+	if deleted {
+		t.Fatal("expected MarkScheduleDead to report no change for a missing schedule")
+	}
+}

--- a/go/handler/internal/state/sqlite/sqlite.go
+++ b/go/handler/internal/state/sqlite/sqlite.go
@@ -2,7 +2,9 @@ package sqlite
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +17,9 @@ import (
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
 	_ "modernc.org/sqlite"
 )
+
+// ErrScheduleNotFound is returned when an operation targets a schedule that has no active version.
+var ErrScheduleNotFound = errors.New("schedule not found")
 
 type Store struct {
 	db *sql.DB
@@ -93,6 +98,35 @@ type ConversationTurn struct {
 type GitHubAssignmentCheckpoint struct {
 	EventCreatedAt time.Time
 	EventID        string
+}
+
+type ScheduleRecord struct {
+	ScheduleID         string
+	Version            int
+	Status             string
+	JobName            string
+	Content            string
+	Cron               string
+	Timezone           string
+	ContextRefs        []string
+	PromptContext      []string
+	ReplyChannelType   string
+	ReplyChannelTarget string
+	CreatedAt          time.Time
+	CreatedBy          string
+	SupersededAt       *time.Time
+}
+
+type ScheduleInput struct {
+	JobName            string
+	Content            string
+	Cron               string
+	Timezone           string
+	ContextRefs        []string
+	PromptContext      []string
+	ReplyChannelType   string
+	ReplyChannelTarget string
+	CreatedBy          string
 }
 
 func Open(ctx context.Context, dbPath string) (*Store, error) {
@@ -197,6 +231,24 @@ func (store *Store) initialize(ctx context.Context) error {
 			event_id TEXT NOT NULL,
 			updated_at TEXT NOT NULL
 		)`,
+		`CREATE TABLE IF NOT EXISTS schedules (
+			row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+			schedule_id TEXT NOT NULL,
+			version INTEGER NOT NULL,
+			status TEXT NOT NULL,
+			job_name TEXT NOT NULL,
+			content TEXT NOT NULL,
+			cron TEXT NOT NULL,
+			timezone TEXT NOT NULL,
+			context_refs TEXT NOT NULL,
+			prompt_context TEXT NOT NULL,
+			reply_channel_type TEXT NOT NULL,
+			reply_channel_target TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			created_by TEXT NOT NULL,
+			superseded_at TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_schedules_schedule_id_status ON schedules (schedule_id, status)`,
 	}
 	for _, statement := range statements {
 		if _, err := store.db.ExecContext(ctx, statement); err != nil {
@@ -262,6 +314,347 @@ func (store *Store) SetGitHubAssignmentCheckpoint(ctx context.Context, scopeKey 
 		formatTimestamp(time.Now()),
 	)
 	return err
+}
+
+const scheduleSelectColumns = `SELECT
+	schedule_id,
+	version,
+	status,
+	job_name,
+	content,
+	cron,
+	timezone,
+	context_refs,
+	prompt_context,
+	reply_channel_type,
+	reply_channel_target,
+	created_at,
+	created_by,
+	superseded_at`
+
+func (store *Store) ListActiveSchedules(ctx context.Context) ([]ScheduleRecord, error) {
+	rows, err := store.db.QueryContext(
+		ctx,
+		scheduleSelectColumns+`
+		FROM schedules
+		WHERE status = 'active'
+		ORDER BY job_name ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanScheduleRecords(rows)
+}
+
+func (store *Store) GetActiveSchedule(ctx context.Context, scheduleID string) (*ScheduleRecord, error) {
+	if strings.TrimSpace(scheduleID) == "" {
+		return nil, errors.New("schedule_id is required")
+	}
+	record, err := scanScheduleRecord(store.db.QueryRowContext(
+		ctx,
+		scheduleSelectColumns+`
+		FROM schedules
+		WHERE schedule_id = ? AND status = 'active'`,
+		scheduleID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &record, nil
+}
+
+func (store *Store) GetScheduleHistory(ctx context.Context, scheduleID string) ([]ScheduleRecord, error) {
+	if strings.TrimSpace(scheduleID) == "" {
+		return nil, errors.New("schedule_id is required")
+	}
+	rows, err := store.db.QueryContext(
+		ctx,
+		scheduleSelectColumns+`
+		FROM schedules
+		WHERE schedule_id = ?
+		ORDER BY version DESC`,
+		scheduleID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanScheduleRecords(rows)
+}
+
+func (store *Store) CreateSchedule(ctx context.Context, input ScheduleInput) (ScheduleRecord, error) {
+	scheduleID, err := generateScheduleID()
+	if err != nil {
+		return ScheduleRecord{}, err
+	}
+	record := scheduleRecordFromInput(scheduleID, 1, input, time.Now())
+	if err := store.insertScheduleRow(ctx, store.db, record); err != nil {
+		return ScheduleRecord{}, err
+	}
+	return record, nil
+}
+
+func (store *Store) ReplaceSchedule(ctx context.Context, scheduleID string, input ScheduleInput) (ScheduleRecord, error) {
+	if strings.TrimSpace(scheduleID) == "" {
+		return ScheduleRecord{}, errors.New("schedule_id is required")
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ScheduleRecord{}, err
+	}
+	defer rollbackUnlessCommitted(tx)
+
+	current, err := scanScheduleRecord(tx.QueryRowContext(
+		ctx,
+		scheduleSelectColumns+`
+		FROM schedules
+		WHERE schedule_id = ? AND status = 'active'`,
+		scheduleID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScheduleRecord{}, ErrScheduleNotFound
+	}
+	if err != nil {
+		return ScheduleRecord{}, err
+	}
+	now := time.Now().UTC()
+	if _, err := tx.ExecContext(
+		ctx,
+		`UPDATE schedules
+		SET status = 'dead', superseded_at = ?
+		WHERE schedule_id = ? AND status = 'active'`,
+		formatTimestamp(now),
+		scheduleID,
+	); err != nil {
+		return ScheduleRecord{}, err
+	}
+	record := scheduleRecordFromInput(scheduleID, current.Version+1, input, now)
+	if err := store.insertScheduleRow(ctx, tx, record); err != nil {
+		return ScheduleRecord{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ScheduleRecord{}, err
+	}
+	return record, nil
+}
+
+func (store *Store) MarkScheduleDead(ctx context.Context, scheduleID string) (bool, error) {
+	if strings.TrimSpace(scheduleID) == "" {
+		return false, errors.New("schedule_id is required")
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer rollbackUnlessCommitted(tx)
+
+	result, err := tx.ExecContext(
+		ctx,
+		`UPDATE schedules
+		SET status = 'dead', superseded_at = ?
+		WHERE schedule_id = ? AND status = 'active'`,
+		formatTimestamp(time.Now()),
+		scheduleID,
+	)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+func (store *Store) insertScheduleRow(ctx context.Context, exec scheduleExecer, record ScheduleRecord) error {
+	contextRefs, err := encodeStringList(record.ContextRefs)
+	if err != nil {
+		return err
+	}
+	promptContext, err := encodeStringList(record.PromptContext)
+	if err != nil {
+		return err
+	}
+	var supersededAt any
+	if record.SupersededAt != nil {
+		supersededAt = formatTimestamp(*record.SupersededAt)
+	}
+	_, err = exec.ExecContext(
+		ctx,
+		`INSERT INTO schedules (
+			schedule_id,
+			version,
+			status,
+			job_name,
+			content,
+			cron,
+			timezone,
+			context_refs,
+			prompt_context,
+			reply_channel_type,
+			reply_channel_target,
+			created_at,
+			created_by,
+			superseded_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		record.ScheduleID,
+		record.Version,
+		record.Status,
+		record.JobName,
+		record.Content,
+		record.Cron,
+		record.Timezone,
+		contextRefs,
+		promptContext,
+		record.ReplyChannelType,
+		record.ReplyChannelTarget,
+		formatTimestamp(record.CreatedAt),
+		record.CreatedBy,
+		supersededAt,
+	)
+	return err
+}
+
+type scheduleExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+type scheduleScanner interface {
+	Scan(dest ...any) error
+}
+
+func scheduleRecordFromInput(scheduleID string, version int, input ScheduleInput, now time.Time) ScheduleRecord {
+	timezone := strings.TrimSpace(input.Timezone)
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	createdBy := strings.TrimSpace(input.CreatedBy)
+	if createdBy == "" {
+		createdBy = "api"
+	}
+	contextRefs := input.ContextRefs
+	if contextRefs == nil {
+		contextRefs = []string{}
+	}
+	promptContext := input.PromptContext
+	if promptContext == nil {
+		promptContext = []string{}
+	}
+	return ScheduleRecord{
+		ScheduleID:         scheduleID,
+		Version:            version,
+		Status:             "active",
+		JobName:            input.JobName,
+		Content:            input.Content,
+		Cron:               input.Cron,
+		Timezone:           timezone,
+		ContextRefs:        contextRefs,
+		PromptContext:      promptContext,
+		ReplyChannelType:   input.ReplyChannelType,
+		ReplyChannelTarget: input.ReplyChannelTarget,
+		CreatedAt:          now.UTC(),
+		CreatedBy:          createdBy,
+	}
+}
+
+func scanScheduleRecords(rows *sql.Rows) ([]ScheduleRecord, error) {
+	records := []ScheduleRecord{}
+	for rows.Next() {
+		record, err := scanScheduleRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func scanScheduleRecord(scanner scheduleScanner) (ScheduleRecord, error) {
+	record := ScheduleRecord{}
+	var contextRefs, promptContext, createdAt string
+	var supersededAt sql.NullString
+	if err := scanner.Scan(
+		&record.ScheduleID,
+		&record.Version,
+		&record.Status,
+		&record.JobName,
+		&record.Content,
+		&record.Cron,
+		&record.Timezone,
+		&contextRefs,
+		&promptContext,
+		&record.ReplyChannelType,
+		&record.ReplyChannelTarget,
+		&createdAt,
+		&record.CreatedBy,
+		&supersededAt,
+	); err != nil {
+		return ScheduleRecord{}, err
+	}
+	decodedContextRefs, err := decodeStringList(contextRefs)
+	if err != nil {
+		return ScheduleRecord{}, err
+	}
+	record.ContextRefs = decodedContextRefs
+	decodedPromptContext, err := decodeStringList(promptContext)
+	if err != nil {
+		return ScheduleRecord{}, err
+	}
+	record.PromptContext = decodedPromptContext
+	parsedCreatedAt, err := parseTimestamp(createdAt)
+	if err != nil {
+		return ScheduleRecord{}, err
+	}
+	record.CreatedAt = parsedCreatedAt
+	if supersededAt.Valid {
+		parsed, err := parseTimestamp(supersededAt.String)
+		if err != nil {
+			return ScheduleRecord{}, err
+		}
+		record.SupersededAt = &parsed
+	}
+	return record, nil
+}
+
+func generateScheduleID() (string, error) {
+	buffer := make([]byte, 8)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", err
+	}
+	return "sched_" + hex.EncodeToString(buffer), nil
+}
+
+func encodeStringList(values []string) (string, error) {
+	if values == nil {
+		values = []string{}
+	}
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func decodeStringList(raw string) ([]string, error) {
+	values := []string{}
+	if strings.TrimSpace(raw) == "" {
+		return values, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil, err
+	}
+	if values == nil {
+		values = []string{}
+	}
+	return values, nil
 }
 
 func (store *Store) RecordTelegramTaskAttachments(ctx context.Context, taskMessage contracts.TaskQueueMessage, attachmentRootDir string) (int, error) {


### PR DESCRIPTION
First of a series to lift schedules out of the on-disk `live-schedule.local.json` into the handler DB with an API and UI. This PR is DB plus API only.

A versioned, append-only `schedules` table (schedule_id + version + status active|dead, at most one active row per id; an edit writes a new active version and marks the prior one dead; a delete marks the active row dead) with Store methods, plus a JSON CRUD API on the handler's existing metrics port (9464): GET/POST `/api/schedules`, GET/PUT/DELETE `/api/schedules/{id}` (plus `?history`). Writes are validated with the schedule connector's own rules via a newly exported `schedule.Validate`, so the API and the file loader reject the same invalid jobs.

No behaviour change yet: the connector still loads schedules from the file. The connector cutover and the web UI are later PRs, and the file is retired last. Deploying this is inert beyond exposing the new API.