### PR TITLE
Clarify phase-1 reply loosening behavior

### DIFF
--- a/go/handler/internal/dispatch/dispatch_test.go
+++ b/go/handler/internal/dispatch/dispatch_test.go
@@ -83,6 +83,33 @@ func TestDispatcherFormatsEmailReplySubjectAndQuotedOriginal(t *testing.T) {
 	}
 }
 
+func TestDispatcherSendsPlainEmailForNonEmailSource(t *testing.T) {
+	body := "Here is the answer."
+	sender := &recordingEmailSender{}
+	message := contracts.OutboundMessage{
+		Channel: "email",
+		Target:  "alice@example.com",
+		Body:    &body,
+	}
+
+	_, err := (Dispatcher{EmailSender: sender}).Dispatch(
+		context.Background(),
+		message,
+		telegramEnvelope("12345"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sent := sender.messages[0]
+	if sent.subject != nil {
+		t.Fatalf("subject = %#v", sent.subject)
+	}
+	if sent.body != "Here is the answer." {
+		t.Fatalf("body = %q", sent.body)
+	}
+}
+
 func TestDispatcherStripsLeadingSubjectLineFromEmailBody(t *testing.T) {
 	body := "Subject: Re: Ice-cream\n\nGreat choice. Let's go classic."
 	sender := &recordingEmailSender{}
@@ -586,6 +613,24 @@ func emailEnvelope(subject string, body string) contracts.TaskEnvelope {
 			Target: "alice@example.com",
 		},
 		DedupeKey: "email:1",
+	}
+}
+
+func telegramEnvelope(target string) contracts.TaskEnvelope {
+	actor := "7:sender"
+	return contracts.TaskEnvelope{
+		SchemaVersion: contracts.SchemaVersion,
+		ID:            "telegram:1",
+		Source:        "im",
+		ReceivedAt:    contracts.NewTimestamp(mustTime("2026-03-06T11:00:00Z")),
+		Actor:         &actor,
+		Content:       "telegram source body",
+		ReplyChannel: contracts.ReplyChannel{
+			Type:     "telegram",
+			Target:   target,
+			Metadata: map[string]any{"message_id": float64(42)},
+		},
+		DedupeKey: "telegram:1",
 	}
 }
 

--- a/go/handler/internal/egress/egress.go
+++ b/go/handler/internal/egress/egress.go
@@ -373,6 +373,8 @@ func (engine *Engine) channelAllowed(message contracts.EgressQueueMessage, task 
 	if task != nil && heartbeat.IsLogPong(message.Message, task.TaskMessage.Envelope) {
 		return true
 	}
+	// Explicit outbound channels are gated only by the handler allowlist.
+	// "final" remains the one default-route alias that resolves through reply_channel.
 	if task != nil && message.Message.Channel == "final" {
 		return engine.allowedChannels[task.TaskMessage.Envelope.ReplyChannel.Type]
 	}

--- a/go/handler/internal/egress/egress_test.go
+++ b/go/handler/internal/egress/egress_test.go
@@ -95,6 +95,56 @@ func TestHandleAllowsFinalChannelWhenEnvelopeReplyChannelAllowed(t *testing.T) {
 	}
 }
 
+func TestHandleAllowsExplicitTelegramFromEmailTaskWhenGloballyAllowed(t *testing.T) {
+	task := testTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngineWithAllowedChannels(t, state, dispatcher, []string{"email", "telegram"})
+	message := testEgressMessage(t, task, nil, "evt:telegram:1", "incremental")
+	message.Message.Channel = "telegram"
+	message.Message.Target = "12345"
+
+	result, err := engine.Handle(context.Background(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDispatched {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(dispatcher.messages) != 1 {
+		t.Fatalf("dispatch count = %d", len(dispatcher.messages))
+	}
+	if dispatcher.messages[0].Channel != "telegram" || dispatcher.messages[0].Target != "12345" {
+		t.Fatalf("dispatch = %#v", dispatcher.messages[0])
+	}
+}
+
+func TestHandleAllowsExplicitEmailFromTelegramTaskWhenGloballyAllowed(t *testing.T) {
+	task := testTelegramTaskMessage(t)
+	state := newFakeState()
+	state.addTask(task)
+	dispatcher := &recordingDispatcher{}
+	engine := newTestEngineWithAllowedChannels(t, state, dispatcher, []string{"email", "telegram"})
+	message := testEgressMessage(t, task, nil, "evt:email:1", "incremental")
+	message.Message.Channel = "email"
+	message.Message.Target = "alice@example.com"
+
+	result, err := engine.Handle(context.Background(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusDispatched {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(dispatcher.messages) != 1 {
+		t.Fatalf("dispatch count = %d", len(dispatcher.messages))
+	}
+	if dispatcher.messages[0].Channel != "email" || dispatcher.messages[0].Target != "alice@example.com" {
+		t.Fatalf("dispatch = %#v", dispatcher.messages[0])
+	}
+}
+
 func TestHandleAllowsInternalHeartbeatLogPongWhenLogDisallowed(t *testing.T) {
 	task := contracts.NewTaskQueueMessage(
 		heartbeat.BuildEnvelope(1, mustTime(t, "2026-03-09T12:00:00Z")),
@@ -671,7 +721,7 @@ func newTestEngine(t *testing.T, state *fakeState, dispatcher *recordingDispatch
 	if dispatcher == nil {
 		dispatcher = &recordingDispatcher{}
 	}
-	return newTestEngineWithState(t, state, dispatcher)
+	return newTestEngineWithAllowedChannels(t, state, dispatcher, []string{"email"})
 }
 
 func newTestEngineWithState(t *testing.T, state State, dispatcher *recordingDispatcher, options ...Option) *Engine {
@@ -684,6 +734,11 @@ func newTestEngineWithState(t *testing.T, state State, dispatcher *recordingDisp
 		t.Fatal(err)
 	}
 	return engine
+}
+
+func newTestEngineWithAllowedChannels(t *testing.T, state State, dispatcher *recordingDispatcher, channels []string) *Engine {
+	t.Helper()
+	return newTestEngineWithState(t, state, dispatcher, WithAllowedChannels(channels))
 }
 
 func testTaskMessage(t *testing.T) contracts.TaskQueueMessage {
@@ -705,6 +760,11 @@ func testTaskMessage(t *testing.T) contracts.TaskQueueMessage {
 }
 
 func telegramTaskMessage(t *testing.T) contracts.TaskQueueMessage {
+	t.Helper()
+	return testTelegramTaskMessage(t)
+}
+
+func testTelegramTaskMessage(t *testing.T) contracts.TaskQueueMessage {
 	t.Helper()
 	actor := "8605042448"
 	return contracts.NewTaskQueueMessage(contracts.TaskEnvelope{


### PR DESCRIPTION
## Summary
- add regression tests proving explicit cross-channel egress is allowed when the handler allowlist permits it
- add a dispatch test showing non-email-source tasks still send plain email bodies rather than email-style quoted replies
- document in `channelAllowed` that only `final` resolves through `reply_channel`

## Testing
- go test ./internal/egress ./internal/dispatch
