### PR TITLE
Send replies via a --spec-file so the body never touches the shell

### DIFF
--- a/app/main_reply.py
+++ b/app/main_reply.py
@@ -28,15 +28,49 @@ EXIT_DROPPED = 1
 EXIT_TRANSIENT = 3
 
 
+# Reply fields that a --spec-file JSON may set. These map 1:1 onto the argparse
+# namespace attributes below so the rest of the module is agnostic to whether a
+# reply came from a spec file or from flags.
+_SPEC_FIELDS = (
+    "task_id",
+    "channel",
+    "target",
+    "message",
+    "attachment_path",
+    "attachment_name",
+    "telegram_reaction",
+    "telegram_message_id",
+    "event_id",
+    "envelope_id",
+    "trace_id",
+)
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Publish one visible egress message. "
-            "Executors should use this for user-visible acknowledgements and final replies."
+            "Executors should use this for user-visible acknowledgements and final replies. "
+            "Prefer --spec-file: it carries the whole reply (including the body) as a JSON "
+            "file so nothing is passed through the shell."
         )
     )
-    parser.add_argument("task_id", help="Task identifier (for example: task:email:53).")
-    parser.add_argument("--message", help="Reply body text.")
+    # Reply body text is deliberately NOT a flag: passing arbitrary prose on the
+    # command line let the shell mangle backticks/quotes/$ and corrupt or split
+    # replies. The body only ever comes from --spec-file (a file the executor
+    # writes directly, never through the shell).
+    parser.add_argument(
+        "--spec-file",
+        help=(
+            "Path to a JSON file describing the whole reply "
+            f"({', '.join(_SPEC_FIELDS)}). The only way to send a text body."
+        ),
+    )
+    # task_id/channel/target may come from the spec file, so they are optional at
+    # the argparse layer and validated after the spec is applied.
+    parser.add_argument(
+        "task_id", nargs="?", help="Task identifier (for example: task:email:53)."
+    )
     parser.add_argument(
         "--attachment-path",
         help="Absolute path to a local file to send as an attachment.",
@@ -46,10 +80,9 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--channel",
-        required=True,
         help="Outbound channel (for example: email, telegram, github).",
     )
-    parser.add_argument("--target", required=True, help="Outbound channel target.")
+    parser.add_argument("--target", help="Outbound channel target.")
     parser.add_argument(
         "--telegram-reaction",
         help="React to the Telegram source message instead of sending a text message.",
@@ -76,7 +109,43 @@ def _parse_args() -> argparse.Namespace:
             f"{WORKER_CONFIG_PATH_ENV_VAR}."
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    # message only exists via the spec file; give the namespace the attribute so
+    # the resolution code below can read it uniformly.
+    args.message = None
+    _apply_spec_file(args)
+    if not args.task_id:
+        parser.error("task_id is required (as a positional argument or in --spec-file)")
+    if not args.channel:
+        parser.error("channel is required (via --channel or in --spec-file)")
+    if not args.target:
+        parser.error("target is required (via --target or in --spec-file)")
+    return args
+
+
+def _apply_spec_file(args: argparse.Namespace) -> None:
+    if args.spec_file is None:
+        return
+    try:
+        raw = Path(args.spec_file).read_text(encoding="utf-8")
+    except OSError as error:
+        raise ValueError(f"spec-file could not be read: {error}") from error
+    try:
+        spec = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"spec-file is not valid JSON: {error}") from error
+    if not isinstance(spec, dict):
+        raise ValueError("spec-file must contain a JSON object")
+    unknown = sorted(set(spec) - set(_SPEC_FIELDS))
+    if unknown:
+        raise ValueError("spec-file contains unknown fields: " + ", ".join(unknown))
+    # The spec file is authoritative: it supplies the whole reply, so it wins
+    # over any overlapping flags (there should be none in normal use).
+    for field in _SPEC_FIELDS:
+        if field in spec and spec[field] is not None:
+            setattr(args, field, spec[field])
+    if isinstance(args.telegram_message_id, str) and args.telegram_message_id.strip():
+        args.telegram_message_id = int(args.telegram_message_id)
 
 
 def _resolve_envelope_id(task_id: str, explicit_value: str | None) -> str:

--- a/app/worker/executor/codex.py
+++ b/app/worker/executor/codex.py
@@ -98,22 +98,35 @@ def _task_payload(
         .isoformat()
         .replace("+00:00", "Z"),
         "reply_contract": {
-            # -P (safe path) is required: it stops Python prepending the current
-            # working directory to sys.path, so this always runs the deployed
-            # app.main_reply even when the cwd is a chatting checkout in the
-            # workspace whose stale app/ would otherwise shadow it (a shadowing
-            # copy still publishes to BBMB and the reply is lost).
-            "visible_replies_must_use": "python3 -P -m app.main_reply",
+            # -P (safe path) stops Python prepending the cwd to sys.path, so this
+            # always runs the deployed app.main_reply even when the cwd is a
+            # chatting checkout in the workspace whose stale app/ would otherwise
+            # shadow it (a shadowing copy publishes to BBMB and the reply is lost).
+            "visible_replies_must_use": "python3 -P -m app.main_reply --spec-file <path>",
+            "reply_spec_instructions": (
+                "Write the whole reply as a JSON file using your file-editing tool (NOT a "
+                "shell command like echo/printf/heredoc), then pass it with --spec-file. "
+                "Never put the reply text on the command line: the shell mangles backticks, "
+                "quotes, $, and newlines, which corrupts or splits the reply. Spec fields: "
+                "task_id, channel, target, message, and optionally attachment_path, "
+                "attachment_name, telegram_reaction, telegram_message_id, event_id."
+            ),
+            "reply_spec_example": {
+                "task_id": "task:telegram:123",
+                "channel": "telegram",
+                "target": "8605042448",
+                "message": "Any text is safe here: backticks, $vars, \"quotes\", newlines.",
+            },
             "visible_replies_must_not_be_returned_in_executor_output": True,
             "executor_exit_status_drives_completion": True,
             "executor_stdout_stderr_are_operator_transcript": True,
             "visible_reply_exit_status": (
-                "python3 -P -m app.main_reply now sends synchronously and its exit code tells "
-                "you whether the user actually received the reply: 0 = delivered; 1 = the "
+                "python3 -P -m app.main_reply --spec-file sends synchronously and its exit code "
+                "tells you whether the user actually received the reply: 0 = delivered; 1 = the "
                 "handler rejected it for good (for example a missing or unreadable "
-                "attachment) so you must adjust and resend, e.g. send the text without the "
-                "attachment; 3 = the handler was unreachable so you may retry. A non-zero "
-                "exit means the reply did NOT reach the user — do not treat it as sent."
+                "attachment) so you must adjust and resend, e.g. without the attachment; "
+                "3 = the handler was unreachable so you may retry. A non-zero exit means the "
+                "reply did NOT reach the user — do not treat it as sent."
             ),
         },
     }

--- a/app/worker/executor/supervised.py
+++ b/app/worker/executor/supervised.py
@@ -11,7 +11,8 @@ from app.worker.executor.base import Executor
 _SUPERVISED_RECOVERY_INSTRUCTION = (
     "The earlier executor pass finished without publishing any visible reply. "
     "Do not redo side effects or rerun the task. Use the captured transcript below "
-    "to send exactly one visible reply with python3 -P -m app.main_reply, then stop."
+    "to send exactly one visible reply: write the reply JSON to a file with your editor, "
+    "then run python3 -P -m app.main_reply --spec-file <path>, then stop."
 )
 
 

--- a/docs/architecture/0004-egress-completion-semantics.md
+++ b/docs/architecture/0004-egress-completion-semantics.md
@@ -35,9 +35,11 @@ Completion is internal-only:
 
 1. A successful task emits exactly one `completion` event.
 2. The executor must not return visible replies in stdout/stderr transcript output.
-3. Any visible reply must be sent by the executor itself, with `python3 -P -m app.main_reply` (the
-   `-P` keeps Python from importing a workspace checkout's stale `app.main_reply` instead of the
-   deployed one).
+3. Any visible reply must be sent by the executor itself, with
+   `python3 -P -m app.main_reply --spec-file <path>`: the executor writes the whole reply as a JSON
+   file (with its editor, never the shell) and passes only the path, so the body can't be mangled by
+   the shell. The `-P` keeps Python from importing a workspace checkout's stale `app.main_reply`
+   instead of the deployed one. The inline `--message` flag is retired.
 4. If a task emits no visible replies, completion alone closes it.
 5. `incremental` is the visible reply path for both intermediate and final executor-published text.
 6. Conversation memory stores only externally visible assistant text on the real reply channel.

--- a/docs/run-split-bbmb.md
+++ b/docs/run-split-bbmb.md
@@ -142,30 +142,30 @@ Edit message-handler config:
 Use the worker-side CLI to submit a visible egress event to the handler's synchronous egress
 endpoint (it POSTs to `handler_egress_url`, not BBMB, and exits non-zero if the handler drops or
 can't reach the send). Executors should use this path for both quick acknowledgements and final
-user-visible answers instead of returning replies in their stdout/stderr transcript:
+user-visible answers instead of returning replies in their stdout/stderr transcript.
+
+The reply is described by a JSON spec file (written with the executor's editor, never via the
+shell) and passed with `--spec-file`, so the body is never a shell argument. Run it with `-P` so a
+workspace checkout's stale `app/` can't shadow the deployed module:
 
 ```bash
-docker compose exec worker python -m app.main_reply task:email:53 \
-  --message "working on it" \
-  --channel email \
-  --target alice@example.com \
+cat > /tmp/reply.json <<'JSON'
+{"task_id": "task:email:53", "channel": "email", "target": "alice@example.com",
+ "message": "working on it"}
+JSON
+docker compose exec worker python -P -m app.main_reply --spec-file /tmp/reply.json \
   --config /config/worker.json
 ```
 
 Notes:
 - `message_type` is `chatting.egress.v2` with `event_kind=incremental`.
 - These events are intentionally unsequenced and dispatch immediately at `message-handler`.
+- The inline `--message` flag is retired: the body only ever comes from `--spec-file`, so shell
+  metacharacters (backticks, `$`, quotes, newlines) can't mangle or split the reply.
 - Executor stdout/stderr are treated as operator transcript and audit detail, not user-visible reply transport.
-- `--event-id` can be supplied for stable idempotency across retries.
-- Telegram reactions use the same CLI, but publish `telegram_reaction` egress under the hood:
-
-```bash
-docker compose exec worker python -m app.main_reply task:telegram:53 \
-  --channel telegram \
-  --target 8605042448 \
-  --telegram-reaction "👍" \
-  --config /config/worker.json
-```
+- `event_id` in the spec can be supplied for stable idempotency across retries.
+- Telegram reactions go in the spec too (`"telegram_reaction": "👍"`); if `telegram_message_id`
+  is omitted, `app.main_reply` looks up the inbound Telegram `message_id` from the task ledger in `db_path`.
 
 - If `--telegram-message-id` is omitted, `app.main_reply` looks up the inbound Telegram `message_id` from the task ledger in `db_path`.
 

--- a/tests/e2e/fake_codex.py
+++ b/tests/e2e/fake_codex.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 
 
 def main():
@@ -31,19 +32,22 @@ def main():
     if channel not in _DELIVERABLE:
         channel = "log"
 
+    # Send via a spec file, like the real reply contract now requires, so the
+    # reply body never passes through the shell.
+    spec = {
+        "task_id": task_id,
+        "channel": channel,
+        "target": target,
+        "message": "E2E fake codex reply",
+    }
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", prefix="fake-codex-reply-", delete=False
+    ) as spec_file:
+        json.dump(spec, spec_file)
+        spec_path = spec_file.name
+
     subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "app.main_reply",
-            task_id,
-            "--message",
-            "E2E fake codex reply",
-            "--channel",
-            channel,
-            "--target",
-            target,
-        ],
+        [sys.executable, "-m", "app.main_reply", "--spec-file", spec_path],
         check=True,
     )
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -92,7 +92,7 @@ class CodexExecutorTests(unittest.TestCase):
         self.assertEqual(payload["task"]["reply_channel"]["type"], "email")
         self.assertEqual(
             payload["reply_contract"]["visible_replies_must_use"],
-            "python3 -P -m app.main_reply",
+            "python3 -P -m app.main_reply --spec-file <path>",
         )
         self.assertEqual(run_mock.call_args.kwargs["cwd"], "/workspace/chatting")
         self.assertEqual(run_mock.call_args.kwargs["env"], {"TOKEN": "secret"})

--- a/tests/test_main_reply.py
+++ b/tests/test_main_reply.py
@@ -19,7 +19,7 @@ from app.task_ledger import TaskLedgerStore
 
 
 class _FakeSubmit:
-    """Stand-in for main_reply._submit_egress: records calls, returns a canned
+    """Stand-in for main_reply.submit_egress: records calls, returns a canned
     (status_code, response) so tests don't do real HTTP."""
 
     def __init__(
@@ -38,30 +38,33 @@ class _FakeSubmit:
         return self.status, dict(self.response)
 
 
+def _write_spec(directory: Path, spec: dict[str, object]) -> str:
+    path = directory / "reply-spec.json"
+    path.write_text(json.dumps(spec), encoding="utf-8")
+    return str(path)
+
+
 class MainReplyCliTests(unittest.TestCase):
-    def test_main_reply_posts_unsequenced_incremental_v2_payload(self) -> None:
+    def test_spec_file_posts_unsequenced_incremental_v2_payload(self) -> None:
         submit = _FakeSubmit()
         stdout = io.StringIO()
-        with (
-            patch("app.main_reply.submit_egress", submit),
-            patch("sys.stdout", stdout),
-            patch(
-                "sys.argv",
-                [
-                    "main_reply.py",
-                    "task:email:53",
-                    "--message",
-                    "working on it",
-                    "--channel",
-                    "email",
-                    "--target",
-                    "alice@example.com",
-                    "--event-id",
-                    "evt:custom:1",
-                ],
-            ),
-        ):
-            exit_code = main()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:email:53",
+                    "channel": "email",
+                    "target": "alice@example.com",
+                    "message": "working on it",
+                    "event_id": "evt:custom:1",
+                },
+            )
+            with (
+                patch("app.main_reply.submit_egress", submit),
+                patch("sys.stdout", stdout),
+                patch("sys.argv", ["main_reply.py", "--spec-file", spec]),
+            ):
+                exit_code = main()
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(len(submit.calls), 1)
@@ -73,39 +76,82 @@ class MainReplyCliTests(unittest.TestCase):
         self.assertEqual(payload["event_id"], "evt:custom:1")
         self.assertEqual(payload["event_kind"], "incremental")
         self.assertEqual(payload["message_type"], "chatting.egress.v2")
+        self.assertEqual(payload["message"]["body"], "working on it")
         self.assertNotIn("sequence", payload)
 
         printed = json.loads(stdout.getvalue())
         self.assertEqual(printed["status"], "dispatched")
         self.assertEqual(printed["http_status"], 200)
-        self.assertIsNone(printed["sequence"])
 
-    def test_main_reply_uses_handler_egress_url_from_worker_config(self) -> None:
+    def test_spec_file_preserves_shell_dangerous_text_verbatim(self) -> None:
+        # The whole point of the spec file: prose that would be mangled as a
+        # shell argument (backticks, $, quotes, newlines) arrives intact.
+        dangerous = "Use `nix shell` for $HOME, say \"hi\".\nSecond line."
+        submit = _FakeSubmit()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:telegram:53",
+                    "channel": "telegram",
+                    "target": "8605042448",
+                    "message": dangerous,
+                },
+            )
+            with (
+                patch("app.main_reply.submit_egress", submit),
+                patch("sys.stdout", io.StringIO()),
+                patch("sys.argv", ["main_reply.py", "--spec-file", spec]),
+            ):
+                exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        _, payload = submit.calls[0]
+        self.assertEqual(payload["message"]["body"], dangerous)
+
+    def test_inline_message_flag_is_rejected(self) -> None:
+        # The inline body path is retired: --message must not exist, so passing
+        # it fails hard rather than risking a shell-mangled send.
+        with patch(
+            "sys.argv",
+            [
+                "main_reply.py",
+                "task:email:53",
+                "--channel",
+                "email",
+                "--target",
+                "alice@example.com",
+                "--message",
+                "inline text",
+            ],
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                main()
+        self.assertNotEqual(raised.exception.code, 0)
+
+    def test_spec_file_uses_handler_egress_url_from_worker_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "worker.json"
             config_path.write_text(
                 json.dumps({"handler_egress_url": "http://10.0.0.5:9999/egress"}),
                 encoding="utf-8",
             )
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:email:53",
+                    "channel": "email",
+                    "target": "alice@example.com",
+                    "message": "working on it",
+                },
+            )
             submit = _FakeSubmit()
-            stdout = io.StringIO()
             with (
                 patch("app.main_reply.submit_egress", submit),
-                patch("sys.stdout", stdout),
+                patch("sys.stdout", io.StringIO()),
                 patch(
                     "sys.argv",
-                    [
-                        "main_reply.py",
-                        "task:email:53",
-                        "--message",
-                        "working on it",
-                        "--channel",
-                        "email",
-                        "--target",
-                        "alice@example.com",
-                        "--config",
-                        str(config_path),
-                    ],
+                    ["main_reply.py", "--spec-file", spec, "--config", str(config_path)],
                 ),
             ):
                 exit_code = main()
@@ -113,12 +159,21 @@ class MainReplyCliTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(submit.calls[0][0], "http://10.0.0.5:9999/egress")
 
-    def test_main_reply_returns_dropped_exit_and_stays_quiet_in_db(self) -> None:
+    def test_dropped_exit_and_stays_quiet_in_db(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "state.db"
             config_path = Path(tmpdir) / "worker.json"
             config_path.write_text(
                 json.dumps({"db_path": str(db_path)}), encoding="utf-8"
+            )
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:telegram:53",
+                    "channel": "telegram",
+                    "target": "8605042448",
+                    "message": "here is the screenshot",
+                },
             )
             submit = _FakeSubmit(
                 status=422,
@@ -130,18 +185,7 @@ class MainReplyCliTests(unittest.TestCase):
                 patch("sys.stderr", stderr),
                 patch(
                     "sys.argv",
-                    [
-                        "main_reply.py",
-                        "task:telegram:53",
-                        "--message",
-                        "here is the screenshot",
-                        "--channel",
-                        "telegram",
-                        "--target",
-                        "8605042448",
-                        "--config",
-                        str(config_path),
-                    ],
+                    ["main_reply.py", "--spec-file", spec, "--config", str(config_path)],
                 ),
             ):
                 exit_code = main()
@@ -155,54 +199,63 @@ class MainReplyCliTests(unittest.TestCase):
         printed = json.loads(stderr.getvalue())
         self.assertEqual(printed["status"], "dropped")
         self.assertEqual(printed["reason"], "telegram_attachment_missing")
-        # A drop is not a delivery, so it must not be recorded as one — the
-        # supervised recovery loop keys off these activity rows.
+        # A drop is not a delivery, so it must not be recorded as one.
         self.assertEqual(activity, [])
 
-    def test_main_reply_returns_transient_exit_when_handler_unreachable(self) -> None:
+    def test_transient_exit_when_handler_unreachable(self) -> None:
         submit = _FakeSubmit(status=0, response={"reason": "egress endpoint unreachable"})
         stderr = io.StringIO()
-        with (
-            patch("app.main_reply.submit_egress", submit),
-            patch("sys.stderr", stderr),
-            patch(
-                "sys.argv",
-                [
-                    "main_reply.py",
-                    "task:email:53",
-                    "--message",
-                    "working on it",
-                    "--channel",
-                    "email",
-                    "--target",
-                    "alice@example.com",
-                ],
-            ),
-        ):
-            exit_code = main()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:email:53",
+                    "channel": "email",
+                    "target": "alice@example.com",
+                    "message": "working on it",
+                },
+            )
+            with (
+                patch("app.main_reply.submit_egress", submit),
+                patch("sys.stderr", stderr),
+                patch("sys.argv", ["main_reply.py", "--spec-file", spec]),
+            ):
+                exit_code = main()
 
         self.assertEqual(exit_code, EXIT_TRANSIENT)
 
-    def test_main_reply_requires_envelope_id_for_non_prefixed_task_id(self) -> None:
-        with patch(
-            "sys.argv",
-            [
-                "main_reply.py",
-                "email:53",
-                "--message",
-                "working on it",
-                "--channel",
-                "email",
-                "--target",
-                "alice@example.com",
-            ],
-        ):
-            with self.assertRaisesRegex(ValueError, "envelope_id is required"):
-                main()
+    def test_requires_envelope_id_for_non_prefixed_task_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "email:53",
+                    "channel": "email",
+                    "target": "alice@example.com",
+                    "message": "working on it",
+                },
+            )
+            with patch("sys.argv", ["main_reply.py", "--spec-file", spec]):
+                with self.assertRaisesRegex(ValueError, "envelope_id is required"):
+                    main()
 
-    def test_main_reply_posts_telegram_reaction_using_explicit_message_id(
-        self,
-    ) -> None:
+    def test_spec_file_rejects_unknown_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:email:53",
+                    "channel": "email",
+                    "target": "alice@example.com",
+                    "message": "hi",
+                    "bogus": "nope",
+                },
+            )
+            with patch("sys.argv", ["main_reply.py", "--spec-file", spec]):
+                with self.assertRaisesRegex(ValueError, "unknown fields"):
+                    main()
+
+    def test_reaction_via_flags_using_explicit_message_id(self) -> None:
         submit = _FakeSubmit()
         with (
             patch("app.main_reply.submit_egress", submit),
@@ -230,9 +283,7 @@ class MainReplyCliTests(unittest.TestCase):
         self.assertEqual(payload["message"]["body"], "👍")
         self.assertEqual(payload["message"]["metadata"], {"message_id": 123})
 
-    def test_main_reply_posts_telegram_reaction_using_task_ledger_message_id(
-        self,
-    ) -> None:
+    def test_reaction_via_spec_file_using_task_ledger_message_id(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "state.db"
             config_path = Path(tmpdir) / "worker.json"
@@ -259,23 +310,21 @@ class MainReplyCliTests(unittest.TestCase):
                 TaskQueueMessage.from_envelope(envelope, trace_id="trace:telegram:53")
             )
 
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:telegram:53",
+                    "channel": "telegram",
+                    "target": "8605042448",
+                    "telegram_reaction": "👍",
+                },
+            )
             submit = _FakeSubmit()
             with (
                 patch("app.main_reply.submit_egress", submit),
                 patch(
                     "sys.argv",
-                    [
-                        "main_reply.py",
-                        "task:telegram:53",
-                        "--channel",
-                        "telegram",
-                        "--target",
-                        "8605042448",
-                        "--telegram-reaction",
-                        "👍",
-                        "--config",
-                        str(config_path),
-                    ],
+                    ["main_reply.py", "--spec-file", spec, "--config", str(config_path)],
                 ),
             ):
                 exit_code = main()
@@ -284,30 +333,26 @@ class MainReplyCliTests(unittest.TestCase):
         _, payload = submit.calls[0]
         self.assertEqual(payload["message"]["metadata"], {"message_id": 456})
 
-    def test_main_reply_posts_attachment_message(self) -> None:
+    def test_spec_file_attachment_message(self) -> None:
         submit = _FakeSubmit()
         with tempfile.TemporaryDirectory() as tmpdir:
             attachment_path = Path(tmpdir) / "menu.pdf"
             attachment_path.write_bytes(b"%PDF-1.4\n")
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:telegram:53",
+                    "channel": "telegram",
+                    "target": "8605042448",
+                    "message": "This week's menu",
+                    "attachment_path": str(attachment_path),
+                    "attachment_name": "menu.pdf",
+                },
+            )
             with (
                 patch("app.main_reply.submit_egress", submit),
-                patch(
-                    "sys.argv",
-                    [
-                        "main_reply.py",
-                        "task:telegram:53",
-                        "--channel",
-                        "telegram",
-                        "--target",
-                        "8605042448",
-                        "--message",
-                        "This week's menu",
-                        "--attachment-path",
-                        str(attachment_path),
-                        "--attachment-name",
-                        "menu.pdf",
-                    ],
-                ),
+                patch("sys.stdout", io.StringIO()),
+                patch("sys.argv", ["main_reply.py", "--spec-file", spec]),
             ):
                 exit_code = main()
 
@@ -319,32 +364,30 @@ class MainReplyCliTests(unittest.TestCase):
             payload["message"]["attachment"]["uri"], attachment_path.as_uri()
         )
 
-    def test_main_reply_records_worker_activity_on_delivery(self) -> None:
+    def test_records_worker_activity_on_delivery(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "state.db"
             config_path = Path(tmpdir) / "worker.json"
             config_path.write_text(
                 json.dumps({"db_path": str(db_path)}), encoding="utf-8"
             )
+            spec = _write_spec(
+                Path(tmpdir),
+                {
+                    "task_id": "task:email:53",
+                    "channel": "email",
+                    "target": "alice@example.com",
+                    "message": "working on it",
+                    "event_id": "evt:custom:1",
+                },
+            )
             submit = _FakeSubmit()
             with (
                 patch("app.main_reply.submit_egress", submit),
+                patch("sys.stdout", io.StringIO()),
                 patch(
                     "sys.argv",
-                    [
-                        "main_reply.py",
-                        "task:email:53",
-                        "--message",
-                        "working on it",
-                        "--channel",
-                        "email",
-                        "--target",
-                        "alice@example.com",
-                        "--event-id",
-                        "evt:custom:1",
-                        "--config",
-                        str(config_path),
-                    ],
+                    ["main_reply.py", "--spec-file", spec, "--config", str(config_path)],
                 ),
             ):
                 exit_code = main()


### PR DESCRIPTION
Follow-on to #250 in the same "make the reply invocation robust" line. The executor passed reply prose as a `--message` argument through `bash -lc`, so the shell interpreted backticks, `$`, quotes and newlines and corrupted or split replies. That forced Billy to resend a "clean" version, a frequent double-send.

Adding a safe flag alongside the unsafe one wasn't enough, because the executor could still pick the unsafe path. So this retires the inline body path entirely: `--message` is removed, and the whole reply (task_id, channel, target, message, attachment, reaction, event_id) is read from a JSON `--spec-file` that the executor writes with its editor tool. Only a file path ever reaches the shell, so no reply content can be mangled.

The reply-contract and supervised-recovery instructions now tell the executor to write the spec JSON and run `python3 -P -m app.main_reply --spec-file <path>`. fake_codex, docs and tests are updated, including tests that the inline `--message` flag is now rejected and that shell-dangerous text round-trips verbatim. The affected Python suites pass locally.

Not deployed on its own. This rides the same reply-robustness deploy as #250 and #248 (merged, not yet deployed) — one lab flake bump carries all three.