### PR TITLE
Document egress as a synchronous endpoint, not a BBMB queue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,3 +21,5 @@
 - [0001 Split-Mode Architecture For Private Single-User Automation](architecture/0001-python-prototype-architecture.md)
 - [0002 Interface Contracts And BBMB Payload Schemas](architecture/0002-interface-contracts.md)
 - [0003 Current Implementation Overview (Split Mode)](architecture/0003-implementation-overview.md)
+- [0004 Separate Visible Egress From Task Completion](architecture/0004-egress-completion-semantics.md)
+- [0005 Synchronous Egress Transport (No BBMB)](architecture/0005-synchronous-egress-transport.md)

--- a/docs/architecture/0002-interface-contracts.md
+++ b/docs/architecture/0002-interface-contracts.md
@@ -43,7 +43,9 @@ Operational extensions:
 
 The BBMB payload contracts are:
 - `chatting.task.v1` on `chatting.tasks.v1`
-- `chatting.egress.v2` on `chatting.egress.v1`
+
+Egress uses the same `chatting.egress.v2` payload but is no longer a BBMB queue: it is POSTed to
+the handler's synchronous egress endpoint (see [BBMB Message Flow](../bbmb-message-flow.md)).
 
 All top-level payload objects include `schema_version` and enforce strict required fields.
 

--- a/docs/architecture/0003-implementation-overview.md
+++ b/docs/architecture/0003-implementation-overview.md
@@ -20,7 +20,7 @@ The deployment model is private, single-user, split mode.
 
 - `go/handler/cmd/chatting-handler`: ingress + egress dispatch in split mode
 - `app.main_worker`: task execution in split mode
-- `app.main_reply`: publish visible worker-side incremental egress for acknowledgements and final replies
+- `app.main_reply`: submit visible worker-side incremental egress (POST to the handler egress endpoint) for acknowledgements and final replies
 
 ## Persistence tables (SQLite)
 

--- a/docs/architecture/0005-synchronous-egress-transport.md
+++ b/docs/architecture/0005-synchronous-egress-transport.md
@@ -1,0 +1,78 @@
+# 0005: Synchronous Egress Transport (No BBMB)
+
+## Status
+Accepted
+
+## Context
+
+Egress used to be published to a BBMB queue (`chatting.egress.v1`) and drained later by the
+`message-handler` in its run loop. That made egress fire-and-forget from the sender's point of view:
+`app.main_reply` (and the worker's own completion events) got a queue GUID back and reported success
+as soon as the message was enqueued — the actual send, and any failure, happened later in a different
+process with no path back to the caller.
+
+This hid a real failure: a Telegram reply with an attachment was dropped by the handler
+(`telegram_attachment_missing`) while the executor reported success, so the user silently got nothing.
+The earlier supervised-reply-recovery heuristic only checked whether a reply was *published*, not
+whether it was *delivered*, so it could not catch this.
+
+Ingress is stream-shaped and benefits from a queue. Egress is request/response-shaped: the sender
+wants the delivery outcome. The handler must remain the sender (it holds the channel secrets; the
+worker runs untrusted executor code), so only the transport worker→handler needs to change.
+
+## Decision
+
+Egress does not use BBMB. Both `app.main_reply` and the worker POST each `chatting.egress.v2`
+payload to a synchronous handler endpoint and act on the result:
+
+- Endpoint: `POST {handler_egress_url}` (default `http://127.0.0.1:9467/egress`), served by a
+  dedicated loopback HTTP server (`egress_http_host`/`egress_http_port`). It is deliberately NOT on
+  the metrics mux, which may bind `0.0.0.0` for scraping — the ability to send messages externally
+  must stay reachable only from the local host, matching BBMB's old posture.
+- The endpoint runs the same `egress.Engine` path the BBMB drain used (`HandleRaw → Result`), so
+  validation, dedup, channel allowlisting, staging/flush, and loud drops are unchanged.
+- HTTP status maps the engine `Result`: `200` dispatched/completed/deduped, `202` staged (a
+  sequenced event waiting on an earlier one), `422` dropped (with reason code), `503` on an
+  infrastructure/state error.
+- `app.main_reply` maps this to an exit code so the executor can react: **0 delivered, 1 dropped
+  (permanent — adjust and resend, e.g. without the attachment), 3 transient (retry)**.
+- The worker's egress outbox is the durability layer, a write-ahead log: persist → POST →
+  `2xx` acks the row; `422` is logged loudly (`worker_egress_dropped_by_handler`) and acked so a
+  permanent drop cannot replay forever; unreachable/`5xx` leaves the row pending and it is retried on
+  a later loop or after restart.
+- The task-queue message is acked once processing completes **regardless of egress delivery**, so a
+  transient egress failure defers the reply to the outbox replay rather than re-running the executor.
+
+## Rules
+
+1. No egress path publishes to BBMB. `handler_egress_url` is the single egress transport.
+2. A dropped send (`422`) is an error: it is logged loudly and, for worker-originated events, acked in
+   the outbox (not retried); `app.main_reply` exits non-zero so the executor falls back.
+3. Only a transient failure (handler unreachable / `5xx`) is retried, via outbox replay.
+4. Outbound attachment paths are confined to `egress_attachment_allowed_dirs` (fail-closed): the path
+   is caller-controlled, so an unlisted path is refused before any file read.
+5. The endpoint binds loopback by default; do not move it onto a `0.0.0.0` mux.
+
+## Consequences
+
+Benefits:
+
+- The sender learns the real delivery outcome; a drop is surfaced immediately instead of silently.
+- No egress queue to buffer, drain, or reason about; the outbox is the only durability layer.
+- Ordering of a task's egress is naturally preserved by sequential synchronous calls.
+
+Tradeoffs / notes:
+
+- Egress now requires the handler to be up. In production all services run under one host so this
+  holds; the outbox covers transient handler downtime for worker-originated events.
+- The handler now writes SQLite from two concurrent places (the ingress loop and the egress
+  endpoint goroutine) where the drain used to run inside the single loop. The handler DB is opened
+  with `busy_timeout=5000` + WAL so a second writer waits for the lock instead of failing with
+  `SQLITE_BUSY`.
+- `DrainEgress`, the `chatting.egress.v1` queue constant, and the `NewRunner` egress-handler
+  parameter are retained (dead in the live path, still unit-tested) pending a follow-up removal.
+
+## Relationship to 0004
+
+0004 (completion vs incremental) is unchanged: the payload semantics are the same; only the transport
+that carries them moved from a queue to a synchronous call.

--- a/docs/bbmb-message-flow.md
+++ b/docs/bbmb-message-flow.md
@@ -19,24 +19,32 @@ Use it as the source of truth for:
 
 ## Queues
 
-There are three BBMB queue roles:
+BBMB now carries ingress only. Egress does not use BBMB — see [Egress transport](#egress-transport).
 
 | Queue | Producer | Consumer | Purpose |
 | --- | --- | --- | --- |
 | `generic-post` or any configured auxiliary ingress queue | `auxiliary-ingress` | `message-handler` | Carries raw JSON webhook bodies as `chatting.auxiliary_ingress.v1` payloads |
 | `chatting.tasks.v1` | `message-handler` | `worker` | Carries normalized ingress tasks as `chatting.task.v1` payloads |
-| `chatting.egress.v1` | `worker` | `message-handler` | Carries `chatting.egress.v2` payloads for visible executor-published incrementals and internal completion |
 
 Important details:
-- Task and egress queue names are hardcoded; auxiliary ingress queue names are configured per route.
+- The task queue name is hardcoded; auxiliary ingress queue names are configured per route.
 - There is no separate BBMB retry queue, dead-letter queue, or approval queue.
 - Retries, dead letters, ingress dedupe state, the task ledger, and the worker egress outbox all
   live in SQLite, not in BBMB.
-- The worker emits `chatting.egress.v2` payloads on `chatting.egress.v1`. The queue name is
-  transport-level; the `message_type` inside the JSON is the payload contract version.
-- `message-handler` enforces this contract and rejects legacy `chatting.egress.v1` payload types.
 - `auxiliary-ingress` only publishes `event_id`, `received_at`, and the parsed JSON `body`; HTTP
   request metadata is intentionally not forwarded into the worker-visible task.
+
+### Egress transport
+
+Egress does not flow over BBMB. Every egress message — the executor's visible replies via
+`app.main_reply` and the worker's own `completion`/sequenced events — is POSTed to the handler's
+synchronous egress endpoint (`handler_egress_url`, default `http://127.0.0.1:9467/egress`), and the
+delivery outcome is returned in the HTTP status. The `chatting.egress.v2` payload contract is
+unchanged; only the transport moved from a queue to a request/response call so the sender learns
+whether the send landed. The `chatting.egress.v1` queue and the handler's `DrainEgress` loop are
+retired from the live path (the code is retained only for its tests, pending removal). The endpoint
+binds loopback only by default, independent of the metrics bind, since it can send messages to the
+outside world.
 
 ## End-To-End Flow
 
@@ -151,10 +159,10 @@ An IMAP message from `alice@example.com` turns into a `chatting.task.v1` payload
 }
 ```
 
-### Example reply on `chatting.egress.v1`
+### Example reply
 
-If the worker decides to send one email reply, it publishes a `chatting.egress.v2` payload
-like this:
+If the worker decides to send one email reply, it POSTs a `chatting.egress.v2` payload
+to the egress endpoint like this:
 
 ```json
 {
@@ -210,7 +218,7 @@ Each message-handler loop also emits one internal heartbeat task by default.
 Flow:
 - `message-handler` creates an internal `TaskEnvelope`
 - it publishes that envelope to `chatting.tasks.v1`
-- `worker` turns it into a log-based pong on `chatting.egress.v1`, then emits completion
+- `worker` turns it into a log-based pong POSTed to the egress endpoint, then emits completion
 - `message-handler` accepts and logs that pong even if `log` is not otherwise allowlisted
 - `message-handler` closes the heartbeat task when the completion event arrives
 
@@ -251,7 +259,9 @@ This gives a built-in round-trip signal for the handler -> BBMB -> worker -> BBM
 ### Message-handler egress and observability config
 
 - `poll_timeout_seconds`
-  How long the message-handler waits on `chatting.egress.v1` for one egress payload each loop.
+  Bounds how long the message-handler blocks on a BBMB pickup per loop iteration. (Egress no
+  longer drains a queue, so this no longer gates egress; it applies to the retained-for-tests
+  egress drain and any auxiliary-ingress pickups.)
 - `allowed_egress_channels`
   Main control for what the worker is allowed to cause externally. Internal heartbeat pong on
   `log/heartbeat` is the only built-in exception.

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -11,15 +11,15 @@ GitHub assignment polling is part of the Go `message-handler` when configured.
 
 BBMB sits in the middle over TCP.
 
-Queues:
+Queues (ingress only — egress does not use BBMB):
 - auxiliary ingress uses one configured queue per route
 - `chatting.tasks.v1`
-- `chatting.egress.v1`
 
-Egress payload contract is v2-only:
-- Queue name `chatting.egress.v1` is transport-level only.
-- Worker publishes `message_type: "chatting.egress.v2"`.
-- `message-handler` rejects legacy `chatting.egress.v1` payload types.
+Egress is a synchronous HTTP call, not a queue:
+- The worker (and `app.main_reply`) POST `message_type: "chatting.egress.v2"` payloads to the
+  handler's egress endpoint (`handler_egress_url`, default `http://127.0.0.1:9467/egress`) and get
+  the delivery outcome back.
+- The `chatting.egress.v1` queue is retired from the live path.
 
 For a worked message example and the full message-handler <-> worker conversation, see
 [BBMB Message Flow](bbmb-message-flow.md).


### PR DESCRIPTION
Documents the current egress architecture now that PR1 (#247) and PR2 (#248) have landed on main. Egress is a synchronous handler endpoint, not the chatting.egress.v1 BBMB queue, but the flow doc, split-mode guide, and the interface-contract/implementation ADRs still described the old queue. This brings them in line.

ADR 0005 is the new canonical description of egress transport: the request/response design, the outbox write-ahead log, the loopback bind and attachment allowlist, and the SQLite busy_timeout/WAL needed now that the handler has concurrent writers. ADR 0004 (completion-vs-incremental semantics) is unchanged.

Docs only.