### PR TITLE
Make egress error drops loud instead of silent

### DIFF
--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -120,9 +120,10 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 			_, err := store.MarkTelegramTaskAttachmentsEligible(ctx, message.TaskID, eligibleAfter)
 			return err
 		}),
-		egress.WithDispatchFailureHook(func(ctx context.Context, message contracts.EgressQueueMessage, reasonCode string) {
-			log.Printf("egress_dispatch_failed task_id=%s event_id=%s channel=%s target=%s reason=%s",
-				message.TaskID, message.EventID, message.Message.Channel, message.Message.Target, reasonCode)
+		egress.WithDropHook(func(ctx context.Context, message contracts.EgressQueueMessage, reasonCode string) {
+			// The engine already logs a loud line for every error-class drop; this hook
+			// is only the operator alert. It sends SMTP directly (not via the egress
+			// engine) so it cannot recurse into another drop.
 			sendEgressDispatchErrorEmail(ctx, emailSender, errorEmailRecipient, message, reasonCode)
 		}),
 	}
@@ -427,9 +428,10 @@ func resolveErrorEmailRecipient(config handlerconfig.Config) string {
 	return ""
 }
 
-// sendEgressDispatchErrorEmail notifies the operator that a single egress event could
-// not be delivered. The event has already been dropped so the handler keeps running;
-// this is the visibility half of that trade-off.
+// sendEgressDispatchErrorEmail notifies the operator that a single egress message was
+// dropped (bad payload, unknown task, disallowed channel, or dispatch failure). The
+// event has already been dropped so the handler keeps running; this is the visibility
+// half of that trade-off.
 func sendEgressDispatchErrorEmail(ctx context.Context, sender dispatch.EmailSender, recipient string, message contracts.EgressQueueMessage, reasonCode string) {
 	if sender == nil || strings.TrimSpace(recipient) == "" {
 		return
@@ -438,9 +440,9 @@ func sendEgressDispatchErrorEmail(ctx context.Context, sender dispatch.EmailSend
 	if message.Sequence != nil {
 		sequence = strconv.Itoa(*message.Sequence)
 	}
-	subject := "Chatting handler dispatch error: " + reasonCode
+	subject := "Chatting handler egress message dropped: " + reasonCode
 	body := strings.Join([]string{
-		"Message-handler egress dispatch failed.",
+		"Message-handler dropped an egress message.",
 		"task_id: " + message.TaskID,
 		"envelope_id: " + message.EnvelopeID,
 		"trace_id: " + message.TraceID,

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -53,11 +54,11 @@ func (fn DispatcherFunc) Dispatch(ctx context.Context, message contracts.Outboun
 }
 
 type Engine struct {
-	state             State
-	dispatcher        Dispatcher
-	allowedChannels   map[string]bool
-	onCompletion      func(context.Context, contracts.EgressQueueMessage) error
-	onDispatchFailure func(context.Context, contracts.EgressQueueMessage, string)
+	state           State
+	dispatcher      Dispatcher
+	allowedChannels map[string]bool
+	onCompletion    func(context.Context, contracts.EgressQueueMessage) error
+	onDrop          func(context.Context, contracts.EgressQueueMessage, string)
 }
 
 type Option func(*Engine)
@@ -77,12 +78,14 @@ func WithCompletionHook(hook func(context.Context, contracts.EgressQueueMessage)
 	}
 }
 
-// WithDispatchFailureHook registers a callback invoked when a single egress event
-// fails to dispatch. The event is dropped (acked) rather than crashing the handler,
-// so the hook is responsible for making the failure visible (log + operator email).
-func WithDispatchFailureHook(hook func(context.Context, contracts.EgressQueueMessage, string)) Option {
+// WithDropHook registers a callback invoked whenever the engine drops an egress
+// message for an error-class reason (bad payload, unknown task, disallowed channel,
+// dispatch failure). Dropping is treated as an operational error, so the engine always
+// logs a loud line; the hook is responsible for the operator alert (email). It is NOT
+// called for idempotency drops (a late/duplicate event after task completion).
+func WithDropHook(hook func(context.Context, contracts.EgressQueueMessage, string)) Option {
 	return func(engine *Engine) {
-		engine.onDispatchFailure = hook
+		engine.onDrop = hook
 	}
 }
 
@@ -120,14 +123,14 @@ const (
 func (engine *Engine) HandleRaw(ctx context.Context, raw []byte) (Result, error) {
 	message, err := contracts.DecodeEgressQueueMessage(raw)
 	if err != nil {
-		return Result{Status: StatusDropped, Reason: "invalid_payload"}, nil
+		return engine.surfaceDrop(ctx, message, "invalid_payload")
 	}
 	return engine.Handle(ctx, message)
 }
 
 func (engine *Engine) Handle(ctx context.Context, message contracts.EgressQueueMessage) (Result, error) {
 	if err := message.Validate(); err != nil {
-		return Result{Status: StatusDropped, Reason: "invalid_payload"}, nil
+		return engine.surfaceDrop(ctx, message, "invalid_payload")
 	}
 
 	completed, err := engine.state.IsTaskCompleted(ctx, message.TaskID, message.EnvelopeID)
@@ -135,6 +138,9 @@ func (engine *Engine) Handle(ctx context.Context, message contracts.EgressQueueM
 		return Result{}, err
 	}
 	if completed {
+		// Idempotency, not an error: a late or duplicate event after the task already
+		// completed. Log plainly and do not raise the operator alert.
+		log.Printf("egress_dropped_after_completion task_id=%s event_id=%s", message.TaskID, message.EventID)
 		return Result{Status: StatusDropped, Reason: "completed_task"}, nil
 	}
 
@@ -143,11 +149,11 @@ func (engine *Engine) Handle(ctx context.Context, message contracts.EgressQueueM
 		return Result{}, err
 	}
 	if task == nil || task.EnvelopeID != message.EnvelopeID {
-		return Result{Status: StatusDropped, Reason: "unknown_task"}, nil
+		return engine.surfaceDrop(ctx, message, "unknown_task")
 	}
 
 	if !engine.channelAllowed(message, task) {
-		return Result{Status: StatusDropped, Reason: "disallowed_channel"}, nil
+		return engine.surfaceDrop(ctx, message, "disallowed_channel")
 	}
 
 	dispatched, err := engine.state.HasDispatchedEventID(ctx, message.TaskID, message.EventID)
@@ -160,7 +166,7 @@ func (engine *Engine) Handle(ctx context.Context, message contracts.EgressQueueM
 
 	if message.Sequence == nil {
 		if message.EventKind == "completion" {
-			return Result{Status: StatusDropped, Reason: "invalid_payload"}, nil
+			return engine.surfaceDrop(ctx, message, "invalid_payload")
 		}
 		if err := engine.dispatchAndMark(ctx, task, message); err != nil {
 			if reason, ok := dispatchFailureReason(err); ok {
@@ -239,7 +245,17 @@ func (engine *Engine) Flush(ctx context.Context, taskID string) (Result, error) 
 		}
 
 		if !engine.channelAllowed(message, task) {
-			return Result{}, fmt.Errorf("staged event %s has disallowed channel %q", staged.EventID, message.Message.Channel)
+			// A disallowed channel is a loud drop, not a fatal error: surface it and
+			// advance past the staged event so the flush is not stuck crash-looping.
+			result, err := engine.surfaceDrop(ctx, message, "disallowed_channel")
+			if err != nil {
+				return Result{}, err
+			}
+			if err := engine.state.MarkStagedEventDispatched(ctx, taskID, staged.EventID, staged.Sequence); err != nil {
+				return Result{}, err
+			}
+			last = result
+			continue
 		}
 		if err := engine.dispatchAndMark(ctx, task, message); err != nil {
 			reason, ok := dispatchFailureReason(err)
@@ -262,13 +278,46 @@ func (engine *Engine) Flush(ctx context.Context, taskID string) (Result, error) 
 	}
 }
 
-// dropFailedDispatch handles a permanent per-message dispatch failure: it surfaces
-// the failure (log + operator email via the hook), records the event as dispatched so
-// it is not retried, and reports the event as dropped. The egress message is acked by
-// the caller, so a single bad event no longer crash-loops the handler.
+// surfaceDrop makes an error-class drop loud: it emits a structured ERROR log line
+// (with a short body preview when present) and invokes the drop hook so the operator is
+// alerted. Every error-class drop must go through here so the engine logs uniformly for
+// all of them. It always reports the event as dropped and never returns an error.
+func (engine *Engine) surfaceDrop(ctx context.Context, message contracts.EgressQueueMessage, reason string) (Result, error) {
+	log.Printf("egress_message_dropped task_id=%s event_id=%s channel=%s target=%s event_kind=%s reason=%s%s",
+		message.TaskID, message.EventID, message.Message.Channel, message.Message.Target, message.EventKind, reason, egressBodyPreview(message))
+	if engine.onDrop != nil {
+		engine.onDrop(ctx, message, reason)
+	}
+	return Result{Status: StatusDropped, Reason: reason}, nil
+}
+
+// egressBodyPreview returns a truncated, single-line preview of the message body for
+// logging, or "" when there is no body. It never appears without a leading space.
+func egressBodyPreview(message contracts.EgressQueueMessage) string {
+	if message.Message.Body == nil {
+		return ""
+	}
+	body := strings.TrimSpace(*message.Message.Body)
+	if body == "" {
+		return ""
+	}
+	body = strings.Join(strings.Fields(body), " ")
+	const maxLen = 120
+	if runes := []rune(body); len(runes) > maxLen {
+		body = string(runes[:maxLen]) + "..."
+	}
+	return fmt.Sprintf(" body=%q", body)
+}
+
+// dropFailedDispatch handles a permanent per-message dispatch failure: it surfaces the
+// drop (loud log + operator alert via the hook), records the event as dispatched so it
+// is not retried, and reports the event as dropped. The egress message is acked by the
+// caller, so a single bad event no longer crash-loops the handler. reasonCode carries
+// the upstream API description for the log/alert; the Result reason stays "dispatch_failed"
+// so metrics bucket dispatch failures together.
 func (engine *Engine) dropFailedDispatch(ctx context.Context, message contracts.EgressQueueMessage, reasonCode string) (Result, error) {
-	if engine.onDispatchFailure != nil {
-		engine.onDispatchFailure(ctx, message, reasonCode)
+	if _, err := engine.surfaceDrop(ctx, message, reasonCode); err != nil {
+		return Result{}, err
 	}
 	if err := engine.state.MarkDispatchedEventID(ctx, message.TaskID, message.EventID); err != nil {
 		return Result{}, err

--- a/go/handler/internal/egress/egress_test.go
+++ b/go/handler/internal/egress/egress_test.go
@@ -1,10 +1,13 @@
 package egress
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -295,7 +298,7 @@ func TestHandleDropsAndNotifiesOnUnsequencedDispatchFailure(t *testing.T) {
 	var notified []string
 	engine := newTestEngineWithState(t, state, dispatcher,
 		WithAllowedChannels([]string{"email"}),
-		WithDispatchFailureHook(func(_ context.Context, message contracts.EgressQueueMessage, reasonCode string) {
+		WithDropHook(func(_ context.Context, message contracts.EgressQueueMessage, reasonCode string) {
 			notified = append(notified, message.EventID+"|"+reasonCode)
 		}),
 	)
@@ -315,6 +318,136 @@ func TestHandleDropsAndNotifiesOnUnsequencedDispatchFailure(t *testing.T) {
 	}
 }
 
+func TestSurfacedDropsFireHookAndLogLoudly(t *testing.T) {
+	names := []string{"disallowed_channel", "unknown_task", "invalid_payload"}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			var notified []string
+			state := newFakeState()
+			var message contracts.EgressQueueMessage
+			switch name {
+			case "disallowed_channel":
+				task := testTaskMessage(t)
+				state.addTask(task)
+				message = testEgressMessage(t, task, nil, "evt:1", "incremental")
+				message.Message.Channel = "telegram"
+			case "unknown_task":
+				message = testEgressMessage(t, testTaskMessage(t), nil, "evt:1", "incremental")
+			case "invalid_payload":
+				// A completion event with no sequence is a malformed payload.
+				task := testTaskMessage(t)
+				state.addTask(task)
+				message = testEgressMessage(t, task, nil, "evt:completion", "completion")
+			}
+			engine := newTestEngineWithState(t, state, &recordingDispatcher{},
+				WithAllowedChannels([]string{"email"}),
+				WithDropHook(func(_ context.Context, m contracts.EgressQueueMessage, reasonCode string) {
+					notified = append(notified, reasonCode)
+				}),
+			)
+
+			logged := captureLog(t, func() {
+				result, err := engine.Handle(context.Background(), message)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if result.Status != StatusDropped || result.Reason != name {
+					t.Fatalf("result = %#v", result)
+				}
+			})
+
+			if want := []string{name}; !reflect.DeepEqual(notified, want) {
+				t.Fatalf("hook fired with %#v, want %#v", notified, want)
+			}
+			if !strings.Contains(logged, "egress_message_dropped") || !strings.Contains(logged, "reason="+name) {
+				t.Fatalf("loud drop log missing, got %q", logged)
+			}
+		})
+	}
+}
+
+func TestCompletedTaskDropDoesNotFireHook(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.completed[task.TaskID] = task.Envelope.ID
+	fired := false
+	engine := newTestEngineWithState(t, state, &recordingDispatcher{},
+		WithAllowedChannels([]string{"email"}),
+		WithDropHook(func(_ context.Context, _ contracts.EgressQueueMessage, _ string) { fired = true }),
+	)
+
+	logged := captureLog(t, func() {
+		result, err := engine.Handle(context.Background(), testEgressMessage(t, task, nil, "evt:1", "incremental"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Status != StatusDropped || result.Reason != "completed_task" {
+			t.Fatalf("result = %#v", result)
+		}
+	})
+
+	if fired {
+		t.Fatal("idempotency drop must not fire the operator alert hook")
+	}
+	if strings.Contains(logged, "egress_message_dropped") {
+		t.Fatalf("completed_task must not log the error-class line, got %q", logged)
+	}
+	if !strings.Contains(logged, "egress_dropped_after_completion") {
+		t.Fatalf("completed_task should log its informational line, got %q", logged)
+	}
+}
+
+func TestFlushDropsAndContinuesOnStagedDisallowedChannel(t *testing.T) {
+	ctx := context.Background()
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	notified := 0
+	engine := newTestEngineWithState(t, state, dispatcher,
+		WithAllowedChannels([]string{"email"}),
+		WithDropHook(func(_ context.Context, _ contracts.EgressQueueMessage, _ string) { notified++ }),
+	)
+
+	// Simulate an event staged under a looser config (e.g. before a restart with a
+	// stricter allowed-channels list): stage a now-disallowed channel directly, then a
+	// deliverable follow-on, and drive the flush.
+	disallowed := testEgressMessage(t, task, intPtr(0), "evt:0", "message")
+	disallowed.Message.Channel = "telegram"
+	disallowed.Message.Body = stringPtr("dropped")
+	if err := state.StageEgressEvent(ctx, disallowed); err != nil {
+		t.Fatal(err)
+	}
+	next := testEgressMessage(t, task, intPtr(1), "evt:1", "message")
+	next.Message.Body = stringPtr("delivered")
+	if err := state.StageEgressEvent(ctx, next); err != nil {
+		t.Fatal(err)
+	}
+
+	logged := captureLog(t, func() {
+		result, err := engine.Flush(ctx, task.TaskID)
+		if err != nil {
+			t.Fatalf("staged disallowed channel must not crash the flush: %v", err)
+		}
+		if result.Status != StatusDispatched {
+			t.Fatalf("flush result = %#v (should end on the delivered follow-on)", result)
+		}
+	})
+	if notified != 1 {
+		t.Fatalf("notified = %d, want 1", notified)
+	}
+	if !strings.Contains(logged, "egress_message_dropped") || !strings.Contains(logged, "reason=disallowed_channel") {
+		t.Fatalf("staged disallowed drop should log loudly, got %q", logged)
+	}
+	if got, _ := state.ExpectedSequence(ctx, task.TaskID); got != 2 {
+		t.Fatalf("expected sequence = %d, want 2 (must advance past both staged events)", got)
+	}
+	if got := dispatcher.bodies(); got != "delivered" {
+		t.Fatalf("dispatched bodies = %q, want %q (disallowed event must be dropped, not sent)", got, "delivered")
+	}
+}
+
 func TestFlushDropsAndContinuesOnSequencedDispatchFailure(t *testing.T) {
 	task := testTaskMessage(t)
 	state := newFakeState()
@@ -323,7 +456,7 @@ func TestFlushDropsAndContinuesOnSequencedDispatchFailure(t *testing.T) {
 	notified := 0
 	engine := newTestEngineWithState(t, state, dispatcher,
 		WithAllowedChannels([]string{"email"}),
-		WithDispatchFailureHook(func(_ context.Context, _ contracts.EgressQueueMessage, _ string) { notified++ }),
+		WithDropHook(func(_ context.Context, _ contracts.EgressQueueMessage, _ string) { notified++ }),
 	)
 	first := testEgressMessage(t, task, intPtr(0), "evt:0", "message")
 	first.Message.Body = stringPtr("first")
@@ -608,6 +741,21 @@ func testEgressMessage(t *testing.T, task contracts.TaskQueueMessage, sequence *
 		},
 		Sequence: sequence,
 	}
+}
+
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buffer bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(&buffer)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+	}()
+	fn()
+	return buffer.String()
 }
 
 func intPtr(value int) *int {


### PR DESCRIPTION
A silently dropped egress message is an operational error - bad config or bad agent behaviour that should be stamped out - not something to swallow. The allowed-channels list is a legitimate guard, but the engine was dropping several classes (disallowed_channel, unknown_task, invalid_payload, HandleRaw decode failure) silently; only dispatch failures were ever surfaced.

Generalised the dispatch-failure hook into a single drop hook (`WithDispatchFailureHook`/`onDispatchFailure` become `WithDropHook`/`onDrop`) and added a `surfaceDrop()` helper that emits a structured ERROR log (`egress_message_dropped`, reason, truncated body preview) and fires the alert hook. Every error-class drop now routes through it, so the engine logs uniformly and the main.go hook is alert-only (operator email, wording generalised to "egress message dropped: <reason>"). `completed_task` is idempotency, so it stays a plain info log with no alert. The alert email is a direct SMTP send rather than going back through the egress engine, so surfacing a drop can't loop.

Also fixed `Flush()`'s staged disallowed-channel path: it was a hard `fmt.Errorf` that crash-looped the flush, and now it drops-and-continues like the non-staged path, which matters when a config tightening makes a previously-staged channel no longer allowed.