### PR TITLE
Fail closed when Telegram replies are not published

### DIFF
--- a/app/state/sqlite_store.py
+++ b/app/state/sqlite_store.py
@@ -738,6 +738,25 @@ class SQLiteStateStore:
             )
             connection.commit()
 
+    def count_task_main_reply_egress_events(self, *, task_id: str) -> int:
+        if not task_id:
+            raise ValueError("task_id is required")
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT detail_json
+                FROM worker_activity_events
+                WHERE task_id = ? AND phase = 'egress_incremental'
+                """,
+                (task_id,),
+            ).fetchall()
+        count = 0
+        for row in rows:
+            detail = json.loads(row["detail_json"])
+            if detail.get("publish_source") == "main_reply":
+                count += 1
+        return count
+
     def list_recent_worker_activity(
         self,
         *,

--- a/app/worker/runtime.py
+++ b/app/worker/runtime.py
@@ -95,15 +95,28 @@ def process_task_message(
                     content=execution_result.stderr,
                 )
 
-            reason_codes = (
-                ["executor_reported_errors"] if execution_result.errors else []
+            published_incremental_reply_count = (
+                store.count_task_main_reply_egress_events(
+                    task_id=task_message.task_id
+                )
             )
+            reason_codes = []
+            if execution_result.errors:
+                reason_codes.append("executor_reported_errors")
+            if (
+                _requires_visible_telegram_reply(task_message)
+                and not execution_result.errors
+                and published_incremental_reply_count == 0
+            ):
+                reason_codes.append("missing_visible_reply")
             result_status = _result_status(reason_codes)
 
             egress_messages = _build_completion_egress_messages(
                 task_message=task_message,
                 starting_sequence=0,
-                visible_error_body=_build_credit_exhausted_visible_error(
+                visible_error_body=_build_visible_error_body(
+                    task_message=task_message,
+                    reason_codes=reason_codes,
                     execution_errors=execution_result.errors,
                     last_error=None,
                 ),
@@ -123,7 +136,9 @@ def process_task_message(
                 egress_messages = _build_completion_egress_messages(
                     task_message=task_message,
                     starting_sequence=0,
-                    visible_error_body=_build_credit_exhausted_visible_error(
+                    visible_error_body=_build_visible_error_body(
+                        task_message=task_message,
+                        reason_codes=reason_codes,
                         execution_errors=[],
                         last_error=last_error,
                     ),
@@ -158,7 +173,11 @@ def process_task_message(
                 "last_error_stage": last_error_stage,
                 "execution_result": execution_payload,
                 "incremental_reply_send_requested_count": 0,
-                "incremental_reply_send_published_count": 0,
+                "incremental_reply_send_published_count": (
+                    store.count_task_main_reply_egress_events(
+                        task_id=task_message.task_id
+                    )
+                ),
                 "egress_message_count": len(egress_messages),
             },
             created_at=run_record.created_at,
@@ -435,9 +454,39 @@ def _build_completion_egress(
 def _result_status(reason_codes: list[str]) -> str:
     if "executor_reported_errors" in reason_codes:
         return "execution_error"
+    if "missing_visible_reply" in reason_codes:
+        return "execution_error"
     if "retry_exhausted" in reason_codes:
         return "dead_letter"
     return "success"
+
+
+def _requires_visible_telegram_reply(task_message: TaskQueueMessage) -> bool:
+    return task_message.envelope.reply_channel.type == "telegram"
+
+
+def _build_visible_error_body(
+    *,
+    task_message: TaskQueueMessage,
+    reason_codes: list[str],
+    execution_errors: list[str],
+    last_error: str | None,
+) -> str | None:
+    if "missing_visible_reply" in reason_codes:
+        return _build_missing_visible_reply_error(task_message=task_message)
+    return _build_credit_exhausted_visible_error(
+        execution_errors=execution_errors,
+        last_error=last_error,
+    )
+
+
+def _build_missing_visible_reply_error(*, task_message: TaskQueueMessage) -> str | None:
+    if not _requires_visible_telegram_reply(task_message):
+        return None
+    return (
+        "I finished the task internally but failed to publish the Telegram reply, "
+        "so this run was marked failed instead of completing silently."
+    )
 
 
 def _build_credit_exhausted_visible_error(

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -88,6 +88,29 @@ class FinalAliasExecutor:
         return ExecutionResult(errors=[])
 
 
+@dataclass(frozen=True)
+class MainReplyExecutor:
+    store: SQLiteStateStore
+
+    def execute(self, task):
+        self.store.append_worker_activity(
+            occurred_at=datetime.now(timezone.utc),
+            task_id=f"task:{task.id}",
+            envelope_id=task.id,
+            phase="egress_incremental",
+            summary="incremental egress to telegram",
+            detail={
+                "channel": "telegram",
+                "target": task.reply_channel.target,
+                "event_id": "evt:test:main-reply",
+                "event_kind": "incremental",
+                "publish_source": "main_reply",
+                "sequence": None,
+            },
+        )
+        return ExecutionResult(errors=[])
+
+
 class WorkerRuntimeTests(unittest.TestCase):
     def _build_monitor(self, store: SQLiteStateStore) -> WorkerActivityMonitor:
         return WorkerActivityMonitor(store=store, history_limit=10)
@@ -105,6 +128,24 @@ class WorkerRuntimeTests(unittest.TestCase):
             dedupe_key="email:1",
         )
         return TaskQueueMessage.from_envelope(envelope, trace_id="trace:email:1")
+
+    def _build_telegram_task_message(self) -> TaskQueueMessage:
+        envelope = TaskEnvelope(
+            id="telegram:1",
+            source="im",
+            received_at=datetime(2026, 3, 6, 13, 0, tzinfo=timezone.utc),
+            actor="8605042448:edsalkeld",
+            content="hello",
+            attachments=[],
+            context_refs=[],
+            reply_channel=ReplyChannel(
+                type="telegram",
+                target="8605042448",
+                metadata={"message_id": 2471},
+            ),
+            dedupe_key="telegram:1",
+        )
+        return TaskQueueMessage.from_envelope(envelope, trace_id="trace:telegram:1")
 
     def _build_internal_heartbeat_task_message(self) -> TaskQueueMessage:
         return TaskQueueMessage.from_envelope(
@@ -261,7 +302,7 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertLessEqual(len(result.error_summary), 240)
             self.assertTrue(result.error_summary.endswith("..."))
 
-    def test_process_task_message_emits_completion_even_when_executor_does_no_actions(
+    def test_process_task_message_keeps_non_telegram_success_without_visible_reply(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -285,24 +326,32 @@ class WorkerRuntimeTests(unittest.TestCase):
                 audit_event.detail["incremental_reply_send_published_count"], 0
             )
 
-    def test_process_task_message_ignores_incremental_reply_policy_when_executor_returns_completion_only(
+    def test_process_task_message_marks_telegram_success_without_visible_reply_as_execution_error(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
             result = process_task_message(
                 store=store,
-                task_message=self._build_task_message(),
+                task_message=self._build_telegram_task_message(),
                 executor_impl=IncrementalReplyExecutor(),
                 max_attempts=2,
                 activity_monitor=self._build_monitor(store),
             )
 
-            self.assertEqual(len(result.egress_messages), 1)
-            self.assertEqual(result.egress_messages[0].event_kind, "completion")
+            self.assertEqual(result.run_record.result_status, "execution_error")
+            self.assertEqual(result.reason_codes, ["missing_visible_reply"])
+            self.assertEqual(len(result.egress_messages), 2)
+            self.assertEqual(result.egress_messages[0].event_kind, "message")
+            self.assertEqual(result.egress_messages[0].message.channel, "telegram")
             audit_event = store.list_audit_events()[0]
-            self.assertNotIn(
-                "incremental_reply_send_not_allowed", audit_event.detail["reason_codes"]
+            self.assertIn(
+                "failed to publish the Telegram reply",
+                result.egress_messages[0].message.body,
+            )
+            self.assertEqual(result.egress_messages[1].event_kind, "completion")
+            self.assertEqual(
+                audit_event.detail["incremental_reply_send_published_count"], 0
             )
 
     def test_process_task_message_handles_internal_heartbeat_without_executor(
@@ -359,6 +408,27 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertEqual(terminal.message.channel, "internal")
             self.assertEqual(terminal.message.target, "task")
             self.assertEqual(terminal.sequence, 0)
+
+    def test_process_task_message_allows_telegram_success_when_main_reply_was_published(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            result = process_task_message(
+                store=store,
+                task_message=self._build_telegram_task_message(),
+                executor_impl=MainReplyExecutor(store=store),
+                max_attempts=2,
+                activity_monitor=self._build_monitor(store),
+            )
+
+            self.assertEqual(result.run_record.result_status, "success")
+            self.assertEqual(len(result.egress_messages), 1)
+            self.assertEqual(result.egress_messages[0].event_kind, "completion")
+            audit_event = store.list_audit_events()[0]
+            self.assertEqual(
+                audit_event.detail["incremental_reply_send_published_count"], 1
+            )
 
     def test_process_task_message_handles_internal_channel_notice_without_executor(
         self,


### PR DESCRIPTION
## Summary
- mark Telegram tasks as execution errors when the executor exits cleanly without any published main_reply egress
- record published main_reply counts in the SQLite state store and audit detail
- cover the non-Telegram, missing-reply, and published-reply paths in worker runtime tests

## Testing
- python3 -m unittest tests.test_worker_runtime tests.test_main_reply
