### PR TITLE
Add timestamps to Telegram context history

### DIFF
--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -348,9 +348,10 @@ func (state handlerIngressState) ListRecentConversationTurns(ctx context.Context
 	result := make([]handlerruntime.ConversationTurn, 0, len(turns))
 	for _, turn := range turns {
 		result = append(result, handlerruntime.ConversationTurn{
-			Role:    turn.Role,
-			Content: turn.Content,
-			Sender:  turn.Sender,
+			Role:      turn.Role,
+			Content:   turn.Content,
+			Sender:    turn.Sender,
+			CreatedAt: turn.CreatedAt,
 		})
 	}
 	return result, nil

--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -48,9 +48,10 @@ type TelegramAttachmentCleanupState interface {
 }
 
 type ConversationTurn struct {
-	Role    string
-	Content string
-	Sender  string
+	Role      string
+	Content   string
+	Sender    string
+	CreatedAt time.Time
 }
 
 type TelegramConversationState interface {
@@ -259,7 +260,7 @@ func prepareTelegramEnvelope(ctx context.Context, state TelegramConversationStat
 		lines := make([]string, 0, len(turns)+3)
 		lines = append(lines, "Recent conversation context (oldest first):")
 		for _, turn := range turns {
-			lines = append(lines, conversationTurnLabel(turn)+": "+turn.Content)
+			lines = append(lines, formatConversationTurn(turn))
 		}
 		header := "Current user message:"
 		if currentSender != "" {
@@ -281,6 +282,14 @@ func conversationTurnLabel(turn ConversationTurn) string {
 		return turn.Sender
 	}
 	return turn.Role
+}
+
+func formatConversationTurn(turn ConversationTurn) string {
+	label := conversationTurnLabel(turn) + ": " + turn.Content
+	if turn.CreatedAt.IsZero() {
+		return label
+	}
+	return "[" + turn.CreatedAt.UTC().Format("2006-01-02 15:04Z") + "] " + label
 }
 
 // telegramSenderLabel derives a human-readable sender for the current inbound

--- a/go/handler/internal/runtime/runtime_test.go
+++ b/go/handler/internal/runtime/runtime_test.go
@@ -231,8 +231,9 @@ func TestPublishIngressEnrichesTelegramEnvelopeWithRecentConversation(t *testing
 	state := newFakeIngressState()
 	for index := 0; index < 35; index++ {
 		state.turns["12345"] = append(state.turns["12345"], ConversationTurn{
-			Role:    "user",
-			Content: fmt.Sprintf("turn-%d", index),
+			Role:      "user",
+			Content:   fmt.Sprintf("turn-%d", index),
+			CreatedAt: mustTime(t, fmt.Sprintf("2026-03-09T11:%02d:00Z", index%60)),
 		})
 	}
 	envelope := contracts.TaskEnvelope{
@@ -270,10 +271,10 @@ func TestPublishIngressEnrichesTelegramEnvelopeWithRecentConversation(t *testing
 	if !strings.Contains(recorded.Envelope.Content, "Recent conversation context (oldest first):") {
 		t.Fatalf("content = %q", recorded.Envelope.Content)
 	}
-	if !strings.Contains(recorded.Envelope.Content, "user: turn-5") || !strings.Contains(recorded.Envelope.Content, "user: turn-34") {
+	if !strings.Contains(recorded.Envelope.Content, "[2026-03-09 11:05Z] user: turn-5") || !strings.Contains(recorded.Envelope.Content, "[2026-03-09 11:34Z] user: turn-34") {
 		t.Fatalf("content = %q", recorded.Envelope.Content)
 	}
-	if strings.Contains(recorded.Envelope.Content, "user: turn-4") {
+	if strings.Contains(recorded.Envelope.Content, "turn-4") {
 		t.Fatalf("content = %q", recorded.Envelope.Content)
 	}
 	if !strings.Contains(recorded.Envelope.Content, "Current user message:\nlatest-turn") {
@@ -289,8 +290,8 @@ func TestPublishIngressAttributesTelegramSenderInConversation(t *testing.T) {
 	broker := &fakeBroker{}
 	state := newFakeIngressState()
 	state.turns["12345"] = []ConversationTurn{
-		{Role: "user", Content: "earlier", Sender: "@alice"},
-		{Role: "assistant", Content: "billy replied"},
+		{Role: "user", Content: "earlier", Sender: "@alice", CreatedAt: mustTime(t, "2026-03-09T11:58:00Z")},
+		{Role: "assistant", Content: "billy replied", CreatedAt: mustTime(t, "2026-03-09T11:59:00Z")},
 	}
 	envelope := contracts.TaskEnvelope{
 		SchemaVersion: contracts.SchemaVersion,
@@ -319,10 +320,10 @@ func TestPublishIngressAttributesTelegramSenderInConversation(t *testing.T) {
 		t.Fatal(err)
 	}
 	content := state.tasks["task:telegram:101"].Envelope.Content
-	if !strings.Contains(content, "@alice: earlier") {
+	if !strings.Contains(content, "[2026-03-09 11:58Z] @alice: earlier") {
 		t.Fatalf("history not attributed by sender: %q", content)
 	}
-	if !strings.Contains(content, "assistant: billy replied") {
+	if !strings.Contains(content, "[2026-03-09 11:59Z] assistant: billy replied") {
 		t.Fatalf("assistant turn should fall back to role: %q", content)
 	}
 	if !strings.Contains(content, "Current message from @bob (bot):\nlatest-turn") {
@@ -524,7 +525,12 @@ func (state *fakeIngressState) AppendConversationTurn(ctx context.Context, chann
 	if channel != "telegram" {
 		return nil
 	}
-	state.turns[target] = append(state.turns[target], ConversationTurn{Role: role, Content: content, Sender: sender})
+	state.turns[target] = append(state.turns[target], ConversationTurn{
+		Role:      role,
+		Content:   content,
+		Sender:    sender,
+		CreatedAt: time.Now().UTC(),
+	})
 	return nil
 }
 

--- a/go/handler/internal/state/sqlite/sqlite.go
+++ b/go/handler/internal/state/sqlite/sqlite.go
@@ -91,9 +91,10 @@ type TelegramAttachmentCleanupResult struct {
 }
 
 type ConversationTurn struct {
-	Role    string
-	Content string
-	Sender  string
+	Role      string
+	Content   string
+	Sender    string
+	CreatedAt time.Time
 }
 
 type GitHubAssignmentCheckpoint struct {
@@ -1063,7 +1064,7 @@ func (store *Store) ListRecentConversationTurns(ctx context.Context, channel str
 	}
 	rows, err := store.db.QueryContext(
 		ctx,
-		`SELECT role, content, sender
+		`SELECT role, content, sender, created_at
 		FROM conversation_turns
 		WHERE channel = ? AND target = ?
 		ORDER BY turn_id DESC
@@ -1080,10 +1081,15 @@ func (store *Store) ListRecentConversationTurns(ctx context.Context, channel str
 	for rows.Next() {
 		turn := ConversationTurn{}
 		var sender sql.NullString
-		if err := rows.Scan(&turn.Role, &turn.Content, &sender); err != nil {
+		var createdAt string
+		if err := rows.Scan(&turn.Role, &turn.Content, &sender, &createdAt); err != nil {
 			return nil, err
 		}
 		turn.Sender = sender.String
+		turn.CreatedAt, err = parseTimestamp(createdAt)
+		if err != nil {
+			return nil, err
+		}
 		reversed = append(reversed, turn)
 	}
 	if err := rows.Err(); err != nil {

--- a/go/handler/internal/state/sqlite/sqlite_test.go
+++ b/go/handler/internal/state/sqlite/sqlite_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -161,11 +160,32 @@ func TestConversationTurnsRoundTripScopedByChannelAndTarget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := turns, []ConversationTurn{
-		{Role: "user", Content: "hello", Sender: "@alice"},
-		{Role: "assistant", Content: "hi there", Sender: ""},
-	}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("turns = %#v, want %#v", got, want)
+	if len(turns) != 2 {
+		t.Fatalf("len(turns) = %d", len(turns))
+	}
+	if got, want := turns[0].Role, "user"; got != want {
+		t.Fatalf("turns[0].Role = %q, want %q", got, want)
+	}
+	if got, want := turns[0].Content, "hello"; got != want {
+		t.Fatalf("turns[0].Content = %q, want %q", got, want)
+	}
+	if got, want := turns[0].Sender, "@alice"; got != want {
+		t.Fatalf("turns[0].Sender = %q, want %q", got, want)
+	}
+	if turns[0].CreatedAt.IsZero() {
+		t.Fatal("turns[0].CreatedAt was zero")
+	}
+	if got, want := turns[1].Role, "assistant"; got != want {
+		t.Fatalf("turns[1].Role = %q, want %q", got, want)
+	}
+	if got, want := turns[1].Content, "hi there"; got != want {
+		t.Fatalf("turns[1].Content = %q, want %q", got, want)
+	}
+	if got, want := turns[1].Sender, ""; got != want {
+		t.Fatalf("turns[1].Sender = %q, want %q", got, want)
+	}
+	if turns[1].CreatedAt.IsZero() {
+		t.Fatal("turns[1].CreatedAt was zero")
 	}
 }
 


### PR DESCRIPTION
## Summary
- plumb `conversation_turns.created_at` through the handler SQLite/state/runtime layers
- include minute-resolution UTC timestamps on prior Telegram conversation context lines
- extend handler runtime/sqlite tests to cover the new prompt shape and stored timestamps

## Testing
- go test ./internal/runtime ./internal/state/sqlite
