### PR TITLE
Add opt-in supervised Telegram reply recovery

### DIFF
--- a/app/worker/executor/__init__.py
+++ b/app/worker/executor/__init__.py
@@ -2,5 +2,6 @@
 
 from app.worker.executor.base import Executor
 from app.worker.executor.codex import CodexExecutor
+from app.worker.executor.supervised import SupervisedReplyRecoveryExecutor
 
-__all__ = ["Executor", "CodexExecutor"]
+__all__ = ["Executor", "CodexExecutor", "SupervisedReplyRecoveryExecutor"]

--- a/app/worker/executor/supervised.py
+++ b/app/worker/executor/supervised.py
@@ -1,0 +1,100 @@
+"""Executor wrapper for opt-in Telegram reply recovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from app.models import ExecutionResult, PromptContext, TaskEnvelope
+from app.state import SQLiteStateStore
+from app.worker.executor.base import Executor
+
+_SUPERVISED_RECOVERY_INSTRUCTION = (
+    "The earlier executor pass finished without publishing any visible reply. "
+    "Do not redo side effects or rerun the task. Use the captured transcript below "
+    "to send exactly one visible reply with python3 -m app.main_reply, then stop."
+)
+
+
+@dataclass
+class SupervisedReplyRecoveryExecutor:
+    """Wrap another executor and retry once for missing visible replies."""
+
+    inner: Executor
+    store: SQLiteStateStore
+    last_recovery_attempted: bool = field(init=False, default=False)
+    last_launch_count: int = field(init=False, default=0)
+
+    def execute(self, envelope: TaskEnvelope) -> ExecutionResult:
+        self.last_recovery_attempted = False
+        self.last_launch_count = 1
+        task_id = f"task:{envelope.id}"
+        before_count = self.store.count_task_main_reply_egress_events(task_id=task_id)
+        first_result = self.inner.execute(envelope)
+        after_first_count = self.store.count_task_main_reply_egress_events(
+            task_id=task_id
+        )
+        if first_result.errors or after_first_count > before_count:
+            return first_result
+
+        self.last_recovery_attempted = True
+        self.last_launch_count = 2
+        recovery_envelope = _build_supervised_recovery_envelope(
+            original_envelope=envelope,
+            execution_result=first_result,
+        )
+        second_result = self.inner.execute(recovery_envelope)
+        return ExecutionResult(
+            errors=list(second_result.errors),
+            stdout=_merge_stream(
+                first_result.stdout, second_result.stdout, label="stdout"
+            ),
+            stderr=_merge_stream(
+                first_result.stderr, second_result.stderr, label="stderr"
+            ),
+        )
+
+
+def _build_supervised_recovery_envelope(
+    *,
+    original_envelope: TaskEnvelope,
+    execution_result: ExecutionResult,
+) -> TaskEnvelope:
+    transcript_parts = []
+    if execution_result.stdout:
+        transcript_parts.append("Captured stdout:\n" + execution_result.stdout.strip())
+    if execution_result.stderr:
+        transcript_parts.append("Captured stderr:\n" + execution_result.stderr.strip())
+    transcript = "\n\n".join(part for part in transcript_parts if part.strip())
+    recovery_instruction = _SUPERVISED_RECOVERY_INSTRUCTION
+    if transcript:
+        recovery_instruction = recovery_instruction + "\n\n" + transcript
+    prompt_context = original_envelope.prompt_context
+    return replace(
+        original_envelope,
+        prompt_context=PromptContext(
+            global_instructions=list(prompt_context.global_instructions),
+            source_instructions=list(prompt_context.source_instructions),
+            reply_channel_instructions=list(prompt_context.reply_channel_instructions),
+            task_instructions=list(prompt_context.task_instructions)
+            + [recovery_instruction],
+        ),
+    )
+
+
+def _merge_stream(
+    first: str | None,
+    second: str | None,
+    *,
+    label: str,
+) -> str | None:
+    parts = []
+    if first:
+        parts.append(f"First pass {label}:\n{first.strip()}")
+    if second:
+        parts.append(f"Recovery pass {label}:\n{second.strip()}")
+    if not parts:
+        return None
+    return "\n\n".join(parts)
+
+
+__all__ = ["SupervisedReplyRecoveryExecutor"]

--- a/app/worker/runtime.py
+++ b/app/worker/runtime.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import re
 import time
+from dataclasses import replace
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
+
 from app.broker import EgressQueueMessage, TaskQueueMessage
 from app.worker.executor import Executor
 from app.internal_heartbeat import (
@@ -18,11 +21,25 @@ from app.internal_notices import (
     build_internal_telegram_channel_not_enabled_egress,
     is_internal_telegram_channel_not_enabled_envelope,
 )
-from app.models import AuditEvent, OutboundMessage, RunRecord
+from app.models import (
+    AuditEvent,
+    ExecutionResult,
+    OutboundMessage,
+    PromptContext,
+    RunRecord,
+    TaskEnvelope,
+)
 from app.state import SQLiteStateStore
 
 if TYPE_CHECKING:
     from app.worker.activity import WorkerActivityMonitor
+
+_SUPERVISED_MARKER_RE = re.compile(r"(?<!\S)#super(?!\S)", re.IGNORECASE)
+_SUPERVISED_RECOVERY_INSTRUCTION = (
+    "The earlier executor pass finished without publishing any visible reply. "
+    "Do not redo side effects or rerun the task. Use the captured transcript below "
+    "to send exactly one visible reply with python3 -m app.main_reply, then stop."
+)
 
 
 @dataclass(frozen=True)
@@ -71,35 +88,60 @@ def process_task_message(
     last_error_stage: str | None = None
     execution_payload: dict[str, object] | None = None
     egress_messages: list[EgressQueueMessage] = []
+    executor_launch_count = 0
+    used_supervised_recovery = False
+    normalized_envelope = _normalize_executor_envelope(envelope)
 
     for attempt in range(1, max_attempts + 1):
         attempt_count = attempt
 
         try:
+            active_envelope = normalized_envelope
+            executor_launch_count += 1
             activity_monitor.record_executor_started(
                 task_message=task_message,
-                attempt=attempt,
+                attempt=executor_launch_count,
             )
-            execution_result = executor_impl.execute(envelope)
+            execution_result = executor_impl.execute(active_envelope)
             execution_payload = execution_result.to_dict()
-            if execution_result.stdout:
-                activity_monitor.record_executor_output(
-                    task_message=task_message,
-                    stream="stdout",
-                    content=execution_result.stdout,
-                )
-            if execution_result.stderr:
-                activity_monitor.record_executor_output(
-                    task_message=task_message,
-                    stream="stderr",
-                    content=execution_result.stderr,
-                )
+            _record_execution_output(
+                activity_monitor=activity_monitor,
+                task_message=task_message,
+                execution_result=execution_result,
+            )
 
             published_incremental_reply_count = (
                 store.count_task_main_reply_egress_events(
                     task_id=task_message.task_id
                 )
             )
+            if (
+                _should_run_supervised_recovery(task_message)
+                and not execution_result.errors
+                and published_incremental_reply_count == 0
+            ):
+                used_supervised_recovery = True
+                active_envelope = _build_supervised_recovery_envelope(
+                    original_envelope=active_envelope,
+                    execution_result=execution_result,
+                )
+                executor_launch_count += 1
+                activity_monitor.record_executor_started(
+                    task_message=task_message,
+                    attempt=executor_launch_count,
+                )
+                execution_result = executor_impl.execute(active_envelope)
+                execution_payload = execution_result.to_dict()
+                _record_execution_output(
+                    activity_monitor=activity_monitor,
+                    task_message=task_message,
+                    execution_result=execution_result,
+                )
+                published_incremental_reply_count = (
+                    store.count_task_main_reply_egress_events(
+                        task_id=task_message.task_id
+                    )
+                )
             reason_codes = []
             if execution_result.errors:
                 reason_codes.append("executor_reported_errors")
@@ -127,7 +169,7 @@ def process_task_message(
             last_error_stage = "executor"
             activity_monitor.record_executor_failure(
                 task_message=task_message,
-                attempt=attempt,
+                attempt=executor_launch_count or attempt,
                 error=last_error,
             )
             if attempt == max_attempts:
@@ -168,9 +210,11 @@ def process_task_message(
                 "task_id": task_message.task_id,
                 "reason_codes": reason_codes,
                 "attempt_count": attempt_count,
+                "executor_launch_count": executor_launch_count,
                 "max_attempts": max_attempts,
                 "last_error": last_error,
                 "last_error_stage": last_error_stage,
+                "supervised_recovery_used": used_supervised_recovery,
                 "execution_result": execution_payload,
                 "incremental_reply_send_requested_count": 0,
                 "incremental_reply_send_published_count": (
@@ -199,7 +243,7 @@ def process_task_message(
         task_message=task_message,
         run_id=run_record.run_id,
         result_status=run_record.result_status,
-        attempt_count=attempt_count,
+        attempt_count=executor_launch_count or attempt_count,
         reason_codes=reason_codes,
         latency_ms=latency_ms,
     )
@@ -220,7 +264,7 @@ def process_task_message(
         run_record=run_record,
         egress_messages=egress_messages,
         dead_lettered=dead_lettered,
-        attempt_count=attempt_count,
+        attempt_count=executor_launch_count or attempt_count,
         reason_codes=list(reason_codes),
         error_summary=error_summary,
     )
@@ -459,6 +503,74 @@ def _result_status(reason_codes: list[str]) -> str:
     if "retry_exhausted" in reason_codes:
         return "dead_letter"
     return "success"
+
+
+def _record_execution_output(
+    *,
+    activity_monitor: WorkerActivityMonitor,
+    task_message: TaskQueueMessage,
+    execution_result: ExecutionResult,
+) -> None:
+    if execution_result.stdout:
+        activity_monitor.record_executor_output(
+            task_message=task_message,
+            stream="stdout",
+            content=execution_result.stdout,
+        )
+    if execution_result.stderr:
+        activity_monitor.record_executor_output(
+            task_message=task_message,
+            stream="stderr",
+            content=execution_result.stderr,
+        )
+
+
+def _should_run_supervised_recovery(task_message: TaskQueueMessage) -> bool:
+    return _requires_visible_telegram_reply(task_message) and bool(
+        _SUPERVISED_MARKER_RE.search(task_message.envelope.content)
+    )
+
+
+def _normalize_executor_envelope(envelope: TaskEnvelope) -> TaskEnvelope:
+    normalized_content = _strip_supervised_marker(envelope.content)
+    if normalized_content == envelope.content:
+        return envelope
+    return replace(envelope, content=normalized_content)
+
+
+def _strip_supervised_marker(content: str) -> str:
+    stripped = _SUPERVISED_MARKER_RE.sub("", content)
+    stripped = re.sub(r"[ \t]{2,}", " ", stripped)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped)
+    stripped = stripped.strip()
+    return stripped or content
+
+
+def _build_supervised_recovery_envelope(
+    *,
+    original_envelope: TaskEnvelope,
+    execution_result: ExecutionResult,
+) -> TaskEnvelope:
+    transcript_parts = []
+    if execution_result.stdout:
+        transcript_parts.append("Captured stdout:\n" + execution_result.stdout.strip())
+    if execution_result.stderr:
+        transcript_parts.append("Captured stderr:\n" + execution_result.stderr.strip())
+    transcript = "\n\n".join(part for part in transcript_parts if part.strip())
+    recovery_instruction = _SUPERVISED_RECOVERY_INSTRUCTION
+    if transcript:
+        recovery_instruction = recovery_instruction + "\n\n" + transcript
+    prompt_context = original_envelope.prompt_context
+    return replace(
+        original_envelope,
+        prompt_context=PromptContext(
+            global_instructions=list(prompt_context.global_instructions),
+            source_instructions=list(prompt_context.source_instructions),
+            reply_channel_instructions=list(prompt_context.reply_channel_instructions),
+            task_instructions=list(prompt_context.task_instructions)
+            + [recovery_instruction],
+        ),
+    )
 
 
 def _requires_visible_telegram_reply(task_message: TaskQueueMessage) -> bool:

--- a/app/worker/runtime.py
+++ b/app/worker/runtime.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from app.broker import EgressQueueMessage, TaskQueueMessage
-from app.worker.executor import Executor
+from app.worker.executor import Executor, SupervisedReplyRecoveryExecutor
 from app.internal_heartbeat import (
     build_internal_completion_egress,
     build_internal_heartbeat_egress,
@@ -25,7 +25,6 @@ from app.models import (
     AuditEvent,
     ExecutionResult,
     OutboundMessage,
-    PromptContext,
     RunRecord,
     TaskEnvelope,
 )
@@ -35,11 +34,6 @@ if TYPE_CHECKING:
     from app.worker.activity import WorkerActivityMonitor
 
 _SUPERVISED_MARKER_RE = re.compile(r"(?<!\S)#super(?!\S)", re.IGNORECASE)
-_SUPERVISED_RECOVERY_INSTRUCTION = (
-    "The earlier executor pass finished without publishing any visible reply. "
-    "Do not redo side effects or rerun the task. Use the captured transcript below "
-    "to send exactly one visible reply with python3 -m app.main_reply, then stop."
-)
 
 
 @dataclass(frozen=True)
@@ -91,6 +85,12 @@ def process_task_message(
     executor_launch_count = 0
     used_supervised_recovery = False
     normalized_envelope = _normalize_executor_envelope(envelope)
+    active_executor: Executor = executor_impl
+    if _should_run_supervised_recovery(task_message):
+        active_executor = SupervisedReplyRecoveryExecutor(
+            inner=executor_impl,
+            store=store,
+        )
 
     for attempt in range(1, max_attempts + 1):
         attempt_count = attempt
@@ -102,7 +102,10 @@ def process_task_message(
                 task_message=task_message,
                 attempt=executor_launch_count,
             )
-            execution_result = executor_impl.execute(active_envelope)
+            execution_result = active_executor.execute(active_envelope)
+            if isinstance(active_executor, SupervisedReplyRecoveryExecutor):
+                executor_launch_count = active_executor.last_launch_count
+                used_supervised_recovery = active_executor.last_recovery_attempted
             execution_payload = execution_result.to_dict()
             _record_execution_output(
                 activity_monitor=activity_monitor,
@@ -115,33 +118,6 @@ def process_task_message(
                     task_id=task_message.task_id
                 )
             )
-            if (
-                _should_run_supervised_recovery(task_message)
-                and not execution_result.errors
-                and published_incremental_reply_count == 0
-            ):
-                used_supervised_recovery = True
-                active_envelope = _build_supervised_recovery_envelope(
-                    original_envelope=active_envelope,
-                    execution_result=execution_result,
-                )
-                executor_launch_count += 1
-                activity_monitor.record_executor_started(
-                    task_message=task_message,
-                    attempt=executor_launch_count,
-                )
-                execution_result = executor_impl.execute(active_envelope)
-                execution_payload = execution_result.to_dict()
-                _record_execution_output(
-                    activity_monitor=activity_monitor,
-                    task_message=task_message,
-                    execution_result=execution_result,
-                )
-                published_incremental_reply_count = (
-                    store.count_task_main_reply_egress_events(
-                        task_id=task_message.task_id
-                    )
-                )
             reason_codes = []
             if execution_result.errors:
                 reason_codes.append("executor_reported_errors")
@@ -544,33 +520,6 @@ def _strip_supervised_marker(content: str) -> str:
     stripped = re.sub(r"\n{3,}", "\n\n", stripped)
     stripped = stripped.strip()
     return stripped or content
-
-
-def _build_supervised_recovery_envelope(
-    *,
-    original_envelope: TaskEnvelope,
-    execution_result: ExecutionResult,
-) -> TaskEnvelope:
-    transcript_parts = []
-    if execution_result.stdout:
-        transcript_parts.append("Captured stdout:\n" + execution_result.stdout.strip())
-    if execution_result.stderr:
-        transcript_parts.append("Captured stderr:\n" + execution_result.stderr.strip())
-    transcript = "\n\n".join(part for part in transcript_parts if part.strip())
-    recovery_instruction = _SUPERVISED_RECOVERY_INSTRUCTION
-    if transcript:
-        recovery_instruction = recovery_instruction + "\n\n" + transcript
-    prompt_context = original_envelope.prompt_context
-    return replace(
-        original_envelope,
-        prompt_context=PromptContext(
-            global_instructions=list(prompt_context.global_instructions),
-            source_instructions=list(prompt_context.source_instructions),
-            reply_channel_instructions=list(prompt_context.reply_channel_instructions),
-            task_instructions=list(prompt_context.task_instructions)
-            + [recovery_instruction],
-        ),
-    )
 
 
 def _requires_visible_telegram_reply(task_message: TaskQueueMessage) -> bool:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -111,6 +111,69 @@ class MainReplyExecutor:
         return ExecutionResult(errors=[])
 
 
+class RecordingExecutor:
+    def __init__(self, results: list[ExecutionResult]) -> None:
+        self._results = list(results)
+        self.calls: list[TaskEnvelope] = []
+
+    def execute(self, task):
+        self.calls.append(task)
+        if not self._results:
+            raise AssertionError("unexpected executor call")
+        return self._results.pop(0)
+
+
+class ReplyOnSecondPassExecutor:
+    def __init__(self, store: SQLiteStateStore) -> None:
+        self.store = store
+        self.calls: list[TaskEnvelope] = []
+
+    def execute(self, task):
+        self.calls.append(task)
+        if len(self.calls) == 2:
+            self.store.append_worker_activity(
+                occurred_at=datetime.now(timezone.utc),
+                task_id=f"task:{task.id}",
+                envelope_id=task.id,
+                phase="egress_incremental",
+                summary="incremental egress to telegram",
+                detail={
+                    "channel": "telegram",
+                    "target": task.reply_channel.target,
+                    "event_id": "evt:test:recovery-main-reply",
+                    "event_kind": "incremental",
+                    "publish_source": "main_reply",
+                    "sequence": None,
+                },
+            )
+        return ExecutionResult(errors=[], stdout=f"pass {len(self.calls)}")
+
+
+class MainReplyRecordingExecutor:
+    def __init__(self, store: SQLiteStateStore) -> None:
+        self.store = store
+        self.calls: list[TaskEnvelope] = []
+
+    def execute(self, task):
+        self.calls.append(task)
+        self.store.append_worker_activity(
+            occurred_at=datetime.now(timezone.utc),
+            task_id=f"task:{task.id}",
+            envelope_id=task.id,
+            phase="egress_incremental",
+            summary="incremental egress to telegram",
+            detail={
+                "channel": "telegram",
+                "target": task.reply_channel.target,
+                "event_id": "evt:test:recording-main-reply",
+                "event_kind": "incremental",
+                "publish_source": "main_reply",
+                "sequence": None,
+            },
+        )
+        return ExecutionResult(errors=[])
+
+
 class WorkerRuntimeTests(unittest.TestCase):
     def _build_monitor(self, store: SQLiteStateStore) -> WorkerActivityMonitor:
         return WorkerActivityMonitor(store=store, history_limit=10)
@@ -146,6 +209,26 @@ class WorkerRuntimeTests(unittest.TestCase):
             dedupe_key="telegram:1",
         )
         return TaskQueueMessage.from_envelope(envelope, trace_id="trace:telegram:1")
+
+    def _build_supervised_telegram_task_message(self) -> TaskQueueMessage:
+        envelope = TaskEnvelope(
+            id="telegram:super:1",
+            source="im",
+            received_at=datetime(2026, 3, 6, 13, 0, tzinfo=timezone.utc),
+            actor="8605042448:edsalkeld",
+            content="hello #super",
+            attachments=[],
+            context_refs=[],
+            reply_channel=ReplyChannel(
+                type="telegram",
+                target="8605042448",
+                metadata={"message_id": 2471},
+            ),
+            dedupe_key="telegram:super:1",
+        )
+        return TaskQueueMessage.from_envelope(
+            envelope, trace_id="trace:telegram:super:1"
+        )
 
     def _build_internal_heartbeat_task_message(self) -> TaskQueueMessage:
         return TaskQueueMessage.from_envelope(
@@ -353,6 +436,106 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertEqual(
                 audit_event.detail["incremental_reply_send_published_count"], 0
             )
+
+    def test_process_task_message_keeps_untagged_telegram_on_standard_single_pass(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            executor = RecordingExecutor([ExecutionResult(errors=[], stdout="pass 1")])
+            result = process_task_message(
+                store=store,
+                task_message=self._build_telegram_task_message(),
+                executor_impl=executor,
+                max_attempts=2,
+                activity_monitor=self._build_monitor(store),
+            )
+
+            self.assertEqual(result.run_record.result_status, "execution_error")
+            self.assertEqual(result.attempt_count, 1)
+            self.assertEqual(len(executor.calls), 1)
+            audit_event = store.list_audit_events()[0]
+            self.assertEqual(audit_event.detail["executor_launch_count"], 1)
+            self.assertEqual(audit_event.detail["supervised_recovery_used"], False)
+
+    def test_process_task_message_strips_supervised_marker_before_executor(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            executor = MainReplyRecordingExecutor(store=store)
+            result = process_task_message(
+                store=store,
+                task_message=self._build_supervised_telegram_task_message(),
+                executor_impl=executor,
+                max_attempts=2,
+                activity_monitor=self._build_monitor(store),
+            )
+
+            self.assertEqual(result.run_record.result_status, "success")
+            self.assertEqual(len(executor.calls), 1)
+            self.assertEqual(executor.calls[0].content, "hello")
+
+    def test_process_task_message_runs_supervised_recovery_for_tagged_telegram(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            executor = RecordingExecutor(
+                [
+                    ExecutionResult(errors=[], stdout="first pass transcript"),
+                    ExecutionResult(errors=[], stdout="second pass transcript"),
+                ]
+            )
+            result = process_task_message(
+                store=store,
+                task_message=self._build_supervised_telegram_task_message(),
+                executor_impl=executor,
+                max_attempts=2,
+                activity_monitor=self._build_monitor(store),
+            )
+
+            self.assertEqual(result.run_record.result_status, "execution_error")
+            self.assertEqual(result.reason_codes, ["missing_visible_reply"])
+            self.assertEqual(result.attempt_count, 2)
+            self.assertEqual(len(executor.calls), 2)
+            self.assertEqual(executor.calls[0].content, "hello")
+            self.assertEqual(executor.calls[1].content, "hello")
+            self.assertIn(
+                "Do not redo side effects or rerun the task.",
+                executor.calls[1].prompt_context.task_instructions[-1],
+            )
+            self.assertIn(
+                "Captured stdout:\nfirst pass transcript",
+                executor.calls[1].prompt_context.task_instructions[-1],
+            )
+            audit_event = store.list_audit_events()[0]
+            self.assertEqual(audit_event.detail["executor_launch_count"], 2)
+            self.assertEqual(audit_event.detail["supervised_recovery_used"], True)
+
+    def test_process_task_message_supervised_recovery_can_publish_reply_and_succeed(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            executor = ReplyOnSecondPassExecutor(store=store)
+            result = process_task_message(
+                store=store,
+                task_message=self._build_supervised_telegram_task_message(),
+                executor_impl=executor,
+                max_attempts=2,
+                activity_monitor=self._build_monitor(store),
+            )
+
+            self.assertEqual(result.run_record.result_status, "success")
+            self.assertEqual(result.attempt_count, 2)
+            self.assertEqual(len(executor.calls), 2)
+            self.assertEqual(result.reason_codes, [])
+            audit_event = store.list_audit_events()[0]
+            self.assertEqual(
+                audit_event.detail["incremental_reply_send_published_count"], 1
+            )
+            self.assertEqual(audit_event.detail["supervised_recovery_used"], True)
 
     def test_process_task_message_handles_internal_heartbeat_without_executor(
         self,

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -512,6 +512,11 @@ class WorkerRuntimeTests(unittest.TestCase):
             audit_event = store.list_audit_events()[0]
             self.assertEqual(audit_event.detail["executor_launch_count"], 2)
             self.assertEqual(audit_event.detail["supervised_recovery_used"], True)
+            self.assertEqual(
+                audit_event.detail["execution_result"]["stdout"],
+                "First pass stdout:\nfirst pass transcript\n\n"
+                "Recovery pass stdout:\nsecond pass transcript",
+            )
 
     def test_process_task_message_supervised_recovery_can_publish_reply_and_succeed(
         self,
@@ -535,6 +540,7 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertEqual(
                 audit_event.detail["incremental_reply_send_published_count"], 1
             )
+            self.assertEqual(audit_event.detail["executor_launch_count"], 2)
             self.assertEqual(audit_event.detail["supervised_recovery_used"], True)
 
     def test_process_task_message_handles_internal_heartbeat_without_executor(


### PR DESCRIPTION
## Summary
- add an opt-in `#super` marker for Telegram tasks and strip it before the executor sees the prompt
- rerun the executor once in reply-recovery mode when the first clean pass exits without publishing any visible reply
- record supervised recovery usage/launch counts and cover the standard and supervised paths in worker runtime tests

## Testing
- `python3 -m unittest tests.test_worker_runtime`
- `python3 -m unittest tests.test_main_reply`
