### PR TITLE
Submit visible replies to the handler synchronously

### DIFF
--- a/app/main_reply.py
+++ b/app/main_reply.py
@@ -7,15 +7,62 @@ import json
 import os
 import sys
 import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
-from app.broker import BBMBQueueAdapter, EGRESS_QUEUE_NAME, EgressQueueMessage
+from app.broker import EgressQueueMessage
 from app.models import AttachmentRef, OutboundMessage
 from app.state import SQLiteStateStore
 from app.task_ledger import TaskLedgerStore
 from app.telegram_text import normalize_telegram_outbound_text
 from app.worker.main import WORKER_CONFIG_PATH_ENV_VAR, _load_config, _resolve_str
+
+# The reply script submits synchronously to the handler's loopback egress
+# endpoint and learns the delivery outcome, instead of publishing to BBMB
+# fire-and-forget. The handler default binds 127.0.0.1:9467 (see the handler's
+# DefaultEgressHTTPHost/Port); a shared default means no extra config is needed
+# when worker and handler run on the same host.
+DEFAULT_HANDLER_EGRESS_URL = "http://127.0.0.1:9467/egress"
+_SUBMIT_TIMEOUT_SECONDS = 30
+
+# Exit codes the executor can act on. 0 = delivered; DROPPED = the handler
+# rejected the message for good (bad payload, unknown task, disallowed channel,
+# dispatch failure such as a missing attachment) so the caller should fall back
+# rather than retry the same send; TRANSIENT = the handler was unreachable or
+# returned a server error, so a retry may succeed. (2 stays the usage/validation
+# error from the ValueError path.)
+EXIT_DROPPED = 1
+EXIT_TRANSIENT = 3
+
+
+def _submit_egress(url: str, payload: dict[str, object]) -> tuple[int, dict[str, object]]:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_SUBMIT_TIMEOUT_SECONDS) as response:
+            return response.status, _decode_body(response.read())
+    except urllib.error.HTTPError as error:
+        return error.code, _decode_body(error.read())
+    except urllib.error.URLError as error:
+        # Connection refused / DNS / timeout: the handler never processed it.
+        return 0, {"reason": f"egress endpoint unreachable: {error.reason}"}
+
+
+def _decode_body(raw: bytes) -> dict[str, object]:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw.decode("utf-8", "replace"))
+    except json.JSONDecodeError:
+        return {"reason": raw.decode("utf-8", "replace")}
+    return parsed if isinstance(parsed, dict) else {"reason": str(parsed)}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -55,7 +102,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--trace-id", help="Trace id (defaults to trace:<envelope_id>)."
     )
-    parser.add_argument("--bbmb-address", help="BBMB broker address host:port.")
+    parser.add_argument(
+        "--handler-egress-url",
+        help="Handler synchronous egress endpoint URL (default the worker config's handler_egress_url).",
+    )
     parser.add_argument(
         "--config",
         help=(
@@ -185,11 +235,11 @@ def main() -> int:
     args = _parse_args()
     config = _load_config(args.config, os.environ)
 
-    bbmb_address = _resolve_str(
-        args.bbmb_address,
-        config.get("bbmb_address"),
-        default_value="127.0.0.1:9876",
-        setting_name="bbmb_address",
+    handler_egress_url = _resolve_str(
+        args.handler_egress_url,
+        config.get("handler_egress_url"),
+        default_value=DEFAULT_HANDLER_EGRESS_URL,
+        setting_name="handler_egress_url",
     )
 
     envelope_id = _resolve_envelope_id(args.task_id, args.envelope_id)
@@ -213,10 +263,15 @@ def main() -> int:
         message_type="chatting.egress.v2",
     )
 
-    broker = BBMBQueueAdapter(address=bbmb_address)
-    broker.ensure_queue(EGRESS_QUEUE_NAME)
-    guid = broker.publish_json(EGRESS_QUEUE_NAME, egress_message.to_dict())
-    if db_path is not None:
+    status_code, response = _submit_egress(handler_egress_url, egress_message.to_dict())
+    result_status = str(response.get("status", "")) if isinstance(response, dict) else ""
+    reason = str(response.get("reason", "")) if isinstance(response, dict) else ""
+
+    delivered = status_code in (200, 202)
+    if delivered and db_path is not None:
+        # Only record the activity event on confirmed delivery: the supervised
+        # reply-recovery loop counts these to decide whether a visible reply was
+        # actually sent, so a dropped send must not look like a success.
         SQLiteStateStore(db_path).append_worker_activity(
             occurred_at=egress_message.emitted_at,
             task_id=egress_message.task_id,
@@ -234,25 +289,30 @@ def main() -> int:
                 "message_type": egress_message.message_type,
                 "publish_source": "main_reply",
                 "sequence": egress_message.sequence,
+                "result_status": result_status,
             },
             is_internal=egress_message.message.channel in {"internal", "log"},
         )
 
-    print(
-        json.dumps(
-            {
-                "status": "published",
-                "queue": EGRESS_QUEUE_NAME,
-                "guid": guid,
-                "task_id": egress_message.task_id,
-                "event_id": egress_message.event_id,
-                "event_kind": egress_message.event_kind,
-                "sequence": egress_message.sequence,
-            },
-            sort_keys=True,
-        )
-    )
-    return 0
+    payload = {
+        "status": result_status or ("dispatched" if delivered else "error"),
+        "http_status": status_code,
+        "task_id": egress_message.task_id,
+        "event_id": egress_message.event_id,
+        "event_kind": egress_message.event_kind,
+        "sequence": egress_message.sequence,
+        "reason": reason,
+    }
+    if delivered:
+        print(json.dumps(payload, sort_keys=True))
+        return 0
+
+    # Not delivered: surface loudly on stderr so the executor transcript shows
+    # it and the exit code drives a fallback (or retry).
+    print(json.dumps(payload, sort_keys=True), file=sys.stderr)
+    if status_code == 422:
+        return EXIT_DROPPED
+    return EXIT_TRANSIENT
 
 
 def _resolve_optional_db_path(config: dict[str, object]) -> str | None:

--- a/app/worker/executor/codex.py
+++ b/app/worker/executor/codex.py
@@ -102,6 +102,14 @@ def _task_payload(
             "visible_replies_must_not_be_returned_in_executor_output": True,
             "executor_exit_status_drives_completion": True,
             "executor_stdout_stderr_are_operator_transcript": True,
+            "visible_reply_exit_status": (
+                "python3 -m app.main_reply now sends synchronously and its exit code tells "
+                "you whether the user actually received the reply: 0 = delivered; 1 = the "
+                "handler rejected it for good (for example a missing or unreadable "
+                "attachment) so you must adjust and resend, e.g. send the text without the "
+                "attachment; 3 = the handler was unreachable so you may retry. A non-zero "
+                "exit means the reply did NOT reach the user — do not treat it as sent."
+            ),
         },
     }
 

--- a/app/worker/main.py
+++ b/app/worker/main.py
@@ -43,6 +43,7 @@ ALLOWED_WORKER_CONFIG_KEYS = frozenset(
         "codex_working_dir",
         "db_path",
         "activity_history_limit",
+        "handler_egress_url",
         "max_attempts",
         "max_loops",
         "poll_timeout_seconds",

--- a/configs/handler.json.example
+++ b/configs/handler.json.example
@@ -5,6 +5,8 @@
   "poll_timeout_seconds": 2,
   "metrics_host": "0.0.0.0",
   "metrics_port": 9464,
+  "egress_http_host": "0.0.0.0",
+  "egress_http_port": 9467,
   "allowed_egress_channels": ["email", "telegram", "github", "log"],
   "imap_host": "imap.example.com",
   "imap_port": 993,

--- a/configs/worker.json.example
+++ b/configs/worker.json.example
@@ -6,5 +6,6 @@
   "sleep_seconds": 1.0,
   "activity_history_limit": 100,
   "codex_command": "codex exec",
-  "codex_working_dir": "/workspace"
+  "codex_working_dir": "/workspace",
+  "handler_egress_url": "http://handler:9467/egress"
 }

--- a/docs/bbmb-message-flow.md
+++ b/docs/bbmb-message-flow.md
@@ -70,13 +70,23 @@ Worker behavior:
 - the executor returns only completion metadata, actions, config updates, and errors
 - the executor must publish any visible reply itself with `app.main_reply`
 - terminal task closure uses `event_kind="completion"` and is internal-only
-- worker-side `app.main_reply` publishes unsequenced `event_kind="incremental"` messages for both
+- worker-side `app.main_reply` submits unsequenced `event_kind="incremental"` messages for both
   intermediate acknowledgements and final user-visible replies
 - the worker emits only the completion event for normal task processing
 - heartbeat tasks skip the normal executor path and emit a log pong followed by completion
 
-Before publishing each egress message, the worker writes it to the SQLite egress outbox. That lets
-the worker replay unpublished or unacked egress after restart.
+`app.main_reply` does not use BBMB. It POSTs the egress payload to the handler's synchronous
+egress endpoint (`handler_egress_url`, default `http://127.0.0.1:9467/egress`) and gets the
+delivery outcome back: HTTP 200 for a dispatched reply, 422 when the handler drops it (bad payload,
+unknown task, disallowed channel, dispatch failure such as a missing attachment), 503 when the
+handler is unreachable. The exit code follows suit (0 delivered, 1 dropped, 3 transient), so the
+executor learns immediately whether a reply landed instead of publishing fire-and-forget and never
+hearing back. The handler runs the identical engine path either way, serialized so the endpoint and
+the BBMB drain loop share one engine.
+
+Completion (`event_kind="completion"`) and any sequenced events still travel through BBMB. Before
+publishing each of those, the worker writes it to the SQLite egress outbox so it can replay
+unpublished or unacked egress after restart.
 
 The task queue message is only acked after processing completes and egress has been published to the
 outbox/BBMB path.

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -139,9 +139,10 @@ Edit message-handler config:
 
 ## 6) Publish a visible reply from worker side
 
-Use the worker-side CLI to push a visible egress event directly to BBMB. Executors should use this
-path for both quick acknowledgements and final user-visible answers instead of returning replies in
-their stdout/stderr transcript:
+Use the worker-side CLI to submit a visible egress event to the handler's synchronous egress
+endpoint (it POSTs to `handler_egress_url`, not BBMB, and exits non-zero if the handler drops or
+can't reach the send). Executors should use this path for both quick acknowledgements and final
+user-visible answers instead of returning replies in their stdout/stderr transcript:
 
 ```bash
 docker compose exec worker python -m app.main_reply task:email:53 \

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -417,9 +417,10 @@ func buildDispatcher(config handlerconfig.Config) (egress.Dispatcher, dispatch.E
 			return nil, nil, fmt.Errorf("missing Telegram bot token env var: %s", config.TelegramBotTokenEnv)
 		}
 		sender, err := dispatch.NewTelegramMessageSender(dispatch.TelegramConfig{
-			BotToken:   token,
-			APIBaseURL: config.TelegramAPIBaseURL,
-			Timeout:    10 * time.Second,
+			BotToken:              token,
+			APIBaseURL:            config.TelegramAPIBaseURL,
+			Timeout:               10 * time.Second,
+			AttachmentAllowedDirs: config.EgressAttachmentAllowedDirs,
 		})
 		if err != nil {
 			return nil, nil, err

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -293,6 +293,16 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		_ = store.Close()
 		return nil, err
 	}
+	// A dedicated loopback server for synchronous egress submits from the worker
+	// reply script. Kept off the metrics mux on purpose: metrics may bind
+	// 0.0.0.0 for scraping, but sending messages to the world must stay
+	// loopback-only, like BBMB.
+	egressServer, err := egress.StartHTTPServer(config.EgressHTTPHost, config.EgressHTTPPort, engine)
+	if err != nil {
+		_ = metricsServer.Close()
+		_ = store.Close()
+		return nil, err
+	}
 	runner, err := handlerruntime.NewRunner(config, adapter, egressHandlerFunc(func(ctx context.Context, raw []byte) error {
 		result, err := engine.HandleRaw(ctx, raw)
 		if err == nil {
@@ -301,11 +311,12 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 		return err
 	}), handlerruntime.WithIngress(handlerIngressState{store: store}, connectors...), handlerruntime.WithMetrics(metricRecorder))
 	if err != nil {
+		_ = egressServer.Close()
 		_ = metricsServer.Close()
 		_ = store.Close()
 		return nil, err
 	}
-	return &closingRunner{runner: runner, closers: []closer{metricsServer, store}}, nil
+	return &closingRunner{runner: runner, closers: []closer{egressServer, metricsServer, store}}, nil
 }
 
 type githubCheckpointStore struct {

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -21,6 +21,8 @@ const (
 	DefaultPollTimeoutSeconds      = 2
 	DefaultMetricsHost             = "127.0.0.1"
 	DefaultMetricsPort             = 9464
+	DefaultEgressHTTPHost          = "127.0.0.1"
+	DefaultEgressHTTPPort          = 9467
 )
 
 var allowedKeys = map[string]bool{
@@ -31,6 +33,8 @@ var allowedKeys = map[string]bool{
 	"poll_timeout_seconds":    true,
 	"metrics_host":            true,
 	"metrics_port":            true,
+	"egress_http_host":        true,
+	"egress_http_port":        true,
 	"allowed_egress_channels": true,
 	"global_prompt_context":   true,
 	"cron_prompt_context":     true,
@@ -85,6 +89,8 @@ type Config struct {
 	PollTimeoutSeconds    int
 	MetricsHost           string
 	MetricsPort           int
+	EgressHTTPHost        string
+	EgressHTTPPort        int
 	AllowedEgressChannels []string
 	GlobalPromptContext   []string
 	CronPromptContext     []string
@@ -140,6 +146,8 @@ func Defaults() Config {
 		PollTimeoutSeconds:    DefaultPollTimeoutSeconds,
 		MetricsHost:           DefaultMetricsHost,
 		MetricsPort:           DefaultMetricsPort,
+		EgressHTTPHost:        DefaultEgressHTTPHost,
+		EgressHTTPPort:        DefaultEgressHTTPPort,
 		AllowedEgressChannels: []string{"email", "telegram", "telegram_reaction", "github", "log"},
 		GlobalPromptContext:   []string{},
 		CronPromptContext:     []string{},
@@ -282,6 +290,18 @@ func Load(raw []byte) (Config, error) {
 	}
 	if rawValue, ok := payload["metrics_port"]; ok && !isNull(rawValue) {
 		config.MetricsPort, err = decodePositiveInt(rawValue, "metrics_port")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["egress_http_host"]; ok && !isNull(rawValue) {
+		config.EgressHTTPHost, err = decodeNonEmptyString(rawValue, "egress_http_host")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["egress_http_port"]; ok && !isNull(rawValue) {
+		config.EgressHTTPPort, err = decodePositiveInt(rawValue, "egress_http_port")
 		if err != nil {
 			return Config{}, err
 		}

--- a/go/handler/internal/config/config.go
+++ b/go/handler/internal/config/config.go
@@ -26,35 +26,36 @@ const (
 )
 
 var allowedKeys = map[string]bool{
-	"bbmb_address":            true,
-	"db_path":                 true,
-	"max_loops":               true,
-	"poll_interval_seconds":   true,
-	"poll_timeout_seconds":    true,
-	"metrics_host":            true,
-	"metrics_port":            true,
-	"egress_http_host":        true,
-	"egress_http_port":        true,
-	"allowed_egress_channels": true,
-	"global_prompt_context":   true,
-	"cron_prompt_context":     true,
-	"email_prompt_context":    true,
-	"context_refs":            true,
-	"schedule_file":           true,
-	"imap_host":               true,
-	"imap_port":               true,
-	"imap_username":           true,
-	"imap_password_env":       true,
-	"imap_mailbox":            true,
-	"imap_search":             true,
-	"imap_use_ssl":            true,
-	"smtp_host":               true,
-	"smtp_port":               true,
-	"smtp_username":           true,
-	"smtp_password_env":       true,
-	"smtp_from":               true,
-	"smtp_starttls":           true,
-	"smtp_use_ssl":            true,
+	"bbmb_address":                   true,
+	"db_path":                        true,
+	"max_loops":                      true,
+	"poll_interval_seconds":          true,
+	"poll_timeout_seconds":           true,
+	"metrics_host":                   true,
+	"metrics_port":                   true,
+	"egress_http_host":               true,
+	"egress_http_port":               true,
+	"egress_attachment_allowed_dirs": true,
+	"allowed_egress_channels":        true,
+	"global_prompt_context":          true,
+	"cron_prompt_context":            true,
+	"email_prompt_context":           true,
+	"context_refs":                   true,
+	"schedule_file":                  true,
+	"imap_host":                      true,
+	"imap_port":                      true,
+	"imap_username":                  true,
+	"imap_password_env":              true,
+	"imap_mailbox":                   true,
+	"imap_search":                    true,
+	"imap_use_ssl":                   true,
+	"smtp_host":                      true,
+	"smtp_port":                      true,
+	"smtp_username":                  true,
+	"smtp_password_env":              true,
+	"smtp_from":                      true,
+	"smtp_starttls":                  true,
+	"smtp_use_ssl":                   true,
 
 	"telegram_enabled":              true,
 	"telegram_bot_token_env":        true,
@@ -82,36 +83,37 @@ var allowedKeys = map[string]bool{
 }
 
 type Config struct {
-	BBMBAddress           string
-	DBPath                string
-	MaxLoops              int
-	PollIntervalSeconds   float64
-	PollTimeoutSeconds    int
-	MetricsHost           string
-	MetricsPort           int
-	EgressHTTPHost        string
-	EgressHTTPPort        int
-	AllowedEgressChannels []string
-	GlobalPromptContext   []string
-	CronPromptContext     []string
-	EmailPromptContext    []string
-	ContextRefs           []string
-	ScheduleFile          string
-	IMAPHost              string
-	IMAPPort              int
-	IMAPUsername          string
-	IMAPPasswordEnv       string
-	IMAPMailbox           string
-	IMAPSearch            string
-	IMAPUseSSL            bool
-	SMTPHost              string
-	SMTPPort              int
-	SMTPUsername          string
-	SMTPPasswordEnv       string
-	SMTPFrom              string
-	SMTPStartTLS          bool
-	SMTPUseSSL            bool
-	ErrorEmailTo          string
+	BBMBAddress                 string
+	DBPath                      string
+	MaxLoops                    int
+	PollIntervalSeconds         float64
+	PollTimeoutSeconds          int
+	MetricsHost                 string
+	MetricsPort                 int
+	EgressHTTPHost              string
+	EgressHTTPPort              int
+	EgressAttachmentAllowedDirs []string
+	AllowedEgressChannels       []string
+	GlobalPromptContext         []string
+	CronPromptContext           []string
+	EmailPromptContext          []string
+	ContextRefs                 []string
+	ScheduleFile                string
+	IMAPHost                    string
+	IMAPPort                    int
+	IMAPUsername                string
+	IMAPPasswordEnv             string
+	IMAPMailbox                 string
+	IMAPSearch                  string
+	IMAPUseSSL                  bool
+	SMTPHost                    string
+	SMTPPort                    int
+	SMTPUsername                string
+	SMTPPasswordEnv             string
+	SMTPFrom                    string
+	SMTPStartTLS                bool
+	SMTPUseSSL                  bool
+	ErrorEmailTo                string
 
 	TelegramEnabled                       bool
 	TelegramBotTokenEnv                   string
@@ -139,36 +141,37 @@ type Config struct {
 
 func Defaults() Config {
 	return Config{
-		BBMBAddress:           DefaultBBMBAddress,
-		DBPath:                filepath.Join(os.TempDir(), "chatting-message-handler-state.db"),
-		MaxLoops:              0,
-		PollIntervalSeconds:   DefaultPollIntervalSeconds,
-		PollTimeoutSeconds:    DefaultPollTimeoutSeconds,
-		MetricsHost:           DefaultMetricsHost,
-		MetricsPort:           DefaultMetricsPort,
-		EgressHTTPHost:        DefaultEgressHTTPHost,
-		EgressHTTPPort:        DefaultEgressHTTPPort,
-		AllowedEgressChannels: []string{"email", "telegram", "telegram_reaction", "github", "log"},
-		GlobalPromptContext:   []string{},
-		CronPromptContext:     []string{},
-		EmailPromptContext:    []string{},
-		ContextRefs:           []string{},
-		ScheduleFile:          "",
-		IMAPHost:              "",
-		IMAPPort:              993,
-		IMAPUsername:          "",
-		IMAPPasswordEnv:       "CHATTING_IMAP_PASSWORD",
-		IMAPMailbox:           "INBOX",
-		IMAPSearch:            "UNSEEN",
-		IMAPUseSSL:            true,
-		SMTPHost:              "",
-		SMTPPort:              465,
-		SMTPUsername:          "",
-		SMTPPasswordEnv:       "CHATTING_SMTP_PASSWORD",
-		SMTPFrom:              "",
-		SMTPStartTLS:          false,
-		SMTPUseSSL:            true,
-		ErrorEmailTo:          "",
+		BBMBAddress:                 DefaultBBMBAddress,
+		DBPath:                      filepath.Join(os.TempDir(), "chatting-message-handler-state.db"),
+		MaxLoops:                    0,
+		PollIntervalSeconds:         DefaultPollIntervalSeconds,
+		PollTimeoutSeconds:          DefaultPollTimeoutSeconds,
+		MetricsHost:                 DefaultMetricsHost,
+		MetricsPort:                 DefaultMetricsPort,
+		EgressHTTPHost:              DefaultEgressHTTPHost,
+		EgressHTTPPort:              DefaultEgressHTTPPort,
+		EgressAttachmentAllowedDirs: []string{},
+		AllowedEgressChannels:       []string{"email", "telegram", "telegram_reaction", "github", "log"},
+		GlobalPromptContext:         []string{},
+		CronPromptContext:           []string{},
+		EmailPromptContext:          []string{},
+		ContextRefs:                 []string{},
+		ScheduleFile:                "",
+		IMAPHost:                    "",
+		IMAPPort:                    993,
+		IMAPUsername:                "",
+		IMAPPasswordEnv:             "CHATTING_IMAP_PASSWORD",
+		IMAPMailbox:                 "INBOX",
+		IMAPSearch:                  "UNSEEN",
+		IMAPUseSSL:                  true,
+		SMTPHost:                    "",
+		SMTPPort:                    465,
+		SMTPUsername:                "",
+		SMTPPasswordEnv:             "CHATTING_SMTP_PASSWORD",
+		SMTPFrom:                    "",
+		SMTPStartTLS:                false,
+		SMTPUseSSL:                  true,
+		ErrorEmailTo:                "",
 
 		TelegramEnabled:                       false,
 		TelegramBotTokenEnv:                   "CHATTING_TELEGRAM_BOT_TOKEN",
@@ -302,6 +305,12 @@ func Load(raw []byte) (Config, error) {
 	}
 	if rawValue, ok := payload["egress_http_port"]; ok && !isNull(rawValue) {
 		config.EgressHTTPPort, err = decodePositiveInt(rawValue, "egress_http_port")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if rawValue, ok := payload["egress_attachment_allowed_dirs"]; ok && !isNull(rawValue) {
+		config.EgressAttachmentAllowedDirs, err = decodeStringList(rawValue, "egress_attachment_allowed_dirs")
 		if err != nil {
 			return Config{}, err
 		}

--- a/go/handler/internal/dispatch/dispatch_test.go
+++ b/go/handler/internal/dispatch/dispatch_test.go
@@ -341,7 +341,7 @@ func TestTelegramMessageSenderSendsPhotoAttachment(t *testing.T) {
 		_ = json.NewEncoder(writer).Encode(map[string]any{"ok": true})
 	}))
 	defer server.Close()
-	sender := newTestTelegramSender(t, server.URL)
+	sender := newTestTelegramSender(t, server.URL, tempDir)
 	body := "what is this?"
 
 	if err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{
@@ -371,7 +371,7 @@ func TestTelegramMessageSenderSendsDocumentAttachmentFromFileURI(t *testing.T) {
 		_ = json.NewEncoder(writer).Encode(map[string]any{"ok": true})
 	}))
 	defer server.Close()
-	sender := newTestTelegramSender(t, server.URL)
+	sender := newTestTelegramSender(t, server.URL, tempDir)
 
 	if err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{
 		Channel: "telegram",
@@ -384,6 +384,41 @@ func TestTelegramMessageSenderSendsDocumentAttachmentFromFileURI(t *testing.T) {
 	}
 	if multipartCall.path != "/bottoken/sendDocument" || multipartCall.fileField != "document" {
 		t.Fatalf("multipart call = %#v", multipartCall)
+	}
+}
+
+func TestTelegramMessageSenderRejectsAttachmentOutsideAllowedDirs(t *testing.T) {
+	tempDir := t.TempDir()
+	allowedDir := filepath.Join(tempDir, "allowed")
+	if err := os.MkdirAll(allowedDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A real file, but outside the allowlist — must be refused before any read.
+	outsidePath := filepath.Join(tempDir, "secret.txt")
+	if err := os.WriteFile(outsidePath, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sender := newTestTelegramSender(t, "http://127.0.0.1", allowedDir)
+
+	err := sender.Send(context.Background(), "12345", contracts.OutboundMessage{
+		Channel: "telegram",
+		Target:  "12345",
+		Attachment: &contracts.AttachmentRef{
+			URI: "file://" + outsidePath,
+		},
+	})
+	if err == nil || err.Error() != "telegram_attachment_path_not_allowed" {
+		t.Fatalf("err = %v, want telegram_attachment_path_not_allowed", err)
+	}
+	// Traversal out of an allowed dir must also be refused.
+	traversal := filepath.Join(allowedDir, "..", "secret.txt")
+	err = sender.Send(context.Background(), "12345", contracts.OutboundMessage{
+		Channel:    "telegram",
+		Target:     "12345",
+		Attachment: &contracts.AttachmentRef{URI: "file://" + traversal},
+	})
+	if err == nil || err.Error() != "telegram_attachment_path_not_allowed" {
+		t.Fatalf("traversal err = %v, want telegram_attachment_path_not_allowed", err)
 	}
 }
 
@@ -483,9 +518,13 @@ type telegramMultipartCall struct {
 	fileName  string
 }
 
-func newTestTelegramSender(t *testing.T, apiBaseURL string) *TelegramMessageSender {
+func newTestTelegramSender(t *testing.T, apiBaseURL string, allowedDirs ...string) *TelegramMessageSender {
 	t.Helper()
-	sender, err := NewTelegramMessageSender(TelegramConfig{BotToken: "token", APIBaseURL: apiBaseURL})
+	sender, err := NewTelegramMessageSender(TelegramConfig{
+		BotToken:              "token",
+		APIBaseURL:            apiBaseURL,
+		AttachmentAllowedDirs: allowedDirs,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/handler/internal/dispatch/telegram.go
+++ b/go/handler/internal/dispatch/telegram.go
@@ -26,13 +26,20 @@ type TelegramConfig struct {
 	ParseMode  *string
 	Timeout    time.Duration
 	HTTPClient *http.Client
+	// AttachmentAllowedDirs constrains which local files may be sent as
+	// attachments. The path in an outbound attachment is caller-controlled
+	// (the executor via app.main_reply), so without this a caller could make
+	// the handler read and exfiltrate an arbitrary file. Empty means no file
+	// attachment is permitted (fail closed).
+	AttachmentAllowedDirs []string
 }
 
 type TelegramMessageSender struct {
-	botToken   string
-	apiBaseURL string
-	parseMode  *string
-	client     *http.Client
+	botToken              string
+	apiBaseURL            string
+	parseMode             *string
+	client                *http.Client
+	attachmentAllowedDirs []string
 }
 
 func NewTelegramMessageSender(config TelegramConfig) (*TelegramMessageSender, error) {
@@ -61,11 +68,20 @@ func NewTelegramMessageSender(config TelegramConfig) (*TelegramMessageSender, er
 	if client == nil {
 		client = &http.Client{Timeout: timeout}
 	}
+	allowedDirs := make([]string, 0, len(config.AttachmentAllowedDirs))
+	for _, dir := range config.AttachmentAllowedDirs {
+		trimmed := strings.TrimSpace(dir)
+		if trimmed == "" {
+			continue
+		}
+		allowedDirs = append(allowedDirs, filepath.Clean(trimmed))
+	}
 	return &TelegramMessageSender{
-		botToken:   config.BotToken,
-		apiBaseURL: strings.TrimRight(config.APIBaseURL, "/"),
-		parseMode:  parseMode,
-		client:     client,
+		botToken:              config.BotToken,
+		apiBaseURL:            strings.TrimRight(config.APIBaseURL, "/"),
+		parseMode:             parseMode,
+		client:                client,
+		attachmentAllowedDirs: allowedDirs,
 	}, nil
 }
 
@@ -80,7 +96,7 @@ func (sender *TelegramMessageSender) Send(ctx context.Context, target string, me
 		return sender.sendText(ctx, target, *message.Body)
 	}
 
-	filePath, err := resolveTelegramAttachmentPath(message.Attachment.URI)
+	filePath, err := resolveTelegramAttachmentPath(message.Attachment.URI, sender.attachmentAllowedDirs)
 	if err != nil {
 		return err
 	}
@@ -237,7 +253,7 @@ func (sender *TelegramMessageSender) methodURL(method string) string {
 	return sender.apiBaseURL + "/bot" + sender.botToken + "/" + method
 }
 
-func resolveTelegramAttachmentPath(rawURI string) (string, error) {
+func resolveTelegramAttachmentPath(rawURI string, allowedDirs []string) (string, error) {
 	parsed, err := url.Parse(rawURI)
 	if err != nil {
 		return "", errors.New("telegram_attachment_unsupported_uri")
@@ -261,11 +277,39 @@ func resolveTelegramAttachmentPath(rawURI string) (string, error) {
 	if !filepath.IsAbs(path) {
 		return "", errors.New("telegram_attachment_path_not_absolute")
 	}
-	info, err := os.Stat(path)
+	// The path is caller-controlled, so confine it to an allowlisted directory
+	// before touching the filesystem — otherwise a caller could have the handler
+	// read and send an arbitrary file. Cleaning first collapses any ".." so the
+	// containment check can't be walked out of.
+	cleaned := filepath.Clean(path)
+	if !pathWithinAllowedDir(cleaned, allowedDirs) {
+		return "", errors.New("telegram_attachment_path_not_allowed")
+	}
+	info, err := os.Stat(cleaned)
 	if err != nil || info.IsDir() {
 		return "", errors.New("telegram_attachment_missing")
 	}
-	return path, nil
+	return cleaned, nil
+}
+
+// pathWithinAllowedDir reports whether cleaned (already filepath.Clean'd and
+// absolute) sits inside one of allowedDirs. Empty allowedDirs denies everything
+// (fail closed).
+func pathWithinAllowedDir(cleaned string, allowedDirs []string) bool {
+	for _, dir := range allowedDirs {
+		rel, err := filepath.Rel(dir, cleaned)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if filepath.IsAbs(rel) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func telegramAPIMethodForAttachment(filePath string) string {

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/connectors/heartbeat"
 	"github.com/EdwardSalkeld/chatting/go/handler/internal/contracts"
@@ -54,6 +55,9 @@ func (fn DispatcherFunc) Dispatch(ctx context.Context, message contracts.Outboun
 }
 
 type Engine struct {
+	// mu serializes handling so the BBMB drain loop and the synchronous HTTP
+	// submit endpoint can share one engine without racing on the state store.
+	mu              sync.Mutex
 	state           State
 	dispatcher      Dispatcher
 	allowedChannels map[string]bool
@@ -120,15 +124,28 @@ const (
 	StatusDeduped    = "deduped"
 )
 
+// HandleRaw decodes a raw egress payload and dispatches it. Safe for concurrent
+// callers: handling is serialized so the BBMB drain loop and the HTTP submit
+// endpoint can share one engine.
 func (engine *Engine) HandleRaw(ctx context.Context, raw []byte) (Result, error) {
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
 	message, err := contracts.DecodeEgressQueueMessage(raw)
 	if err != nil {
 		return engine.surfaceDrop(ctx, message, "invalid_payload")
 	}
-	return engine.Handle(ctx, message)
+	return engine.handleLocked(ctx, message)
 }
 
+// Handle validates and dispatches a decoded egress message, serialized against
+// other callers.
 func (engine *Engine) Handle(ctx context.Context, message contracts.EgressQueueMessage) (Result, error) {
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	return engine.handleLocked(ctx, message)
+}
+
+func (engine *Engine) handleLocked(ctx context.Context, message contracts.EgressQueueMessage) (Result, error) {
 	if err := message.Validate(); err != nil {
 		return engine.surfaceDrop(ctx, message, "invalid_payload")
 	}

--- a/go/handler/internal/egress/http.go
+++ b/go/handler/internal/egress/http.go
@@ -1,0 +1,119 @@
+package egress
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+)
+
+// EgressRoutePath is the path the synchronous egress-submit endpoint listens on.
+const EgressRoutePath = "/egress"
+
+// maxEgressBodyBytes caps the submit body. Egress messages reference attachments
+// by URI, never inline bytes, so a reply payload is small; this is a guard, not
+// a real limit.
+const maxEgressBodyBytes = 5 << 20
+
+type submitResponse struct {
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// RegisterHTTPRoutes wires the synchronous egress-submit endpoint onto mux. It
+// lets the worker's reply script submit an egress message and learn the delivery
+// outcome synchronously, instead of publishing to BBMB fire-and-forget and never
+// hearing whether the send actually happened.
+func RegisterHTTPRoutes(mux *http.ServeMux, engine *Engine) {
+	mux.HandleFunc(EgressRoutePath, func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			writeSubmitJSON(writer, http.StatusMethodNotAllowed, submitResponse{Status: "error", Reason: "method not allowed"})
+			return
+		}
+		raw, err := io.ReadAll(http.MaxBytesReader(writer, request.Body, maxEgressBodyBytes))
+		if err != nil {
+			writeSubmitJSON(writer, http.StatusBadRequest, submitResponse{Status: "error", Reason: "read body: " + err.Error()})
+			return
+		}
+		result, err := engine.HandleRaw(request.Context(), raw)
+		if err != nil {
+			// Infrastructure/state error: the send did not happen and the caller
+			// should retry. Mirrors the BBMB path leaving the message un-acked.
+			writeSubmitJSON(writer, http.StatusServiceUnavailable, submitResponse{Status: "error", Reason: err.Error()})
+			return
+		}
+		writeSubmitJSON(writer, statusCodeForResult(result), submitResponse{Status: result.Status, Reason: result.Reason})
+	})
+}
+
+// statusCodeForResult maps an engine Result to an HTTP status the caller can act
+// on: 2xx means the message is delivered (or already was); 422 means it was
+// dropped for good (bad payload, unknown task, disallowed channel, dispatch
+// failure) and the caller should fall back rather than retry.
+func statusCodeForResult(result Result) int {
+	switch result.Status {
+	case StatusDispatched, StatusCompleted, StatusDeduped:
+		return http.StatusOK
+	case StatusStaged:
+		// Accepted and buffered, waiting on an earlier sequence to arrive; not
+		// sent yet, but not an error either.
+		return http.StatusAccepted
+	case StatusDropped:
+		return http.StatusUnprocessableEntity
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func writeSubmitJSON(writer http.ResponseWriter, status int, payload submitResponse) {
+	writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+	writer.WriteHeader(status)
+	_ = json.NewEncoder(writer).Encode(payload)
+}
+
+// Server owns the dedicated loopback HTTP server for synchronous egress submits.
+type Server struct {
+	server *http.Server
+	done   chan struct{}
+	addr   string
+}
+
+// StartHTTPServer binds a loopback-only HTTP server exposing the egress-submit
+// endpoint. It is intentionally separate from the metrics server: the metrics
+// bind may be 0.0.0.0 (so Prometheus can scrape), but the ability to send
+// messages to the outside world must stay reachable only from the local host,
+// matching BBMB's loopback posture.
+func StartHTTPServer(host string, port int, engine *Engine) (*Server, error) {
+	mux := http.NewServeMux()
+	RegisterHTTPRoutes(mux, engine)
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		return nil, err
+	}
+	server := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			return
+		}
+	}()
+	return &Server{server: server, done: done, addr: listener.Addr().String()}, nil
+}
+
+func (server *Server) Addr() string {
+	if server == nil {
+		return ""
+	}
+	return server.addr
+}
+
+func (server *Server) Close() error {
+	if server == nil || server.server == nil {
+		return nil
+	}
+	err := server.server.Close()
+	<-server.done
+	return err
+}

--- a/go/handler/internal/egress/http_test.go
+++ b/go/handler/internal/egress/http_test.go
@@ -1,0 +1,124 @@
+package egress
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func submitEgress(t *testing.T, engine *Engine, method string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	RegisterHTTPRoutes(mux, engine)
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	request := httptest.NewRequest(method, EgressRoutePath, reader)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func decodeSubmit(t *testing.T, recorder *httptest.ResponseRecorder) submitResponse {
+	t.Helper()
+	var response submitResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response %q: %v", recorder.Body.String(), err)
+	}
+	return response
+}
+
+func TestSubmitEndpointDeliversAndReturnsOK(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngine(t, state, dispatcher)
+
+	raw, err := json.Marshal(testEgressMessage(t, task, nil, "evt:http:1", "incremental"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := submitEgress(t, engine, http.MethodPost, raw)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if response := decodeSubmit(t, recorder); response.Status != StatusDispatched {
+		t.Fatalf("response = %#v", response)
+	}
+	if len(dispatcher.messages) != 1 {
+		t.Fatalf("dispatched messages = %#v", dispatcher.messages)
+	}
+}
+
+func TestSubmitEndpointReturns422OnDrop(t *testing.T) {
+	// No task registered, so the engine drops the message as unknown_task.
+	state := newFakeState()
+	engine := newTestEngine(t, state, nil)
+	raw, err := json.Marshal(testEgressMessage(t, testTaskMessage(t), nil, "evt:http:2", "incremental"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var recorder *httptest.ResponseRecorder
+	logs := captureLog(t, func() {
+		recorder = submitEgress(t, engine, http.MethodPost, raw)
+	})
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	response := decodeSubmit(t, recorder)
+	if response.Status != StatusDropped || response.Reason != "unknown_task" {
+		t.Fatalf("response = %#v", response)
+	}
+	// A drop must stay loud, same as the BBMB path.
+	if !bytes.Contains([]byte(logs), []byte("egress_message_dropped")) {
+		t.Fatalf("expected a loud drop log, got %q", logs)
+	}
+}
+
+func TestSubmitEndpointDropsInvalidJSON(t *testing.T) {
+	engine := newTestEngine(t, newFakeState(), nil)
+
+	var recorder *httptest.ResponseRecorder
+	captureLog(t, func() {
+		recorder = submitEgress(t, engine, http.MethodPost, []byte("{not json"))
+	})
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+	if response := decodeSubmit(t, recorder); response.Reason != "invalid_payload" {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestSubmitEndpointRejectsNonPost(t *testing.T) {
+	engine := newTestEngine(t, newFakeState(), nil)
+	recorder := submitEgress(t, engine, http.MethodGet, nil)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+}
+
+func TestStatusCodeForResult(t *testing.T) {
+	cases := map[string]int{
+		StatusDispatched: http.StatusOK,
+		StatusCompleted:  http.StatusOK,
+		StatusDeduped:    http.StatusOK,
+		StatusStaged:     http.StatusAccepted,
+		StatusDropped:    http.StatusUnprocessableEntity,
+		"weird":          http.StatusInternalServerError,
+	}
+	for status, want := range cases {
+		if got := statusCodeForResult(Result{Status: status}); got != want {
+			t.Errorf("statusCodeForResult(%q) = %d, want %d", status, got, want)
+		}
+	}
+}

--- a/tests/e2e/configs/handler.json
+++ b/tests/e2e/configs/handler.json
@@ -4,6 +4,7 @@
   "poll_interval_seconds": 0.5,
   "poll_timeout_seconds": 2,
   "allowed_egress_channels": ["email", "log"],
+  "egress_http_host": "0.0.0.0",
   "imap_host": "greenmail",
   "imap_port": 3143,
   "imap_username": "bot",

--- a/tests/e2e/configs/worker.json
+++ b/tests/e2e/configs/worker.json
@@ -4,5 +4,6 @@
   "max_attempts": 2,
   "poll_timeout_seconds": 2,
   "sleep_seconds": 0.2,
-  "codex_command": "python3 /app/tests/e2e/fake_codex.py"
+  "codex_command": "python3 /app/tests/e2e/fake_codex.py",
+  "handler_egress_url": "http://handler:9467/egress"
 }

--- a/tests/e2e/fake_codex.py
+++ b/tests/e2e/fake_codex.py
@@ -22,6 +22,14 @@ def main():
     reply_channel = task.get("reply_channel", {})
     channel = reply_channel.get("type", "log")
     target = reply_channel.get("target", "test")
+    # Some ingress sources (e.g. webhook/auxiliary-ingress) declare a reply
+    # channel that the handler has no dispatcher for, so a reply there is
+    # undeliverable by design. Send the reply on "log" in that case rather than
+    # emitting an undeliverable one: main_reply is now synchronous and would
+    # exit non-zero on a dropped send, failing this run.
+    _DELIVERABLE = {"email", "telegram", "telegram_reaction", "github", "log"}
+    if channel not in _DELIVERABLE:
+        channel = "log"
 
     subprocess.run(
         [

--- a/tests/e2e/test_auxiliary_ingress_e2e.py
+++ b/tests/e2e/test_auxiliary_ingress_e2e.py
@@ -117,6 +117,7 @@ class AuxiliaryIngressE2ETests(unittest.TestCase):
         auxiliary_port = _reserve_port()
         handler_metrics_port = _reserve_port()
         worker_activity_port = _reserve_port()
+        egress_http_port = _reserve_port()
         main_bbmb_address = f"127.0.0.1:{main_bbmb_port}"
         auxiliary_bbmb_address = f"127.0.0.1:{auxiliary_bbmb_port}"
 
@@ -153,6 +154,7 @@ class AuxiliaryIngressE2ETests(unittest.TestCase):
                         "max_loops": max_loops,
                         "allowed_egress_channels": ["log"],
                         "metrics_port": handler_metrics_port,
+                        "egress_http_port": egress_http_port,
                         "auxiliary_ingress_enabled": True,
                         "auxiliary_ingress_bbmb_address": auxiliary_bbmb_address,
                         "auxiliary_ingress_queues": ["generic-post"],
@@ -171,6 +173,7 @@ class AuxiliaryIngressE2ETests(unittest.TestCase):
                         "max_loops": max_loops,
                         "activity_port": worker_activity_port,
                         "codex_command": f"{sys.executable} {fake_codex}",
+                        "handler_egress_url": f"http://127.0.0.1:{egress_http_port}/egress",
                     }
                 ),
                 encoding="utf-8",

--- a/tests/e2e/test_email_e2e.py
+++ b/tests/e2e/test_email_e2e.py
@@ -76,6 +76,7 @@ class EmailE2ETests(unittest.TestCase):
         fake_codex = str(repo_root / "tests" / "e2e" / "fake_codex.py")
         bbmb_port = _reserve_port()
         bbmb_metrics_port = _reserve_port()
+        egress_http_port = _reserve_port()
         bbmb_address = f"127.0.0.1:{bbmb_port}"
 
         server_proc = None
@@ -104,6 +105,7 @@ class EmailE2ETests(unittest.TestCase):
                         "poll_timeout_seconds": 2,
                         "max_loops": 200,
                         "allowed_egress_channels": ["email", "log"],
+                        "egress_http_port": egress_http_port,
                         "imap_host": "127.0.0.1",
                         "imap_port": 3143,
                         "imap_username": "bot",
@@ -129,6 +131,7 @@ class EmailE2ETests(unittest.TestCase):
                         "sleep_seconds": 0.2,
                         "max_loops": 200,
                         "codex_command": f"{sys.executable} {fake_codex}",
+                        "handler_egress_url": f"http://127.0.0.1:{egress_http_port}/egress",
                     }
                 ),
                 encoding="utf-8",

--- a/tests/test_main_reply.py
+++ b/tests/test_main_reply.py
@@ -7,32 +7,43 @@ from pathlib import Path
 from unittest.mock import patch
 
 from app.broker import TaskQueueMessage
-from app.main_reply import main
+from app.main_reply import (
+    DEFAULT_HANDLER_EGRESS_URL,
+    EXIT_DROPPED,
+    EXIT_TRANSIENT,
+    main,
+)
 from app.models import ReplyChannel, TaskEnvelope
 from app.state import SQLiteStateStore
 from app.task_ledger import TaskLedgerStore
 
 
-class _FakeBroker:
-    def __init__(self, address: str):
-        self.address = address
-        self.ensured: list[str] = []
-        self.published: list[tuple[str, dict[str, object]]] = []
+class _FakeSubmit:
+    """Stand-in for main_reply._submit_egress: records calls, returns a canned
+    (status_code, response) so tests don't do real HTTP."""
 
-    def ensure_queue(self, queue_name: str) -> None:
-        self.ensured.append(queue_name)
+    def __init__(
+        self, status: int = 200, response: dict[str, object] | None = None
+    ) -> None:
+        self.status = status
+        self.response = (
+            response if response is not None else {"status": "dispatched", "reason": ""}
+        )
+        self.calls: list[tuple[str, dict[str, object]]] = []
 
-    def publish_json(self, queue_name: str, payload: dict[str, object]) -> str:
-        self.published.append((queue_name, payload))
-        return "guid-1"
+    def __call__(
+        self, url: str, payload: dict[str, object]
+    ) -> tuple[int, dict[str, object]]:
+        self.calls.append((url, payload))
+        return self.status, dict(self.response)
 
 
 class MainReplyCliTests(unittest.TestCase):
-    def test_main_reply_publishes_unsequenced_incremental_v2_payload(self) -> None:
-        broker = _FakeBroker("127.0.0.1:9876")
+    def test_main_reply_posts_unsequenced_incremental_v2_payload(self) -> None:
+        submit = _FakeSubmit()
         stdout = io.StringIO()
         with (
-            patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+            patch("app.main_reply._submit_egress", submit),
             patch("sys.stdout", stdout),
             patch(
                 "sys.argv",
@@ -53,10 +64,9 @@ class MainReplyCliTests(unittest.TestCase):
             exit_code = main()
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(broker.ensured, ["chatting.egress.v1"])
-        self.assertEqual(len(broker.published), 1)
-        queue_name, payload = broker.published[0]
-        self.assertEqual(queue_name, "chatting.egress.v1")
+        self.assertEqual(len(submit.calls), 1)
+        url, payload = submit.calls[0]
+        self.assertEqual(url, DEFAULT_HANDLER_EGRESS_URL)
         self.assertEqual(payload["task_id"], "task:email:53")
         self.assertEqual(payload["envelope_id"], "email:53")
         self.assertEqual(payload["trace_id"], "trace:email:53")
@@ -66,22 +76,21 @@ class MainReplyCliTests(unittest.TestCase):
         self.assertNotIn("sequence", payload)
 
         printed = json.loads(stdout.getvalue())
-        self.assertEqual(printed["status"], "published")
-        self.assertEqual(printed["guid"], "guid-1")
+        self.assertEqual(printed["status"], "dispatched")
+        self.assertEqual(printed["http_status"], 200)
         self.assertIsNone(printed["sequence"])
 
-    def test_main_reply_uses_bbmb_address_from_worker_config(self) -> None:
+    def test_main_reply_uses_handler_egress_url_from_worker_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "worker.json"
             config_path.write_text(
-                json.dumps({"bbmb_address": "10.0.0.5:9999"}), encoding="utf-8"
+                json.dumps({"handler_egress_url": "http://10.0.0.5:9999/egress"}),
+                encoding="utf-8",
             )
-            broker = _FakeBroker("placeholder")
+            submit = _FakeSubmit()
             stdout = io.StringIO()
             with (
-                patch(
-                    "app.main_reply.BBMBQueueAdapter", return_value=broker
-                ) as broker_ctor,
+                patch("app.main_reply._submit_egress", submit),
                 patch("sys.stdout", stdout),
                 patch(
                     "sys.argv",
@@ -102,8 +111,77 @@ class MainReplyCliTests(unittest.TestCase):
                 exit_code = main()
 
         self.assertEqual(exit_code, 0)
-        broker_ctor.assert_called_once_with(address="10.0.0.5:9999")
-        self.assertEqual(broker.ensured, ["chatting.egress.v1"])
+        self.assertEqual(submit.calls[0][0], "http://10.0.0.5:9999/egress")
+
+    def test_main_reply_returns_dropped_exit_and_stays_quiet_in_db(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            config_path = Path(tmpdir) / "worker.json"
+            config_path.write_text(
+                json.dumps({"db_path": str(db_path)}), encoding="utf-8"
+            )
+            submit = _FakeSubmit(
+                status=422,
+                response={"status": "dropped", "reason": "telegram_attachment_missing"},
+            )
+            stderr = io.StringIO()
+            with (
+                patch("app.main_reply._submit_egress", submit),
+                patch("sys.stderr", stderr),
+                patch(
+                    "sys.argv",
+                    [
+                        "main_reply.py",
+                        "task:telegram:53",
+                        "--message",
+                        "here is the screenshot",
+                        "--channel",
+                        "telegram",
+                        "--target",
+                        "8605042448",
+                        "--config",
+                        str(config_path),
+                    ],
+                ),
+            ):
+                exit_code = main()
+
+            activity = SQLiteStateStore(str(db_path)).list_recent_worker_activity(
+                limit=10,
+                include_internal=True,
+            )
+
+        self.assertEqual(exit_code, EXIT_DROPPED)
+        printed = json.loads(stderr.getvalue())
+        self.assertEqual(printed["status"], "dropped")
+        self.assertEqual(printed["reason"], "telegram_attachment_missing")
+        # A drop is not a delivery, so it must not be recorded as one — the
+        # supervised recovery loop keys off these activity rows.
+        self.assertEqual(activity, [])
+
+    def test_main_reply_returns_transient_exit_when_handler_unreachable(self) -> None:
+        submit = _FakeSubmit(status=0, response={"reason": "egress endpoint unreachable"})
+        stderr = io.StringIO()
+        with (
+            patch("app.main_reply._submit_egress", submit),
+            patch("sys.stderr", stderr),
+            patch(
+                "sys.argv",
+                [
+                    "main_reply.py",
+                    "task:email:53",
+                    "--message",
+                    "working on it",
+                    "--channel",
+                    "email",
+                    "--target",
+                    "alice@example.com",
+                ],
+            ),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, EXIT_TRANSIENT)
 
     def test_main_reply_requires_envelope_id_for_non_prefixed_task_id(self) -> None:
         with patch(
@@ -122,12 +200,12 @@ class MainReplyCliTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "envelope_id is required"):
                 main()
 
-    def test_main_reply_publishes_telegram_reaction_using_explicit_message_id(
+    def test_main_reply_posts_telegram_reaction_using_explicit_message_id(
         self,
     ) -> None:
-        broker = _FakeBroker("127.0.0.1:9876")
+        submit = _FakeSubmit()
         with (
-            patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+            patch("app.main_reply._submit_egress", submit),
             patch(
                 "sys.argv",
                 [
@@ -147,12 +225,12 @@ class MainReplyCliTests(unittest.TestCase):
             exit_code = main()
 
         self.assertEqual(exit_code, 0)
-        _, payload = broker.published[0]
+        _, payload = submit.calls[0]
         self.assertEqual(payload["message"]["channel"], "telegram_reaction")
         self.assertEqual(payload["message"]["body"], "👍")
         self.assertEqual(payload["message"]["metadata"], {"message_id": 123})
 
-    def test_main_reply_publishes_telegram_reaction_using_task_ledger_message_id(
+    def test_main_reply_posts_telegram_reaction_using_task_ledger_message_id(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -181,9 +259,9 @@ class MainReplyCliTests(unittest.TestCase):
                 TaskQueueMessage.from_envelope(envelope, trace_id="trace:telegram:53")
             )
 
-            broker = _FakeBroker("127.0.0.1:9876")
+            submit = _FakeSubmit()
             with (
-                patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+                patch("app.main_reply._submit_egress", submit),
                 patch(
                     "sys.argv",
                     [
@@ -203,16 +281,16 @@ class MainReplyCliTests(unittest.TestCase):
                 exit_code = main()
 
         self.assertEqual(exit_code, 0)
-        _, payload = broker.published[0]
+        _, payload = submit.calls[0]
         self.assertEqual(payload["message"]["metadata"], {"message_id": 456})
 
-    def test_main_reply_publishes_attachment_message(self) -> None:
-        broker = _FakeBroker("127.0.0.1:9876")
+    def test_main_reply_posts_attachment_message(self) -> None:
+        submit = _FakeSubmit()
         with tempfile.TemporaryDirectory() as tmpdir:
             attachment_path = Path(tmpdir) / "menu.pdf"
             attachment_path.write_bytes(b"%PDF-1.4\n")
             with (
-                patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+                patch("app.main_reply._submit_egress", submit),
                 patch(
                     "sys.argv",
                     [
@@ -234,25 +312,23 @@ class MainReplyCliTests(unittest.TestCase):
                 exit_code = main()
 
         self.assertEqual(exit_code, 0)
-        _, payload = broker.published[0]
+        _, payload = submit.calls[0]
         self.assertEqual(payload["message"]["body"], "This week's menu")
         self.assertEqual(payload["message"]["attachment"]["name"], "menu.pdf")
         self.assertEqual(
             payload["message"]["attachment"]["uri"], attachment_path.as_uri()
         )
 
-    def test_main_reply_records_worker_activity_when_db_path_is_configured(
-        self,
-    ) -> None:
+    def test_main_reply_records_worker_activity_on_delivery(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "state.db"
             config_path = Path(tmpdir) / "worker.json"
             config_path.write_text(
                 json.dumps({"db_path": str(db_path)}), encoding="utf-8"
             )
-            broker = _FakeBroker("127.0.0.1:9876")
+            submit = _FakeSubmit()
             with (
-                patch("app.main_reply.BBMBQueueAdapter", return_value=broker),
+                patch("app.main_reply._submit_egress", submit),
                 patch(
                     "sys.argv",
                     [

--- a/tests/test_split_mode_e2e.py
+++ b/tests/test_split_mode_e2e.py
@@ -118,6 +118,7 @@ class SplitModeE2ETests(unittest.TestCase):
         fake_codex = str(repo_root / "tests" / "e2e" / "fake_codex.py")
         bbmb_port = _reserve_port()
         bbmb_metrics_port = _reserve_port()
+        egress_http_port = _reserve_port()
         bbmb_address = f"127.0.0.1:{bbmb_port}"
         server_proc: subprocess.Popen[str] | None = None
         worker_proc: subprocess.Popen[str] | None = None
@@ -139,6 +140,7 @@ class SplitModeE2ETests(unittest.TestCase):
                         "poll_timeout_seconds": 1,
                         "max_loops": 20,
                         "allowed_egress_channels": ["log"],
+                        "egress_http_port": egress_http_port,
                     }
                 ),
                 encoding="utf-8",
@@ -166,6 +168,7 @@ class SplitModeE2ETests(unittest.TestCase):
                         "max_loops": 20,
                         "activity_port": 0,
                         "codex_command": f"{sys.executable} {fake_codex}",
+                        "handler_egress_url": f"http://127.0.0.1:{egress_http_port}/egress",
                     }
                 ),
                 encoding="utf-8",


### PR DESCRIPTION
Egress was fire-and-forget. When a reply is sent, the executor (codex) calls `python3 -m app.main_reply`, which published the reply to the BBMB egress queue and returned "published" as soon as BBMB accepted it. The actual send happens later, in the handler, in a different process. So when the handler dropped a message (e.g. `telegram_attachment_missing`, where the attachment path couldn't be resolved at send time), the executor had already seen success and the user silently got nothing. This bit us on a real Telegram screenshot reply.

This is PR1 of two. It adds a synchronous egress-submit endpoint on the handler. `main_reply` now POSTs the egress payload to it and gets the real delivery outcome back. The handler runs the identical `egress.Engine.HandleRaw` path (same validation, dedup by event_id, allowed-channel guard, dispatch, loud drop logging), so it's just a second caller of an already transport-agnostic engine.

HTTP status maps the engine Result: 200 dispatched/completed/deduped, 202 staged, 422 dropped (with the reason code), 503 on infra error. `main_reply`'s exit code follows: 0 delivered, 1 dropped (permanent, so the caller should adjust and resend, e.g. drop the attachment), 3 transient (retry). The executor reply-contract now documents these codes so codex falls back instead of assuming success.

The endpoint runs on its own loopback-bound server (default 127.0.0.1:9467), deliberately not on the metrics mux: metrics may bind 0.0.0.0 for Prometheus scraping, but the power to send messages to the world must stay loopback-only, matching BBMB's posture. The egress Engine is now mutex-serialized so the BBMB drain loop and the HTTP endpoint can share one engine safely (verified with `go test -race`).

Completion and sequenced egress still go via BBMB in this PR. PR2 will move those across (outbox-as-WAL) and retire the BBMB egress queue.

## CI fixes

The first CI run failed four checks. All were real problems the synchronous path surfaced:

- Auxiliary-ingress declares a "webhook" reply channel that no dispatcher handles, so those replies were always dropped silently. Now that a drop is a loud 422, the e2e's fake executor failed. `fake_codex` now replies on "log" when the channel isn't deliverable, matching reality (webhook replies have no send path).
- The egress endpoint's loopback default is unreachable across Docker containers, so the split-deploy compose and e2e configs now bind it on 0.0.0.0 and point the worker at `http://handler:9467`. Magpie keeps the loopback default.
- CodeQL flagged the caller-controlled outbound Telegram attachment path (now reachable from the new HTTP source) as an arbitrary-file-read. It's now constrained to an allowlist of directories (`egress_attachment_allowed_dirs`), failing closed. The email-header sink was already CRLF-sanitised, so that alert is a false positive.

## Deployment

Defaults still align for the single-host case (handler binds 127.0.0.1:9467; `main_reply` defaults to `http://127.0.0.1:9467/egress`), so co-located worker and handler need no wiring change. Split deploys must point the worker at the handler over the network (compose/e2e now use `http://handler:9467`).

Important for the companion lab bump: the attachment allowlist fails closed, so a handler deployed with an empty `egress_attachment_allowed_dirs` will refuse ALL outbound Telegram file attachments. The magpie lab config must set `egress_attachment_allowed_dirs` (e.g. the workspace and shared attachment dirs) in the same deploy as this flake bump, or outbound attachments will break.

Validation done locally: `go build ./...` clean; full `go test ./...` for the handler passes; `go test -race ./internal/egress/` passes; gofmt clean. Python unit suites pass: tests.test_main_reply (rewritten to cover the HTTP submit plus the new dropped/transient exit codes), tests.test_main_worker, tests.test_executor, tests.test_worker_runtime. The three e2e tests (test_split_mode_e2e, test_email_e2e, test_auxiliary_ingress_e2e) need the bbmb-server release binary (downloaded in CI) so they were not run locally; CI is the gate for the e2e path.
