### PR TITLE
Move the rest of worker egress off BBMB onto the handler endpoint

### DIFF
--- a/app/egress_client.py
+++ b/app/egress_client.py
@@ -1,0 +1,56 @@
+"""Client for submitting egress messages to the handler's synchronous endpoint.
+
+Egress no longer flows through BBMB: the worker (and the app.main_reply CLI)
+POST each egress message to the handler and learn the delivery outcome instead
+of publishing fire-and-forget. This is the shared transport both use.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+# The handler binds this loopback endpoint by default (see the handler's
+# DefaultEgressHTTPHost/Port). A shared default means no extra config is needed
+# when worker and handler run on the same host.
+DEFAULT_HANDLER_EGRESS_URL = "http://127.0.0.1:9467/egress"
+DEFAULT_SUBMIT_TIMEOUT_SECONDS = 30
+
+
+def submit_egress(
+    url: str,
+    payload: dict[str, object],
+    *,
+    timeout_seconds: float = DEFAULT_SUBMIT_TIMEOUT_SECONDS,
+) -> tuple[int, dict[str, object]]:
+    """POST an egress payload to the handler.
+
+    Returns (http_status, response_body). http_status is 0 when the handler was
+    unreachable (connection refused, DNS, timeout) — i.e. it never processed the
+    message and a retry may succeed.
+    """
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return response.status, _decode_body(response.read())
+    except urllib.error.HTTPError as error:
+        return error.code, _decode_body(error.read())
+    except urllib.error.URLError as error:
+        return 0, {"reason": f"egress endpoint unreachable: {error.reason}"}
+
+
+def _decode_body(raw: bytes) -> dict[str, object]:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw.decode("utf-8", "replace"))
+    except json.JSONDecodeError:
+        return {"reason": raw.decode("utf-8", "replace")}
+    return parsed if isinstance(parsed, dict) else {"reason": str(parsed)}

--- a/app/main_reply.py
+++ b/app/main_reply.py
@@ -7,25 +7,16 @@ import json
 import os
 import sys
 import time
-import urllib.error
-import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
 from app.broker import EgressQueueMessage
+from app.egress_client import DEFAULT_HANDLER_EGRESS_URL, submit_egress
 from app.models import AttachmentRef, OutboundMessage
 from app.state import SQLiteStateStore
 from app.task_ledger import TaskLedgerStore
 from app.telegram_text import normalize_telegram_outbound_text
 from app.worker.main import WORKER_CONFIG_PATH_ENV_VAR, _load_config, _resolve_str
-
-# The reply script submits synchronously to the handler's loopback egress
-# endpoint and learns the delivery outcome, instead of publishing to BBMB
-# fire-and-forget. The handler default binds 127.0.0.1:9467 (see the handler's
-# DefaultEgressHTTPHost/Port); a shared default means no extra config is needed
-# when worker and handler run on the same host.
-DEFAULT_HANDLER_EGRESS_URL = "http://127.0.0.1:9467/egress"
-_SUBMIT_TIMEOUT_SECONDS = 30
 
 # Exit codes the executor can act on. 0 = delivered; DROPPED = the handler
 # rejected the message for good (bad payload, unknown task, disallowed channel,
@@ -35,34 +26,6 @@ _SUBMIT_TIMEOUT_SECONDS = 30
 # error from the ValueError path.)
 EXIT_DROPPED = 1
 EXIT_TRANSIENT = 3
-
-
-def _submit_egress(url: str, payload: dict[str, object]) -> tuple[int, dict[str, object]]:
-    data = json.dumps(payload).encode("utf-8")
-    request = urllib.request.Request(
-        url,
-        data=data,
-        method="POST",
-        headers={"Content-Type": "application/json"},
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=_SUBMIT_TIMEOUT_SECONDS) as response:
-            return response.status, _decode_body(response.read())
-    except urllib.error.HTTPError as error:
-        return error.code, _decode_body(error.read())
-    except urllib.error.URLError as error:
-        # Connection refused / DNS / timeout: the handler never processed it.
-        return 0, {"reason": f"egress endpoint unreachable: {error.reason}"}
-
-
-def _decode_body(raw: bytes) -> dict[str, object]:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw.decode("utf-8", "replace"))
-    except json.JSONDecodeError:
-        return {"reason": raw.decode("utf-8", "replace")}
-    return parsed if isinstance(parsed, dict) else {"reason": str(parsed)}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -263,7 +226,7 @@ def main() -> int:
         message_type="chatting.egress.v2",
     )
 
-    status_code, response = _submit_egress(handler_egress_url, egress_message.to_dict())
+    status_code, response = submit_egress(handler_egress_url, egress_message.to_dict())
     result_status = str(response.get("status", "")) if isinstance(response, dict) else ""
     reason = str(response.get("reason", "")) if isinstance(response, dict) else ""
 

--- a/app/worker/main.py
+++ b/app/worker/main.py
@@ -15,11 +15,11 @@ from typing import Mapping
 
 from app.broker import (
     BBMBQueueAdapter,
-    EGRESS_QUEUE_NAME,
     EgressQueueMessage,
     TASK_QUEUE_NAME,
     TaskQueueMessage,
 )
+from app.egress_client import DEFAULT_HANDLER_EGRESS_URL, submit_egress
 from app.worker.activity import (
     DEFAULT_ACTIVITY_HISTORY_LIMIT,
     DEFAULT_ACTIVITY_HOST,
@@ -112,6 +112,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--config", help="Path to JSON config file.")
     parser.add_argument("--db-path", help="Path to worker SQLite state DB.")
     parser.add_argument("--bbmb-address", help="BBMB broker address host:port.")
+    parser.add_argument(
+        "--handler-egress-url",
+        help="Handler synchronous egress endpoint URL (default the worker config's handler_egress_url).",
+    )
     parser.add_argument(
         "--max-attempts",
         type=_positive_int,
@@ -338,6 +342,12 @@ def main() -> int:
         default_value="127.0.0.1:9876",
         setting_name="bbmb_address",
     )
+    handler_egress_url = _resolve_str(
+        args.handler_egress_url,
+        config.get("handler_egress_url"),
+        default_value=DEFAULT_HANDLER_EGRESS_URL,
+        setting_name="handler_egress_url",
+    )
     max_attempts = _resolve_positive_int(
         args.max_attempts,
         config.get("max_attempts"),
@@ -387,22 +397,20 @@ def main() -> int:
     )
     broker = BBMBQueueAdapter(address=bbmb_address)
     broker.ensure_queue(TASK_QUEUE_NAME)
-    broker.ensure_queue(EGRESS_QUEUE_NAME)
 
     executor = _build_executor(args, config)
-    replay_done = False
 
     try:
         loop_count = 0
         while True:
             loop_count += 1
-            if not replay_done:
-                _replay_egress_outbox(
-                    store=store,
-                    broker=broker,
-                    activity_monitor=activity_monitor,
-                )
-                replay_done = True
+            # Replay any egress still pending in the outbox (a prior POST that
+            # failed transiently, or a crash before ack). Cheap when empty.
+            _replay_egress_outbox(
+                store=store,
+                handler_egress_url=handler_egress_url,
+                activity_monitor=activity_monitor,
+            )
             picked = broker.pickup_json(
                 TASK_QUEUE_NAME,
                 timeout_seconds=poll_timeout_seconds,
@@ -428,7 +436,7 @@ def main() -> int:
                 for egress_message in result.egress_messages:
                     _publish_egress_with_outbox(
                         store=store,
-                        broker=broker,
+                        handler_egress_url=handler_egress_url,
                         egress_message=egress_message,
                         activity_monitor=activity_monitor,
                     )
@@ -447,17 +455,20 @@ def main() -> int:
 def _publish_egress_with_outbox(
     *,
     store: SQLiteStateStore,
-    broker: BBMBQueueAdapter,
+    handler_egress_url: str,
     egress_message: EgressQueueMessage,
     activity_monitor: WorkerActivityMonitor,
 ) -> None:
+    # Persist to the outbox first (write-ahead), then submit to the handler. If
+    # the submit fails transiently the event stays pending and is replayed on a
+    # later loop; the task is still acked, so we never re-run the executor just
+    # because a reply could not be delivered yet.
     store.queue_egress_outbox_event(egress_message)
-    broker.publish_json(EGRESS_QUEUE_NAME, egress_message.to_dict())
-    if egress_message.event_id is None:
-        return
-    store.mark_egress_outbox_event_published(event_id=egress_message.event_id)
-    activity_monitor.record_egress(
+    _deliver_egress_event(
+        store=store,
+        handler_egress_url=handler_egress_url,
         egress_message=egress_message,
+        activity_monitor=activity_monitor,
         publish_source="worker",
     )
 
@@ -465,22 +476,80 @@ def _publish_egress_with_outbox(
 def _replay_egress_outbox(
     *,
     store: SQLiteStateStore,
-    broker: BBMBQueueAdapter,
+    handler_egress_url: str,
     activity_monitor: WorkerActivityMonitor,
 ) -> None:
     replayable = store.list_replayable_egress_outbox_events()
     if not replayable:
         return
+    delivered = 0
     for message in replayable:
-        broker.publish_json(EGRESS_QUEUE_NAME, message.to_dict())
-        if message.event_id is None:
-            continue
-        store.mark_egress_outbox_event_published(event_id=message.event_id)
-        activity_monitor.record_egress(
+        if _deliver_egress_event(
+            store=store,
+            handler_egress_url=handler_egress_url,
             egress_message=message,
+            activity_monitor=activity_monitor,
             publish_source="outbox_replay",
+        ):
+            delivered += 1
+    LOGGER.info(
+        "worker_egress_outbox_replayed pending=%s delivered=%s",
+        len(replayable),
+        delivered,
+    )
+
+
+def _deliver_egress_event(
+    *,
+    store: SQLiteStateStore,
+    handler_egress_url: str,
+    egress_message: EgressQueueMessage,
+    activity_monitor: WorkerActivityMonitor,
+    publish_source: str,
+) -> bool:
+    """Submit one egress event to the handler and settle its outbox row.
+
+    Returns True when the handler accepted it (delivered). 2xx acks the row;
+    a 422 is a permanent drop — logged loudly and acked so it is not retried
+    forever; anything else (handler unreachable / 5xx) leaves the row pending
+    for the next replay.
+    """
+    status_code, response = submit_egress(handler_egress_url, egress_message.to_dict())
+    reason = str(response.get("reason", "")) if isinstance(response, dict) else ""
+
+    if status_code in (200, 202):
+        if egress_message.event_id is not None:
+            store.mark_egress_outbox_event_acked(event_id=egress_message.event_id)
+        activity_monitor.record_egress(
+            egress_message=egress_message,
+            publish_source=publish_source,
         )
-    LOGGER.info("worker_egress_outbox_replayed count=%s", len(replayable))
+        return True
+
+    if status_code == 422:
+        # The handler rejected it for good (bad payload, unknown task,
+        # disallowed channel, dispatch failure). Dropping egress is an error, so
+        # make it loud; ack the row so it does not replay endlessly.
+        LOGGER.error(
+            "worker_egress_dropped_by_handler task_id=%s event_id=%s channel=%s reason=%s",
+            egress_message.task_id,
+            egress_message.event_id,
+            egress_message.message.channel,
+            reason or "unknown",
+        )
+        if egress_message.event_id is not None:
+            store.mark_egress_outbox_event_acked(event_id=egress_message.event_id)
+        return False
+
+    # Handler unreachable or server error: leave the row pending for replay.
+    LOGGER.warning(
+        "worker_egress_delivery_deferred task_id=%s event_id=%s http_status=%s reason=%s",
+        egress_message.task_id,
+        egress_message.event_id,
+        status_code,
+        reason or "unknown",
+    )
+    return False
 
 
 if __name__ == "__main__":

--- a/docs/bbmb-message-flow.md
+++ b/docs/bbmb-message-flow.md
@@ -75,25 +75,25 @@ Worker behavior:
 - the worker emits only the completion event for normal task processing
 - heartbeat tasks skip the normal executor path and emit a log pong followed by completion
 
-`app.main_reply` does not use BBMB. It POSTs the egress payload to the handler's synchronous
-egress endpoint (`handler_egress_url`, default `http://127.0.0.1:9467/egress`) and gets the
-delivery outcome back: HTTP 200 for a dispatched reply, 422 when the handler drops it (bad payload,
-unknown task, disallowed channel, dispatch failure such as a missing attachment), 503 when the
-handler is unreachable. The exit code follows suit (0 delivered, 1 dropped, 3 transient), so the
-executor learns immediately whether a reply landed instead of publishing fire-and-forget and never
-hearing back. The handler runs the identical engine path either way, serialized so the endpoint and
-the BBMB drain loop share one engine.
+Egress does not use BBMB at all. Every egress message — the executor's visible replies via
+`app.main_reply`, and the worker's own `completion`/sequenced events — is POSTed to the handler's
+synchronous egress endpoint (`handler_egress_url`, default `http://127.0.0.1:9467/egress`) and the
+delivery outcome comes straight back: HTTP 200 for a dispatched/completed message, 202 for a
+sequenced event staged pending an earlier one, 422 when the handler drops it (bad payload, unknown
+task, disallowed channel, dispatch failure such as a missing attachment), 503 when the handler is
+unreachable. `app.main_reply` maps this to an exit code (0 delivered, 1 dropped, 3 transient) so the
+executor learns immediately whether a reply landed instead of publishing fire-and-forget.
 
-Completion (`event_kind="completion"`) and any sequenced events still travel through BBMB. Before
-publishing each of those, the worker writes it to the SQLite egress outbox so it can replay
-unpublished or unacked egress after restart.
+The worker still writes each of its own egress events to the SQLite egress outbox first, as a
+write-ahead log: on a 2xx the row is acked; a 422 is logged loudly and acked (a permanent drop is an
+error, not something to retry forever); anything else leaves the row pending and it is replayed on a
+later loop or after restart. Crucially the task-queue message is acked once processing completes
+regardless of egress delivery — a transient egress failure never re-runs the executor, it just
+defers the reply to the outbox replay.
 
-The task queue message is only acked after processing completes and egress has been published to the
-outbox/BBMB path.
+### 3. Message-handler dispatches egress
 
-### 3. Message-handler consumes egress
-
-`message-handler` picks one payload from `chatting.egress.v1` and then:
+The handler receives each egress POST on its egress endpoint and then:
 - validates `message_type == "chatting.egress.v2"`
 - validates that the task exists in the ingress ledger
 - drops unknown-task egress

--- a/go/handler/cmd/chatting-handler/main.go
+++ b/go/handler/cmd/chatting-handler/main.go
@@ -297,12 +297,17 @@ func newRuntimeRunner(ctx context.Context, config handlerconfig.Config) (runner,
 	// reply script. Kept off the metrics mux on purpose: metrics may bind
 	// 0.0.0.0 for scraping, but sending messages to the world must stay
 	// loopback-only, like BBMB.
-	egressServer, err := egress.StartHTTPServer(config.EgressHTTPHost, config.EgressHTTPPort, engine)
+	egressServer, err := egress.StartHTTPServer(config.EgressHTTPHost, config.EgressHTTPPort, engine, func(result egress.Result) {
+		metricRecorder.RecordEgressResult(result.Status, result.Reason)
+	})
 	if err != nil {
 		_ = metricsServer.Close()
 		_ = store.Close()
 		return nil, err
 	}
+	// Egress no longer flows through BBMB: the worker submits every egress
+	// message to the loopback endpoint above. The runner's egress handler is
+	// retained only for the (now unused in prod) DrainEgress path and its tests.
 	runner, err := handlerruntime.NewRunner(config, adapter, egressHandlerFunc(func(ctx context.Context, raw []byte) error {
 		result, err := engine.HandleRaw(ctx, raw)
 		if err == nil {

--- a/go/handler/internal/egress/http.go
+++ b/go/handler/internal/egress/http.go
@@ -22,10 +22,12 @@ type submitResponse struct {
 }
 
 // RegisterHTTPRoutes wires the synchronous egress-submit endpoint onto mux. It
-// lets the worker's reply script submit an egress message and learn the delivery
-// outcome synchronously, instead of publishing to BBMB fire-and-forget and never
-// hearing whether the send actually happened.
-func RegisterHTTPRoutes(mux *http.ServeMux, engine *Engine) {
+// lets the worker (and the reply script) submit an egress message and learn the
+// delivery outcome synchronously, instead of publishing to BBMB fire-and-forget
+// and never hearing whether the send actually happened. onResult, if non-nil,
+// is invoked with each terminal Result so callers can record metrics (this is
+// the only egress path now, so metrics live here rather than the drain loop).
+func RegisterHTTPRoutes(mux *http.ServeMux, engine *Engine, onResult func(Result)) {
 	mux.HandleFunc(EgressRoutePath, func(writer http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodPost {
 			writeSubmitJSON(writer, http.StatusMethodNotAllowed, submitResponse{Status: "error", Reason: "method not allowed"})
@@ -42,6 +44,9 @@ func RegisterHTTPRoutes(mux *http.ServeMux, engine *Engine) {
 			// should retry. Mirrors the BBMB path leaving the message un-acked.
 			writeSubmitJSON(writer, http.StatusServiceUnavailable, submitResponse{Status: "error", Reason: err.Error()})
 			return
+		}
+		if onResult != nil {
+			onResult(result)
 		}
 		writeSubmitJSON(writer, statusCodeForResult(result), submitResponse{Status: result.Status, Reason: result.Reason})
 	})
@@ -84,9 +89,9 @@ type Server struct {
 // bind may be 0.0.0.0 (so Prometheus can scrape), but the ability to send
 // messages to the outside world must stay reachable only from the local host,
 // matching BBMB's loopback posture.
-func StartHTTPServer(host string, port int, engine *Engine) (*Server, error) {
+func StartHTTPServer(host string, port int, engine *Engine, onResult func(Result)) (*Server, error) {
 	mux := http.NewServeMux()
-	RegisterHTTPRoutes(mux, engine)
+	RegisterHTTPRoutes(mux, engine, onResult)
 	listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return nil, err

--- a/go/handler/internal/egress/http_test.go
+++ b/go/handler/internal/egress/http_test.go
@@ -12,7 +12,7 @@ import (
 func submitEgress(t *testing.T, engine *Engine, method string, body []byte) *httptest.ResponseRecorder {
 	t.Helper()
 	mux := http.NewServeMux()
-	RegisterHTTPRoutes(mux, engine)
+	RegisterHTTPRoutes(mux, engine, nil)
 	var reader io.Reader
 	if body != nil {
 		reader = bytes.NewReader(body)

--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -137,9 +137,10 @@ func (runner *Runner) Run(ctx context.Context) error {
 	if err := runner.broker.EnsureQueue(ctx, TaskQueueName); err != nil {
 		return err
 	}
-	if err := runner.broker.EnsureQueue(ctx, EgressQueueName); err != nil {
-		return err
-	}
+	// Egress no longer travels over BBMB: the worker submits each egress message
+	// straight to the handler's synchronous HTTP endpoint, so this loop only
+	// pumps ingress. DrainEgress and the egress queue remain for its tests but
+	// are no longer part of the live path.
 
 	loopCount := 0
 	for {
@@ -149,9 +150,6 @@ func (runner *Runner) Run(ctx context.Context) error {
 		loopCount++
 		published, err := runner.PublishIngress(ctx)
 		if err != nil {
-			return err
-		}
-		if _, err := runner.DrainEgress(ctx); err != nil {
 			return err
 		}
 		if err := runner.cleanupTelegramAttachments(ctx); err != nil {

--- a/go/handler/internal/runtime/runtime_test.go
+++ b/go/handler/internal/runtime/runtime_test.go
@@ -32,10 +32,13 @@ func TestRunEnsuresQueuesAndExitsAfterMaxLoops(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := broker.ensured, []string{TaskQueueName, EgressQueueName}; !reflect.DeepEqual(got, want) {
+	// Egress no longer flows over BBMB, so Run only ensures the task queue.
+	if got, want := broker.ensured, []string{TaskQueueName}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("ensured = %#v, want %#v", got, want)
 	}
-	if len(broker.pickups) != 1 {
+	// No broker pickups: ingress is published from connectors and egress no
+	// longer drains a queue, so the loop never picks up from BBMB.
+	if len(broker.pickups) != 0 {
 		t.Fatalf("pickup calls = %#v", broker.pickups)
 	}
 	if len(handler.rawPayloads) != 0 {
@@ -419,9 +422,8 @@ func TestRunRecordsLoopAndEgressMetrics(t *testing.T) {
 	if snapshot["loops_total"] != 1 {
 		t.Fatalf("loops_total = %v", snapshot["loops_total"])
 	}
-	if snapshot["egress_loops_total"] != 1 {
-		t.Fatalf("egress_loops_total = %v", snapshot["egress_loops_total"])
-	}
+	// egress_loops_total is no longer driven by Run: egress does not flow over
+	// BBMB, so the loop performs no egress drain.
 	if snapshot["last_loop_completed_timestamp_seconds"] != float64(mustTime(t, "2026-03-09T12:00:02Z").Unix()) {
 		t.Fatalf("last_loop_completed_timestamp_seconds = %v", snapshot["last_loop_completed_timestamp_seconds"])
 	}

--- a/go/handler/internal/state/sqlite/sqlite.go
+++ b/go/handler/internal/state/sqlite/sqlite.go
@@ -141,7 +141,18 @@ func Open(ctx context.Context, dbPath string) (*Store, error) {
 			return nil, err
 		}
 	}
-	db, err := sql.Open("sqlite", dbPath)
+	// The handler writes to this DB from two places concurrently now: the
+	// ingress Run loop and the synchronous egress HTTP endpoint. Without a busy
+	// timeout the second writer fails immediately with SQLITE_BUSY ("database is
+	// locked"); busy_timeout makes it wait for the lock instead, and WAL lets
+	// reads proceed alongside a writer. Applied per-connection via the modernc
+	// DSN so every pooled connection gets them.
+	separator := "?"
+	if strings.Contains(dbPath, "?") {
+		separator = "&"
+	}
+	dsn := dbPath + separator + "_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/test_auxiliary_ingress_e2e.py
+++ b/tests/e2e/test_auxiliary_ingress_e2e.py
@@ -151,7 +151,9 @@ class AuxiliaryIngressE2ETests(unittest.TestCase):
                         "bbmb_address": main_bbmb_address,
                         "poll_interval_seconds": 0.1,
                         "poll_timeout_seconds": 1,
-                        "max_loops": max_loops,
+                        # No max_loops: egress is delivered synchronously to the
+                        # handler, so it must stay up until the worker is done.
+                        # The finally block terminates it.
                         "allowed_egress_channels": ["log"],
                         "metrics_port": handler_metrics_port,
                         "egress_http_port": egress_http_port,

--- a/tests/test_main_reply.py
+++ b/tests/test_main_reply.py
@@ -43,7 +43,7 @@ class MainReplyCliTests(unittest.TestCase):
         submit = _FakeSubmit()
         stdout = io.StringIO()
         with (
-            patch("app.main_reply._submit_egress", submit),
+            patch("app.main_reply.submit_egress", submit),
             patch("sys.stdout", stdout),
             patch(
                 "sys.argv",
@@ -90,7 +90,7 @@ class MainReplyCliTests(unittest.TestCase):
             submit = _FakeSubmit()
             stdout = io.StringIO()
             with (
-                patch("app.main_reply._submit_egress", submit),
+                patch("app.main_reply.submit_egress", submit),
                 patch("sys.stdout", stdout),
                 patch(
                     "sys.argv",
@@ -126,7 +126,7 @@ class MainReplyCliTests(unittest.TestCase):
             )
             stderr = io.StringIO()
             with (
-                patch("app.main_reply._submit_egress", submit),
+                patch("app.main_reply.submit_egress", submit),
                 patch("sys.stderr", stderr),
                 patch(
                     "sys.argv",
@@ -163,7 +163,7 @@ class MainReplyCliTests(unittest.TestCase):
         submit = _FakeSubmit(status=0, response={"reason": "egress endpoint unreachable"})
         stderr = io.StringIO()
         with (
-            patch("app.main_reply._submit_egress", submit),
+            patch("app.main_reply.submit_egress", submit),
             patch("sys.stderr", stderr),
             patch(
                 "sys.argv",
@@ -205,7 +205,7 @@ class MainReplyCliTests(unittest.TestCase):
     ) -> None:
         submit = _FakeSubmit()
         with (
-            patch("app.main_reply._submit_egress", submit),
+            patch("app.main_reply.submit_egress", submit),
             patch(
                 "sys.argv",
                 [
@@ -261,7 +261,7 @@ class MainReplyCliTests(unittest.TestCase):
 
             submit = _FakeSubmit()
             with (
-                patch("app.main_reply._submit_egress", submit),
+                patch("app.main_reply.submit_egress", submit),
                 patch(
                     "sys.argv",
                     [
@@ -290,7 +290,7 @@ class MainReplyCliTests(unittest.TestCase):
             attachment_path = Path(tmpdir) / "menu.pdf"
             attachment_path.write_bytes(b"%PDF-1.4\n")
             with (
-                patch("app.main_reply._submit_egress", submit),
+                patch("app.main_reply.submit_egress", submit),
                 patch(
                     "sys.argv",
                     [
@@ -328,7 +328,7 @@ class MainReplyCliTests(unittest.TestCase):
             )
             submit = _FakeSubmit()
             with (
-                patch("app.main_reply._submit_egress", submit),
+                patch("app.main_reply.submit_egress", submit),
                 patch(
                     "sys.argv",
                     [

--- a/tests/test_main_worker.py
+++ b/tests/test_main_worker.py
@@ -3,17 +3,84 @@ import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 from app.broker import EgressQueueMessage
 from app.models import OutboundMessage, RunRecord
+from app.state import SQLiteStateStore
 from app.worker.main import (
     WORKER_CONFIG_PATH_ENV_VAR,
     _build_executor_env,
     _log_worker_processed,
     _load_config,
+    _publish_egress_with_outbox,
     _resolve_non_negative_int,
 )
 from app.worker.runtime import WorkerProcessResult
+
+
+class _RecordingMonitor:
+    def __init__(self) -> None:
+        self.egress_calls: list[str] = []
+
+    def record_egress(self, *, egress_message, publish_source: str) -> None:
+        self.egress_calls.append(publish_source)
+
+
+def _completion_egress(event_id: str = "evt:task:1:0:completion") -> EgressQueueMessage:
+    return EgressQueueMessage(
+        task_id="task:1",
+        envelope_id="email:1",
+        trace_id="trace:1",
+        event_index=0,
+        event_count=1,
+        message=OutboundMessage(channel="log", target="task", body="done"),
+        emitted_at=datetime(2026, 6, 7, 22, 30, tzinfo=timezone.utc),
+        event_id=event_id,
+        sequence=0,
+        event_kind="completion",
+        message_type="chatting.egress.v2",
+    )
+
+
+class PublishEgressWithOutboxTests(unittest.TestCase):
+    def _run(self, submit_return):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        store = SQLiteStateStore(str(Path(tmp.name) / "worker.db"))
+        monitor = _RecordingMonitor()
+        with patch("app.worker.main.submit_egress", return_value=submit_return):
+            _publish_egress_with_outbox(
+                store=store,
+                handler_egress_url="http://handler.test/egress",
+                egress_message=_completion_egress(),
+                activity_monitor=monitor,
+            )
+        return store, monitor
+
+    def test_delivered_2xx_acks_outbox_and_records_activity(self) -> None:
+        store, monitor = self._run((200, {"status": "completed"}))
+        # Acked -> not replayable.
+        self.assertEqual(store.list_replayable_egress_outbox_events(), [])
+        self.assertEqual(monitor.egress_calls, ["worker"])
+
+    def test_transient_failure_leaves_event_pending_for_replay(self) -> None:
+        store, monitor = self._run((0, {"reason": "unreachable"}))
+        replayable = store.list_replayable_egress_outbox_events()
+        self.assertEqual(len(replayable), 1)
+        self.assertEqual(monitor.egress_calls, [])
+
+    def test_permanent_drop_422_is_loud_and_acked(self) -> None:
+        with self.assertLogs("app.worker.main", level="ERROR") as captured:
+            store, monitor = self._run(
+                (422, {"status": "dropped", "reason": "disallowed_channel"})
+            )
+        # Acked so it does not replay forever, but not counted as delivered.
+        self.assertEqual(store.list_replayable_egress_outbox_events(), [])
+        self.assertEqual(monitor.egress_calls, [])
+        self.assertTrue(
+            any("worker_egress_dropped_by_handler" in line for line in captured.output)
+        )
 
 
 class MainWorkerTests(unittest.TestCase):

--- a/tests/test_split_mode_e2e.py
+++ b/tests/test_split_mode_e2e.py
@@ -1,5 +1,6 @@
 import json
 import os
+import signal
 import socket
 import sqlite3
 import subprocess
@@ -138,7 +139,6 @@ class SplitModeE2ETests(unittest.TestCase):
                         "bbmb_address": bbmb_address,
                         "poll_interval_seconds": 0.1,
                         "poll_timeout_seconds": 1,
-                        "max_loops": 20,
                         "allowed_egress_channels": ["log"],
                         "egress_http_port": egress_http_port,
                     }
@@ -209,8 +209,13 @@ class SplitModeE2ETests(unittest.TestCase):
                     text=True,
                 )
 
-                handler_out, handler_err = handler_proc.communicate(timeout=45)
+                # Egress is delivered synchronously worker -> handler, so the
+                # handler must stay up until the worker is done. The handler runs
+                # until terminated (no max_loops); wait for the bounded worker
+                # first, then stop the handler and collect its output.
                 worker_out, worker_err = worker_proc.communicate(timeout=45)
+                handler_proc.terminate()
+                handler_out, handler_err = handler_proc.communicate(timeout=15)
             finally:
                 for proc in (handler_proc, worker_proc, server_proc):
                     if proc is None:
@@ -227,10 +232,12 @@ class SplitModeE2ETests(unittest.TestCase):
                     if proc.stderr is not None:
                         proc.stderr.close()
 
-            self.assertEqual(
+            # The handler runs until we terminate it, so a clean self-exit (0)
+            # or the SIGTERM we send are both fine; anything else is a crash.
+            self.assertIn(
                 handler_proc.returncode,
-                0,
-                msg=f"message-handler exited non-zero\nstdout:\n{handler_out}\nstderr:\n{handler_err}",
+                (0, -signal.SIGTERM),
+                msg=f"message-handler exited unexpectedly\nstdout:\n{handler_out}\nstderr:\n{handler_err}",
             )
             self.assertEqual(
                 worker_proc.returncode,


### PR DESCRIPTION
Second half of taking egress off the broker. #247 already made the executor's visible replies (app.main_reply) POST synchronously to a new handler egress endpoint. This moves the rest: the worker's own completion and sequenced egress events now POST to that same endpoint, so no egress path touches BBMB anymore. The shared HTTP client lives in app/egress_client.py and is used by both main_reply and the worker.

The worker's egress outbox becomes a genuine write-ahead log: persist first, then POST. A 2xx acks the outbox row. A 422 is treated as a permanent drop - logged loudly via worker_egress_dropped_by_handler and acked so it can't replay forever. Handler-unreachable or 5xx leaves the row pending, to be replayed on a later loop (replay now runs every loop, not just at startup) or after a restart.

The correctness property that matters: the task-queue message is acked once processing completes, regardless of whether egress delivery succeeded. So a transient egress failure defers the reply to outbox replay rather than re-running the executor - re-running would re-run codex.

On the handler side, the Run loop no longer ensures or drains the BBMB egress queue. Egress result metrics moved to the HTTP endpoint (via an onResult callback) since that's the only egress path now.

DrainEgress and the EgressQueueName constant are deliberately left in place as dead-in-prod code, still covered by their unit tests, to keep this PR's blast radius small. Removing them - along with the now-unused NewRunner egress handler param - is a planned follow-up cleanup.

Validation done locally: full go test ./... for the handler passes, gofmt clean, and the Python unit suites pass (tests.test_main_worker including a new PublishEgressWithOutboxTests covering 2xx-acks / transient-stays-pending / 422-loud-and-acked, plus tests.test_main_reply, tests.test_executor, tests.test_worker_runtime). The three e2e suites (split-mode, email, auxiliary) exercise the full worker to handler egress over HTTP and need the bbmb-server release binary, so CI is the gate for those.


CI on the second run turned up two things now fixed. First, and prod-relevant: moving egress onto the HTTP endpoint left the handler with two concurrent SQLite writers (the ingress Run loop and the egress endpoint goroutine) where the BBMB drain used to run inside the single loop. The connection had no busy timeout, so the second writer failed instantly with SQLITE_BUSY and returned a 503 that deferred egress. The handler DB now opens with busy_timeout=5000 and WAL (per-connection via the modernc DSN), so a writer waits for the lock and reads proceed alongside it. Second, test-only: the auxiliary-ingress e2e handler exited on max_loops before the worker delivered its egress, so the worker's synchronous reply POST hit connection-refused; that handler now runs until terminated, matching the split-mode fix.
