### PR TITLE
Make the schedules DB authoritative with a web UI

### DIFF
--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -136,24 +136,17 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		return nil, err
 	}
 	connectors := []handlerruntime.Connector{heartbeat.New(nil)}
-	if config.ScheduleFile != "" {
-		jobs, err := schedule.LoadJobs(config.ScheduleFile)
-		if err != nil {
-			_ = store.Close()
-			return nil, err
-		}
-		connector, err := schedule.New(
-			jobs,
-			config.GlobalPromptContext,
-			config.CronPromptContext,
-			nil,
-		)
-		if err != nil {
-			_ = store.Close()
-			return nil, err
-		}
-		connectors = append(connectors, connector)
+	scheduleConnector, err := schedule.NewFromSource(
+		schedule.NewStoreSource(store),
+		config.GlobalPromptContext,
+		config.CronPromptContext,
+		nil,
+	)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
 	}
+	connectors = append(connectors, scheduleConnector)
 	if config.IMAPHost != "" {
 		password := os.Getenv(config.IMAPPasswordEnv)
 		if password == "" {
@@ -293,6 +286,7 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 	scheduleService := schedules.NewService(store)
 	metricsServer, err := metrics.StartServer(metricRecorder, config.MetricsHost, config.MetricsPort, func(mux *http.ServeMux) {
 		schedules.RegisterRoutes(mux, scheduleService)
+		schedules.RegisterUIRoutes(mux, scheduleService)
 	})
 	if err != nil {
 		_ = store.Close()

--- a/go/handler/internal/connectors/schedule/schedule.go
+++ b/go/handler/internal/connectors/schedule/schedule.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -52,32 +53,74 @@ type Job struct {
 	location           *time.Location
 }
 
+// Scheduled pairs a stable ScheduleID with its Job. The ScheduleID (not the
+// mutable job_name) keys the connector's in-memory scheduling state so that
+// edits which rename a job keep their next-run timing.
+type Scheduled struct {
+	ScheduleID string
+	Job        Job
+}
+
+// ScheduleSource yields the active schedule set on each Poll, allowing the
+// connector to live-reload from an authoritative store rather than a static
+// snapshot loaded once at startup.
+type ScheduleSource interface {
+	ActiveSchedules(ctx context.Context) ([]Scheduled, error)
+}
+
+type scheduleState struct {
+	job       Job
+	cron      string
+	nextRunAt time.Time
+}
+
 type Connector struct {
-	jobs                []Job
+	source              ScheduleSource
 	globalPromptContext []string
 	sourcePromptContext []string
 	now                 NowFunc
-	nextRunAtByJob      map[string]time.Time
+	states              map[string]*scheduleState
 }
 
+// staticSource serves a fixed schedule set, preserving the pre-DB behaviour of
+// New where jobs are validated once and never change.
+type staticSource struct {
+	scheduled []Scheduled
+}
+
+func (source staticSource) ActiveSchedules(context.Context) ([]Scheduled, error) {
+	return source.scheduled, nil
+}
+
+// New builds a connector over a fixed set of jobs. Jobs are validated up front;
+// each is keyed by its job_name for scheduling-state continuity.
 func New(jobs []Job, globalPromptContext []string, sourcePromptContext []string, now NowFunc) (*Connector, error) {
-	if now == nil {
-		now = func() time.Time { return time.Now().UTC() }
-	}
-	normalized := make([]Job, 0, len(jobs))
+	scheduled := make([]Scheduled, 0, len(jobs))
 	for _, job := range jobs {
 		prepared, err := prepareJob(job)
 		if err != nil {
 			return nil, err
 		}
-		normalized = append(normalized, prepared)
+		scheduled = append(scheduled, Scheduled{ScheduleID: prepared.JobName, Job: prepared})
+	}
+	return NewFromSource(staticSource{scheduled: scheduled}, globalPromptContext, sourcePromptContext, now)
+}
+
+// NewFromSource builds a connector that reloads its active schedule set from
+// source on every Poll.
+func NewFromSource(source ScheduleSource, globalPromptContext []string, sourcePromptContext []string, now NowFunc) (*Connector, error) {
+	if source == nil {
+		return nil, errors.New("schedule source is required")
+	}
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
 	}
 	return &Connector{
-		jobs:                normalized,
+		source:              source,
 		globalPromptContext: append([]string{}, globalPromptContext...),
 		sourcePromptContext: append([]string{}, sourcePromptContext...),
 		now:                 now,
-		nextRunAtByJob:      map[string]time.Time{},
+		states:              map[string]*scheduleState{},
 	}, nil
 }
 
@@ -197,17 +240,38 @@ func (connector *Connector) Poll(ctx context.Context) ([]contracts.TaskEnvelope,
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	scheduled, err := connector.source.ActiveSchedules(ctx)
+	if err != nil {
+		return nil, err
+	}
 	now := connector.now().UTC()
 	envelopes := []contracts.TaskEnvelope{}
-	for _, job := range connector.jobs {
-		nextRunAt, ok := connector.nextRunAtByJob[job.JobName]
-		if !ok {
-			nextRunAt = initialNextRunAt(job, now)
-		}
-		if now.Before(nextRunAt) {
-			connector.nextRunAtByJob[job.JobName] = nextRunAt
+	seen := make(map[string]bool, len(scheduled))
+	for _, entry := range scheduled {
+		job, err := prepareJob(entry.Job)
+		if err != nil {
+			log.Printf("schedule_skip_invalid schedule_id=%q job_name=%q err=%v", entry.ScheduleID, entry.Job.JobName, err)
 			continue
 		}
+		seen[entry.ScheduleID] = true
+		state, ok := connector.states[entry.ScheduleID]
+		switch {
+		case !ok:
+			// A newly active schedule initialises its next run from now.
+			state = &scheduleState{cron: job.Cron, nextRunAt: initialNextRunAt(job, now)}
+			connector.states[entry.ScheduleID] = state
+		case state.cron != job.Cron:
+			// A changed cron expression recomputes the next run from now.
+			state.cron = job.Cron
+			state.nextRunAt = initialNextRunAt(job, now)
+		}
+		// Refresh the job so non-cron edits (content, reply channel, refs) take
+		// effect on the next fire without disturbing the schedule timing.
+		state.job = job
+		if now.Before(state.nextRunAt) {
+			continue
+		}
+		nextRunAt := state.nextRunAt
 		eventID := "cron:" + job.JobName + ":" + pythonUTCISO(nextRunAt)
 		replyChannel := contracts.ReplyChannel{Type: "log", Target: job.JobName}
 		if job.ReplyChannelType != "" {
@@ -234,7 +298,13 @@ func (connector *Connector) Poll(ctx context.Context) ([]contracts.TaskEnvelope,
 			ReplyChannel:  replyChannel,
 			DedupeKey:     eventID,
 		})
-		connector.nextRunAtByJob[job.JobName] = nextDueTime(job, now)
+		state.nextRunAt = nextDueTime(job, now)
+	}
+	// Drop scheduling state for schedules that are no longer active.
+	for scheduleID := range connector.states {
+		if !seen[scheduleID] {
+			delete(connector.states, scheduleID)
+		}
 	}
 	return envelopes, nil
 }

--- a/go/handler/internal/connectors/schedule/schedule_test.go
+++ b/go/handler/internal/connectors/schedule/schedule_test.go
@@ -222,6 +222,129 @@ func TestPollUsesConfiguredTimezoneAndReplyChannel(t *testing.T) {
 	}
 }
 
+type fakeSource struct {
+	scheduled []Scheduled
+}
+
+func (source *fakeSource) ActiveSchedules(context.Context) ([]Scheduled, error) {
+	return source.scheduled, nil
+}
+
+func TestPollFromSourceFiresDueScheduleOnce(t *testing.T) {
+	now := mustTime(t, "2026-03-09T12:34:56Z")
+	source := &fakeSource{scheduled: []Scheduled{
+		{
+			ScheduleID: "sched_a",
+			Job: Job{
+				JobName: "daily-note",
+				Content: "Write the daily note",
+				Cron:    "34 12 * * *",
+			},
+		},
+	}}
+	connector, err := NewFromSource(source, nil, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(envelopes) != 1 {
+		t.Fatalf("first poll envelopes = %#v", envelopes)
+	}
+	if envelopes[0].ID != "cron:daily-note:2026-03-09T12:34:00+00:00" {
+		t.Fatalf("ID = %q", envelopes[0].ID)
+	}
+
+	envelopes, err = connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(envelopes) != 0 {
+		t.Fatalf("second poll should not refire: %#v", envelopes)
+	}
+}
+
+func TestPollFromSourceStopsRemovedSchedule(t *testing.T) {
+	now := mustTime(t, "2026-03-09T12:34:56Z")
+	source := &fakeSource{scheduled: []Scheduled{
+		{
+			ScheduleID: "sched_a",
+			Job: Job{
+				JobName: "daily-note",
+				Content: "Write the daily note",
+				Cron:    "34 12 * * *",
+			},
+		},
+	}}
+	connector, err := NewFromSource(source, nil, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if envelopes, err := connector.Poll(context.Background()); err != nil || len(envelopes) != 1 {
+		t.Fatalf("first poll envelopes = %#v err = %v", envelopes, err)
+	}
+
+	// Remove the schedule and advance to the next due window; it must not fire.
+	source.scheduled = nil
+	now = mustTime(t, "2026-03-10T12:34:56Z")
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(envelopes) != 0 {
+		t.Fatalf("removed schedule should not fire: %#v", envelopes)
+	}
+	if _, ok := connector.states["sched_a"]; ok {
+		t.Fatal("state for removed schedule was not pruned")
+	}
+}
+
+func TestPollFromSourceRecomputesOnCronChange(t *testing.T) {
+	now := mustTime(t, "2026-03-09T11:00:00Z")
+	job := Scheduled{
+		ScheduleID: "sched_a",
+		Job: Job{
+			JobName: "daily-note",
+			Content: "Write the daily note",
+			Cron:    "0 12 * * *",
+		},
+	}
+	source := &fakeSource{scheduled: []Scheduled{job}}
+	connector, err := NewFromSource(source, nil, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if envelopes, err := connector.Poll(context.Background()); err != nil || len(envelopes) != 0 {
+		t.Fatalf("initial poll should not fire: %#v err = %v", envelopes, err)
+	}
+
+	// Change the cron so the next run moves from 12:00 to 13:00.
+	job.Job.Cron = "0 13 * * *"
+	source.scheduled = []Scheduled{job}
+
+	now = mustTime(t, "2026-03-09T12:00:00Z")
+	if envelopes, err := connector.Poll(context.Background()); err != nil || len(envelopes) != 0 {
+		t.Fatalf("must not fire at the old cron time after a cron change: %#v err = %v", envelopes, err)
+	}
+
+	now = mustTime(t, "2026-03-09T13:00:00Z")
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(envelopes) != 1 {
+		t.Fatalf("should fire at the new cron time: %#v", envelopes)
+	}
+	if envelopes[0].ID != "cron:daily-note:2026-03-09T13:00:00+00:00" {
+		t.Fatalf("ID = %q", envelopes[0].ID)
+	}
+}
+
 func mustTime(t *testing.T, value string) time.Time {
 	t.Helper()
 	parsed, err := time.Parse(time.RFC3339, value)

--- a/go/handler/internal/connectors/schedule/source.go
+++ b/go/handler/internal/connectors/schedule/source.go
@@ -1,0 +1,41 @@
+package schedule
+
+import (
+	"context"
+
+	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
+)
+
+// StoreSource adapts the sqlite store to a ScheduleSource, exposing the active
+// schedule set so the connector can live-reload from the authoritative DB.
+type StoreSource struct {
+	store *sqlitestate.Store
+}
+
+func NewStoreSource(store *sqlitestate.Store) *StoreSource {
+	return &StoreSource{store: store}
+}
+
+func (source *StoreSource) ActiveSchedules(ctx context.Context) ([]Scheduled, error) {
+	records, err := source.store.ListActiveSchedules(ctx)
+	if err != nil {
+		return nil, err
+	}
+	scheduled := make([]Scheduled, 0, len(records))
+	for _, record := range records {
+		scheduled = append(scheduled, Scheduled{
+			ScheduleID: record.ScheduleID,
+			Job: Job{
+				JobName:            record.JobName,
+				Content:            record.Content,
+				ContextRefs:        record.ContextRefs,
+				Cron:               record.Cron,
+				PromptContext:      record.PromptContext,
+				TimezoneName:       record.Timezone,
+				ReplyChannelType:   record.ReplyChannelType,
+				ReplyChannelTarget: record.ReplyChannelTarget,
+			},
+		})
+	}
+	return scheduled, nil
+}

--- a/go/handler/internal/schedules/ui.go
+++ b/go/handler/internal/schedules/ui.go
@@ -1,0 +1,254 @@
+package schedules
+
+import (
+	"html/template"
+	"net/http"
+	"strings"
+
+	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
+)
+
+const uiRoutePrefix = "/schedules"
+
+// RegisterUIRoutes wires the server-rendered CRUD UI onto the shared mux. Reads
+// are rendered from the store; all mutations go through the JSON API via fetch
+// so the UI and agents share a single write path.
+func RegisterUIRoutes(mux *http.ServeMux, service *Service) {
+	mux.HandleFunc(uiRoutePrefix, service.handleUIList)
+	mux.HandleFunc(uiRoutePrefix+"/", service.handleUIDetail)
+}
+
+type scheduleFormView struct {
+	IsNew              bool
+	ScheduleID         string
+	JobName            string
+	Content            string
+	Cron               string
+	Timezone           string
+	ContextRefs        string
+	PromptContext      string
+	ReplyChannelType   string
+	ReplyChannelTarget string
+}
+
+func (service *Service) handleUIList(writer http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodGet {
+		writer.Header().Set("Allow", http.MethodGet)
+		http.Error(writer, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	records, err := service.store.ListActiveSchedules(request.Context())
+	if err != nil {
+		http.Error(writer, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	renderTemplate(writer, listTemplate, schedulesToJSON(records))
+}
+
+func (service *Service) handleUIDetail(writer http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodGet {
+		writer.Header().Set("Allow", http.MethodGet)
+		http.Error(writer, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	scheduleID := strings.TrimPrefix(request.URL.Path, uiRoutePrefix+"/")
+	if scheduleID == "" || strings.Contains(scheduleID, "/") {
+		http.NotFound(writer, request)
+		return
+	}
+	if scheduleID == "new" {
+		renderTemplate(writer, formTemplate, scheduleFormView{IsNew: true, Timezone: "UTC"})
+		return
+	}
+	record, err := service.store.GetActiveSchedule(request.Context(), scheduleID)
+	if err != nil {
+		http.Error(writer, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if record == nil {
+		http.NotFound(writer, request)
+		return
+	}
+	renderTemplate(writer, formTemplate, formViewFromRecord(*record))
+}
+
+func formViewFromRecord(record sqlitestate.ScheduleRecord) scheduleFormView {
+	return scheduleFormView{
+		IsNew:              false,
+		ScheduleID:         record.ScheduleID,
+		JobName:            record.JobName,
+		Content:            record.Content,
+		Cron:               record.Cron,
+		Timezone:           record.Timezone,
+		ContextRefs:        strings.Join(record.ContextRefs, "\n"),
+		PromptContext:      strings.Join(record.PromptContext, "\n"),
+		ReplyChannelType:   record.ReplyChannelType,
+		ReplyChannelTarget: record.ReplyChannelTarget,
+	}
+}
+
+func renderTemplate(writer http.ResponseWriter, tmpl *template.Template, data any) {
+	writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmpl.Execute(writer, data); err != nil {
+		http.Error(writer, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+const pageStyle = `
+	:root { color-scheme: light dark; }
+	body { font-family: system-ui, sans-serif; max-width: 52rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
+	h1 { font-size: 1.4rem; }
+	a { color: #2563eb; }
+	table { border-collapse: collapse; width: 100%; }
+	th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid #8883; vertical-align: top; }
+	form { display: grid; gap: 0.9rem; margin-top: 1rem; }
+	label { display: grid; gap: 0.25rem; font-weight: 600; }
+	input, textarea { font: inherit; padding: 0.4rem; width: 100%; box-sizing: border-box; }
+	textarea { min-height: 4rem; }
+	.hint { font-weight: 400; color: #6b7280; font-size: 0.85rem; }
+	.actions { display: flex; gap: 0.6rem; align-items: center; }
+	button { font: inherit; padding: 0.45rem 0.9rem; cursor: pointer; }
+	button.danger { color: #b91c1c; }
+	.new { display: inline-block; margin-bottom: 1rem; }
+	#error { color: #b91c1c; white-space: pre-wrap; }
+`
+
+var listTemplate = template.Must(template.New("list").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Schedules</title>
+<style>` + pageStyle + `</style>
+</head>
+<body>
+<h1>Schedules</h1>
+<a class="new" href="/schedules/new">+ New schedule</a>
+<table>
+<thead><tr><th>Job name</th><th>Cron</th><th>Timezone</th><th>Reply target</th></tr></thead>
+<tbody>
+{{range .}}
+<tr>
+<td><a href="/schedules/{{.ScheduleID}}">{{.JobName}}</a></td>
+<td><code>{{.Cron}}</code></td>
+<td>{{.Timezone}}</td>
+<td>{{if .ReplyChannelType}}{{.ReplyChannelType}}:{{.ReplyChannelTarget}}{{else}}&mdash;{{end}}</td>
+</tr>
+{{else}}
+<tr><td colspan="4">No active schedules.</td></tr>
+{{end}}
+</tbody>
+</table>
+</body>
+</html>`))
+
+var formTemplate = template.Must(template.New("form").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{if .IsNew}}New schedule{{else}}Edit {{.JobName}}{{end}}</title>
+<style>` + pageStyle + `</style>
+</head>
+<body>
+<a href="/schedules">&larr; All schedules</a>
+<h1>{{if .IsNew}}New schedule{{else}}Edit schedule{{end}}</h1>
+<form id="schedule-form" data-schedule-id="{{.ScheduleID}}" data-is-new="{{if .IsNew}}1{{else}}0{{end}}">
+<label>Job name
+<input name="job_name" value="{{.JobName}}" required>
+</label>
+<label>Content
+<textarea name="content" required>{{.Content}}</textarea>
+</label>
+<label>Cron <span class="hint">5 fields, e.g. <code>5 7 * * *</code></span>
+<input name="cron" value="{{.Cron}}" required>
+</label>
+<label>Timezone
+<input name="timezone" value="{{.Timezone}}" placeholder="UTC">
+</label>
+<label>Context refs <span class="hint">one per line</span>
+<textarea name="context_refs">{{.ContextRefs}}</textarea>
+</label>
+<label>Prompt context <span class="hint">one per line</span>
+<textarea name="prompt_context">{{.PromptContext}}</textarea>
+</label>
+<label>Reply channel type
+<input name="reply_channel_type" value="{{.ReplyChannelType}}" placeholder="telegram">
+</label>
+<label>Reply channel target
+<input name="reply_channel_target" value="{{.ReplyChannelTarget}}">
+</label>
+<div class="actions">
+<button type="submit">Save</button>
+{{if not .IsNew}}<button type="button" class="danger" id="delete">Delete</button>{{end}}
+</div>
+<div id="error"></div>
+</form>
+<script>
+const form = document.getElementById("schedule-form");
+const errorBox = document.getElementById("error");
+const apiBase = "/api/schedules";
+
+function lines(value) {
+	return value.split("\n").map(line => line.trim()).filter(line => line.length > 0);
+}
+
+function payload() {
+	const data = new FormData(form);
+	return {
+		job_name: (data.get("job_name") || "").trim(),
+		content: (data.get("content") || "").trim(),
+		cron: (data.get("cron") || "").trim(),
+		timezone: (data.get("timezone") || "").trim(),
+		context_refs: lines(data.get("context_refs") || ""),
+		prompt_context: lines(data.get("prompt_context") || ""),
+		reply_channel_type: (data.get("reply_channel_type") || "").trim(),
+		reply_channel_target: (data.get("reply_channel_target") || "").trim(),
+		created_by: "ui",
+	};
+}
+
+async function readError(response) {
+	try {
+		const body = await response.json();
+		return body.error || ("request failed with status " + response.status);
+	} catch (e) {
+		return "request failed with status " + response.status;
+	}
+}
+
+form.addEventListener("submit", async (event) => {
+	event.preventDefault();
+	errorBox.textContent = "";
+	const isNew = form.dataset.isNew === "1";
+	const scheduleId = form.dataset.scheduleId;
+	const response = await fetch(isNew ? apiBase : apiBase + "/" + encodeURIComponent(scheduleId), {
+		method: isNew ? "POST" : "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload()),
+	});
+	if (response.ok) {
+		window.location.href = "/schedules";
+		return;
+	}
+	errorBox.textContent = await readError(response);
+});
+
+const deleteButton = document.getElementById("delete");
+if (deleteButton) {
+	deleteButton.addEventListener("click", async () => {
+		if (!window.confirm("Delete this schedule?")) {
+			return;
+		}
+		errorBox.textContent = "";
+		const response = await fetch(apiBase + "/" + encodeURIComponent(form.dataset.scheduleId), { method: "DELETE" });
+		if (response.ok) {
+			window.location.href = "/schedules";
+			return;
+		}
+		errorBox.textContent = await readError(response);
+	});
+}
+</script>
+</body>
+</html>`))

--- a/go/handler/internal/schedules/ui_test.go
+++ b/go/handler/internal/schedules/ui_test.go
@@ -1,0 +1,107 @@
+package schedules
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sqlitestate "github.com/EdwardSalkeld/chatting/go/handler/internal/state/sqlite"
+)
+
+func newTestUIServer(t *testing.T) (*httptest.Server, *sqlitestate.Store) {
+	t.Helper()
+	store, err := sqlitestate.Open(context.Background(), filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+	})
+	mux := http.NewServeMux()
+	service := NewService(store)
+	RegisterRoutes(mux, service)
+	RegisterUIRoutes(mux, service)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server, store
+}
+
+func TestUIListAndDetailRender(t *testing.T) {
+	server, store := newTestUIServer(t)
+	record, err := store.CreateSchedule(context.Background(), sqlitestate.ScheduleInput{
+		JobName:            "daily-note",
+		Content:            "Write the daily note",
+		Cron:               "5 7 * * *",
+		Timezone:           "Europe/London",
+		ContextRefs:        []string{"repo:/workspace/chatting"},
+		ReplyChannelType:   "telegram",
+		ReplyChannelTarget: "8605042448",
+	})
+	if err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+
+	listBody := getOK(t, server.Client(), server.URL+"/schedules")
+	for _, marker := range []string{"daily-note", "5 7 * * *", "/schedules/new", "/schedules/" + record.ScheduleID} {
+		if !strings.Contains(listBody, marker) {
+			t.Fatalf("list page missing %q\n%s", marker, listBody)
+		}
+	}
+
+	detailBody := getOK(t, server.Client(), server.URL+"/schedules/"+record.ScheduleID)
+	for _, marker := range []string{
+		`name="job_name"`,
+		`name="content"`,
+		`name="cron"`,
+		`name="timezone"`,
+		`name="context_refs"`,
+		`name="prompt_context"`,
+		`name="reply_channel_type"`,
+		`name="reply_channel_target"`,
+		"daily-note",
+		"Europe/London",
+		"8605042448",
+		`id="delete"`,
+	} {
+		if !strings.Contains(detailBody, marker) {
+			t.Fatalf("detail page missing %q\n%s", marker, detailBody)
+		}
+	}
+
+	newBody := getOK(t, server.Client(), server.URL+"/schedules/new")
+	if !strings.Contains(newBody, `name="job_name"`) {
+		t.Fatalf("new schedule form missing job_name input\n%s", newBody)
+	}
+	if strings.Contains(newBody, `id="delete"`) {
+		t.Fatal("new schedule form should not offer delete")
+	}
+}
+
+func TestUIDetailMissingReturns404(t *testing.T) {
+	server, _ := newTestUIServer(t)
+	response, err := server.Client().Get(server.URL + "/schedules/sched_missing")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing schedule, got %d", response.StatusCode)
+	}
+}
+
+func getOK(t *testing.T, client *http.Client, url string) string {
+	t.Helper()
+	response, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s expected 200, got %d", url, response.StatusCode)
+	}
+	return string(readBody(t, response))
+}

--- a/tests/test_split_mode_e2e.py
+++ b/tests/test_split_mode_e2e.py
@@ -1,15 +1,85 @@
 import json
 import os
 import socket
+import sqlite3
 import subprocess
 import sys
 import tempfile
 import time
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 from app.state import SQLiteStateStore
 from tests.e2e.handler_selector import message_handler_command
+
+
+def _seed_schedule(
+    handler_db_path: Path,
+    *,
+    job_name: str,
+    content: str,
+    cron: str,
+    context_refs: list[str],
+    reply_channel_type: str,
+    reply_channel_target: str,
+) -> None:
+    # The handler's schedule connector reads active schedules from its DB, not
+    # from a file, so seed the row the same way the API/UI would. Column layout
+    # mirrors the handler's schedules table; created_at uses RFC3339 so the Go
+    # store's parseTimestamp accepts it.
+    now = datetime.now(timezone.utc).isoformat()
+    connection = sqlite3.connect(str(handler_db_path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schedules (
+                row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                schedule_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                job_name TEXT NOT NULL,
+                content TEXT NOT NULL,
+                cron TEXT NOT NULL,
+                timezone TEXT NOT NULL,
+                context_refs TEXT NOT NULL,
+                prompt_context TEXT NOT NULL,
+                reply_channel_type TEXT NOT NULL,
+                reply_channel_target TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                created_by TEXT NOT NULL,
+                superseded_at TEXT
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO schedules (
+                schedule_id, version, status, job_name, content, cron, timezone,
+                context_refs, prompt_context, reply_channel_type,
+                reply_channel_target, created_at, created_by, superseded_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "sched_ci_split_smoke",
+                1,
+                "active",
+                job_name,
+                content,
+                cron,
+                "UTC",
+                json.dumps(context_refs),
+                "[]",
+                reply_channel_type,
+                reply_channel_target,
+                now,
+                "test",
+                None,
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
 
 
 def _is_port_open(host: str, port: int) -> bool:
@@ -57,20 +127,8 @@ class SplitModeE2ETests(unittest.TestCase):
             temp_root = Path(tmpdir)
             handler_db_path = temp_root / "handler.db"
             worker_db_path = temp_root / "worker.db"
-            schedule_path = temp_root / "schedule.json"
             handler_config_path = temp_root / "message-handler.json"
             worker_config_path = temp_root / "worker.json"
-            schedule_payload = [
-                {
-                    "job_name": "ci-split-smoke",
-                    "content": "CI smoke task",
-                    "cron": "* * * * *",
-                    "context_refs": [f"repo:{repo_root}"],
-                    "reply_channel_type": "log",
-                    "reply_channel_target": "ci-split-smoke",
-                }
-            ]
-            schedule_path.write_text(json.dumps(schedule_payload), encoding="utf-8")
 
             handler_config_path.write_text(
                 json.dumps(
@@ -81,10 +139,21 @@ class SplitModeE2ETests(unittest.TestCase):
                         "poll_timeout_seconds": 1,
                         "max_loops": 20,
                         "allowed_egress_channels": ["log"],
-                        "schedule_file": str(schedule_path),
                     }
                 ),
                 encoding="utf-8",
+            )
+
+            # The connector reads active schedules from the handler DB (not a
+            # file), so seed the smoke schedule before the handler starts.
+            _seed_schedule(
+                handler_db_path,
+                job_name="ci-split-smoke",
+                content="CI smoke task",
+                cron="* * * * *",
+                context_refs=[f"repo:{repo_root}"],
+                reply_channel_type="log",
+                reply_channel_target="ci-split-smoke",
             )
             worker_config_path.write_text(
                 json.dumps(


### PR DESCRIPTION
PR1 (#237) added the schedules table and CRUD API, but the connector still loaded jobs once from `live-schedule.local.json` at startup, so nothing the API wrote could actually change what fired. This makes the DB authoritative and editable.

The connector now reads active schedules from the DB on every Poll via a new `ScheduleSource` (a `StoreSource` adapter over the sqlite Store) and reconciles in-memory scheduling state keyed by the stable `schedule_id` rather than the mutable job name: new schedules initialise their next run, a changed cron expression recomputes it, other edits keep the existing timing but refresh the job so content/reply/ref changes apply, removed schedules are pruned, and invalid ones are skipped and logged. The emitted `cron:<job_name>:<time>` event id is preserved so idempotency stays continuous across the file to DB cutover. `main.go` now always builds the connector from the store source.

Also serves a small server-rendered CRUD UI on the existing 9464 server: `/schedules` (list), `/schedules/{id}` (edit), `/schedules/new` (create). Every mutation goes through the JSON API via fetch, so the UI and agents share one validated write path. No auth, LAN-only, same posture as the worker UI.

On magpie the DB is already seeded with the 5 schedules from the file, so on deploy the connector fires the same set from the DB, just now editable. `config.ScheduleFile` is now unused; removing it and retiring the file is the follow-up lab PR.