### PR TITLE
Write Telegram attachments readable by the worker

### DIFF
--- a/go/handler/internal/connectors/telegram/telegram.go
+++ b/go/handler/internal/connectors/telegram/telegram.go
@@ -330,7 +330,16 @@ func (connector *Connector) extractAttachments(updateID int64, message telegramM
 	if err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(destination, raw, 0o600); err != nil {
+	if err := os.WriteFile(destination, raw, 0o644); err != nil {
+		return nil, err
+	}
+	// The worker/executor runs as a different OS user than the handler in the
+	// split deployment, so it must be able to read a file it never wrote.
+	// os.WriteFile's mode is masked by the process umask (the handler runs
+	// UMask=0077), which would leave the file 0600 and unreadable by the
+	// worker. An explicit Chmod is not subject to the umask, so force the
+	// readable mode here.
+	if err := os.Chmod(destination, 0o644); err != nil {
 		return nil, err
 	}
 	name := path.Base(metadata.FilePath)

--- a/go/handler/internal/connectors/telegram/telegram_test.go
+++ b/go/handler/internal/connectors/telegram/telegram_test.go
@@ -321,6 +321,16 @@ func TestPollDownloadsPhotoAttachmentAndUsesCaptionAsContent(t *testing.T) {
 	if string(raw) != "jpeg-bytes" {
 		t.Fatalf("downloaded bytes = %q", string(raw))
 	}
+	// The worker runs as a separate OS user, so the attachment must be
+	// readable beyond the owner (see extractAttachments). Assert the
+	// group/other read bits survive rather than the file staying 0600.
+	info, err := os.Stat(downloadedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm&0o044 != 0o044 {
+		t.Fatalf("attachment mode = %o, want group/other readable", perm)
+	}
 	if len(requestedURLs) != 3 {
 		t.Fatalf("requested URLs = %#v", requestedURLs)
 	}


### PR DESCRIPTION
Telegram photo attachments stopped reaching the worker/codex after chatting moved off the old Docker host (blink) onto the NixOS host (magpie). On blink the handler and worker were separate containers but shared one container UID and a shared /tmp, so a 0600 file the handler wrote was readable by the worker. On magpie the runtime is split into three OS users (bbmb/handler/worker) with private trees and the handler runs UMask=0077, so the downloaded 0600 attachment is readable only by `handler` and the `worker` user running `codex exec` gets permission denied and never sees the image.

The handler now writes the attachment readable beyond its owner: `os.WriteFile` requests 0o644 plus an explicit `os.Chmod(destination, 0o644)`. The chmod is what actually matters here since WriteFile's create mode is masked by the process umask but an explicit chmod is not. A test in telegram_test.go now asserts the group/other read bits survive so this can't silently regress.

This is the app-side half of a two-part fix. The companion lab (NixOS) PR provides a shared, worker-traversable attachment directory and points `telegram_attachment_dir` at it - the file being readable is necessary but not sufficient, it also has to live somewhere the worker can traverse to. Deploy is gated on the corresponding lab flake bump.