### PR TITLE
Run the reply script with -P so a workspace checkout can't shadow it

### DIFF
--- a/app/worker/executor/codex.py
+++ b/app/worker/executor/codex.py
@@ -98,12 +98,17 @@ def _task_payload(
         .isoformat()
         .replace("+00:00", "Z"),
         "reply_contract": {
-            "visible_replies_must_use": "python3 -m app.main_reply",
+            # -P (safe path) is required: it stops Python prepending the current
+            # working directory to sys.path, so this always runs the deployed
+            # app.main_reply even when the cwd is a chatting checkout in the
+            # workspace whose stale app/ would otherwise shadow it (a shadowing
+            # copy still publishes to BBMB and the reply is lost).
+            "visible_replies_must_use": "python3 -P -m app.main_reply",
             "visible_replies_must_not_be_returned_in_executor_output": True,
             "executor_exit_status_drives_completion": True,
             "executor_stdout_stderr_are_operator_transcript": True,
             "visible_reply_exit_status": (
-                "python3 -m app.main_reply now sends synchronously and its exit code tells "
+                "python3 -P -m app.main_reply now sends synchronously and its exit code tells "
                 "you whether the user actually received the reply: 0 = delivered; 1 = the "
                 "handler rejected it for good (for example a missing or unreadable "
                 "attachment) so you must adjust and resend, e.g. send the text without the "

--- a/app/worker/executor/supervised.py
+++ b/app/worker/executor/supervised.py
@@ -11,7 +11,7 @@ from app.worker.executor.base import Executor
 _SUPERVISED_RECOVERY_INSTRUCTION = (
     "The earlier executor pass finished without publishing any visible reply. "
     "Do not redo side effects or rerun the task. Use the captured transcript below "
-    "to send exactly one visible reply with python3 -m app.main_reply, then stop."
+    "to send exactly one visible reply with python3 -P -m app.main_reply, then stop."
 )
 
 

--- a/docs/architecture/0004-egress-completion-semantics.md
+++ b/docs/architecture/0004-egress-completion-semantics.md
@@ -35,7 +35,9 @@ Completion is internal-only:
 
 1. A successful task emits exactly one `completion` event.
 2. The executor must not return visible replies in stdout/stderr transcript output.
-3. Any visible reply must be sent by the executor itself, typically with `python3 -m app.main_reply`.
+3. Any visible reply must be sent by the executor itself, with `python3 -P -m app.main_reply` (the
+   `-P` keeps Python from importing a workspace checkout's stale `app.main_reply` instead of the
+   deployed one).
 4. If a task emits no visible replies, completion alone closes it.
 5. `incremental` is the visible reply path for both intermediate and final executor-published text.
 6. Conversation memory stores only externally visible assistant text on the real reply channel.

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -92,7 +92,7 @@ class CodexExecutorTests(unittest.TestCase):
         self.assertEqual(payload["task"]["reply_channel"]["type"], "email")
         self.assertEqual(
             payload["reply_contract"]["visible_replies_must_use"],
-            "python3 -m app.main_reply",
+            "python3 -P -m app.main_reply",
         )
         self.assertEqual(run_mock.call_args.kwargs["cwd"], "/workspace/chatting")
         self.assertEqual(run_mock.call_args.kwargs["env"], {"TOKEN": "secret"})


### PR DESCRIPTION
Billy's Telegram replies mostly stopped arriving for ~17h. The executor (codex) runs the reply as `python3 -m app.main_reply`, and Billy's workspace (/srv/chatting/workspace) holds a dozen chatting checkouts and worktrees, each with its own `app/`. When codex cd's into one to work on a task and then runs the reply, Python prepends the cwd to `sys.path` and imports that checkout's stale `app.main_reply` — the pre-egress-refactor version that publishes to the BBMB egress queue fire-and-forget instead of POSTing to the handler's synchronous `/egress` endpoint. Those BBMB replies raced the completion event and got dropped as `completed_task`. Replies sent from the workspace root used the deployed code and arrived, hence the intermittent symptom.

`-P` (safe path) stops Python adding the cwd to `sys.path`, so the deployed module — on the worker's PYTHONPATH, a nix store path — always wins regardless of cwd. It's scoped to the reply invocation only, not a blanket PYTHONSAFEPATH, so Billy's other ad-hoc python is unaffected. Validated on magpie: from a shadowing checkout, without `-P` Python resolves `/srv/chatting/workspace/chatting/app/main_reply.py` (the stale copy); with `-P` it resolves the deployed `/nix/store/...-source/app/main_reply.py`.

Also updates the supervised-recovery instruction, ADR 0004's reply-invocation note, and the test asserting the contract string.

This must deploy together with #248 (merged to main, not yet deployed) — the same lab flake bump will carry both. Ordering matters because #248 removes the BBMB egress drain, so once it deploys the shadowed replies would be lost entirely rather than merely dropped.