### PR TITLE
Reply in disallowed Telegram groups

### DIFF
--- a/app/internal_notices.py
+++ b/app/internal_notices.py
@@ -9,6 +9,7 @@ from app.models import OutboundMessage, TaskEnvelope
 
 INTERNAL_NOTICE_METADATA_KEY = "internal_notice"
 TELEGRAM_CHANNEL_NOT_ENABLED_NOTICE = "telegram_channel_not_enabled"
+TELEGRAM_GROUP_NOT_ENABLED_NOTICE = "telegram_group_not_enabled"
 
 
 def is_internal_telegram_channel_not_enabled_envelope(
@@ -18,7 +19,10 @@ def is_internal_telegram_channel_not_enabled_envelope(
         envelope.source == "internal"
         and envelope.reply_channel.type == "telegram"
         and envelope.reply_channel.metadata.get(INTERNAL_NOTICE_METADATA_KEY)
-        == TELEGRAM_CHANNEL_NOT_ENABLED_NOTICE
+        in {
+            TELEGRAM_CHANNEL_NOT_ENABLED_NOTICE,
+            TELEGRAM_GROUP_NOT_ENABLED_NOTICE,
+        }
     )
 
 

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -46,6 +46,7 @@ Matching CLI flags exist (`--telegram-enabled`, `--telegram-bot-token-env`, etc.
 - When a message includes both text and a Telegram `location`, the location block is appended to the text so the worker can reason over both in one prompt.
 - `channel_post` updates from allowlisted channel IDs are ingested normally.
 - `channel_post` updates from other channel IDs still update `telegram_chat_registry`, then trigger an automatic Telegram reply that includes the channel ID so it can be copied into `telegram_allowed_channel_ids`.
+- `message` updates from non-allowlisted `group` and `supergroup` chats still update `telegram_chat_registry`, then trigger an automatic Telegram reply that includes the chat ID so it can be copied into `telegram_allowed_chat_ids`.
 - Each observed `message`, `channel_post`, and `my_chat_member` chat is upserted into the handler SQLite table `telegram_chat_registry` before allowlist filtering. Query that table to discover new DM/group/supergroup/channel IDs, titles, usernames, and the latest retrieval timestamp.
 - Offset is advanced as `highest_update_id + 1` each poll.
 - The message handler tracks downloaded Telegram attachments in its SQLite DB and only makes them cleanup-eligible after the task reaches terminal completion.

--- a/go/handler/internal/connectors/telegram/telegram.go
+++ b/go/handler/internal/connectors/telegram/telegram.go
@@ -23,6 +23,7 @@ const Source = "im"
 
 const internalNoticeKey = "internal_notice"
 const telegramChannelNotEnabledNotice = "telegram_channel_not_enabled"
+const telegramGroupNotEnabledNotice = "telegram_group_not_enabled"
 
 type ChatObservation struct {
 	ChatID      string
@@ -186,6 +187,9 @@ func (connector *Connector) normalizeMessage(ctx context.Context, updateID int64
 		return nil, err
 	}
 	if len(connector.allowedChatIDs) > 0 && !connector.allowedChatIDs[chatID] {
+		if message.Chat.Type == "group" || message.Chat.Type == "supergroup" {
+			return connector.buildDisallowedGroupNoticeEnvelope(updateID, message, chatID), nil
+		}
 		return nil, nil
 	}
 	return connector.buildEnvelope(updateID, message, chatID, actor)
@@ -210,7 +214,36 @@ func (connector *Connector) normalizeChannelPost(ctx context.Context, updateID i
 }
 
 func (connector *Connector) buildDisallowedChannelNoticeEnvelope(updateID int64, message telegramMessage, chatID string) *contracts.TaskEnvelope {
-	eventID := "telegram-disallowed-channel:" + strconv.FormatInt(updateID, 10)
+	return connector.buildDisallowedTelegramNoticeEnvelope(
+		updateID,
+		message,
+		chatID,
+		telegramChannelNotEnabledNotice,
+		fmt.Sprintf("Not enabled in channel %s. Add this id to telegram_allowed_channel_ids to enable replies here.", chatID),
+		"telegram-disallowed-channel:",
+	)
+}
+
+func (connector *Connector) buildDisallowedGroupNoticeEnvelope(updateID int64, message telegramMessage, chatID string) *contracts.TaskEnvelope {
+	return connector.buildDisallowedTelegramNoticeEnvelope(
+		updateID,
+		message,
+		chatID,
+		telegramGroupNotEnabledNotice,
+		fmt.Sprintf("Not enabled in group %s. Add this id to telegram_allowed_chat_ids to enable replies here.", chatID),
+		"telegram-disallowed-group:",
+	)
+}
+
+func (connector *Connector) buildDisallowedTelegramNoticeEnvelope(
+	updateID int64,
+	message telegramMessage,
+	chatID string,
+	noticeType string,
+	content string,
+	eventPrefix string,
+) *contracts.TaskEnvelope {
+	eventID := eventPrefix + strconv.FormatInt(updateID, 10)
 	actor := "message-handler"
 	return &contracts.TaskEnvelope{
 		SchemaVersion: contracts.SchemaVersion,
@@ -218,7 +251,7 @@ func (connector *Connector) buildDisallowedChannelNoticeEnvelope(updateID int64,
 		Source:        "internal",
 		ReceivedAt:    contracts.NewTimestamp(parseTelegramDate(message.Date, connector.now())),
 		Actor:         &actor,
-		Content:       fmt.Sprintf("Not enabled in channel %s. Add this id to telegram_allowed_channel_ids to enable replies here.", chatID),
+		Content:       content,
 		Attachments:   []contracts.AttachmentRef{},
 		ContextRefs:   []string{},
 		ReplyChannel: contracts.ReplyChannel{
@@ -226,7 +259,7 @@ func (connector *Connector) buildDisallowedChannelNoticeEnvelope(updateID int64,
 			Target: chatID,
 			Metadata: map[string]any{
 				"message_id":      message.MessageID,
-				internalNoticeKey: telegramChannelNotEnabledNotice,
+				internalNoticeKey: noticeType,
 			},
 		},
 		DedupeKey: eventID,

--- a/go/handler/internal/connectors/telegram/telegram_test.go
+++ b/go/handler/internal/connectors/telegram/telegram_test.go
@@ -244,6 +244,68 @@ func TestPollBuildsInternalNoticeForDisallowedChannelPost(t *testing.T) {
 	}
 }
 
+func TestPollBuildsInternalNoticeForDisallowedGroupMessage(t *testing.T) {
+	client := &fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(`{
+			"ok": true,
+			"result": [
+				{
+					"update_id": 2201,
+					"message": {
+						"message_id": 29,
+						"date": 1779345600,
+						"chat": {"id": -100888, "type": "supergroup", "title": "Ops Group"},
+						"from": {"id": 7, "username": "sender"},
+						"text": "hello group"
+					}
+				}
+			]
+		}`), nil
+	}}
+	observed := []ChatObservation{}
+	connector, err := New(Config{
+		BotToken:       "token",
+		AllowedChatIDs: []string{"12345"},
+		HTTPClient:     client,
+		ObserveChat: func(ctx context.Context, observation ChatObservation) error {
+			observed = append(observed, observation)
+			return nil
+		},
+		Now: func() time.Time { return mustTime(t, "2026-05-21T06:40:00Z") },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes, err := connector.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("envelopes = %#v", envelopes)
+	}
+	envelope := envelopes[0]
+	if envelope.Source != "internal" {
+		t.Fatalf("source = %q", envelope.Source)
+	}
+	if envelope.ReplyChannel.Type != "telegram" || envelope.ReplyChannel.Target != "-100888" {
+		t.Fatalf("reply channel = %#v", envelope.ReplyChannel)
+	}
+	if envelope.Content != "Not enabled in group -100888. Add this id to telegram_allowed_chat_ids to enable replies here." {
+		t.Fatalf("content = %q", envelope.Content)
+	}
+	if envelope.ReplyChannel.Metadata["internal_notice"] != "telegram_group_not_enabled" {
+		t.Fatalf("metadata = %#v", envelope.ReplyChannel.Metadata)
+	}
+	if envelope.ReplyChannel.Metadata["message_id"] != float64(29) && envelope.ReplyChannel.Metadata["message_id"] != int64(29) {
+		t.Fatalf("metadata = %#v", envelope.ReplyChannel.Metadata)
+	}
+	if len(observed) != 1 || observed[0].ChatID != "-100888" || observed[0].UpdateKind != "message" {
+		t.Fatalf("observed = %#v", observed)
+	}
+}
+
 func TestPollDownloadsPhotoAttachmentAndUsesCaptionAsContent(t *testing.T) {
 	attachmentDir := t.TempDir()
 	requestedURLs := []string{}

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -10,6 +10,7 @@ from app.internal_heartbeat import build_internal_heartbeat_envelope
 from app.internal_notices import (
     INTERNAL_NOTICE_METADATA_KEY,
     TELEGRAM_CHANNEL_NOT_ENABLED_NOTICE,
+    TELEGRAM_GROUP_NOT_ENABLED_NOTICE,
 )
 from app.models import (
     ExecutionResult,
@@ -266,6 +267,33 @@ class WorkerRuntimeTests(unittest.TestCase):
         return TaskQueueMessage.from_envelope(
             envelope,
             trace_id="trace:internal:telegram-disallowed-channel:2101",
+        )
+
+    def _build_internal_group_notice_task_message(self) -> TaskQueueMessage:
+        envelope = TaskEnvelope(
+            id="telegram-disallowed-group:2201",
+            source="internal",
+            received_at=datetime(2026, 6, 25, 8, 5, tzinfo=timezone.utc),
+            actor="message-handler",
+            content=(
+                "Not enabled in group -100888. "
+                "Add this id to telegram_allowed_chat_ids to enable replies here."
+            ),
+            attachments=[],
+            context_refs=[],
+            reply_channel=ReplyChannel(
+                type="telegram",
+                target="-100888",
+                metadata={
+                    INTERNAL_NOTICE_METADATA_KEY: TELEGRAM_GROUP_NOT_ENABLED_NOTICE,
+                    "message_id": 29,
+                },
+            ),
+            dedupe_key="telegram-disallowed-group:2201",
+        )
+        return TaskQueueMessage.from_envelope(
+            envelope,
+            trace_id="trace:internal:telegram-disallowed-group:2201",
         )
 
     def test_process_task_message_emits_completion_only_for_successful_task(
@@ -653,6 +681,42 @@ class WorkerRuntimeTests(unittest.TestCase):
             self.assertEqual(
                 audit_event.detail["internal_notice"],
                 "telegram_channel_not_enabled",
+            )
+
+    def test_process_task_message_handles_internal_group_notice_without_executor(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SQLiteStateStore(str(Path(tmpdir) / "worker.db"))
+            result = process_task_message(
+                store=store,
+                task_message=self._build_internal_group_notice_task_message(),
+                executor_impl=AlwaysFailExecutor(),
+                max_attempts=2,
+                activity_monitor=self._build_monitor(store),
+            )
+
+            self.assertEqual(result.run_record.result_status, "success")
+            self.assertEqual(result.run_record.source, "internal")
+            self.assertEqual(len(result.egress_messages), 2)
+            visible_egress_message = result.egress_messages[0]
+            completion_egress_message = result.egress_messages[1]
+            self.assertEqual(visible_egress_message.event_kind, "message")
+            self.assertEqual(visible_egress_message.message.channel, "telegram")
+            self.assertEqual(visible_egress_message.message.target, "-100888")
+            self.assertEqual(
+                visible_egress_message.message.body,
+                "Not enabled in group -100888. Add this id to telegram_allowed_chat_ids to enable replies here.",
+            )
+            self.assertEqual(completion_egress_message.event_kind, "completion")
+            self.assertEqual(completion_egress_message.sequence, 1)
+            self.assertEqual(result.reason_codes, ["internal_notice"])
+            self.assertIsNone(result.error_summary)
+            audit_event = store.list_audit_events()[0]
+            self.assertEqual(audit_event.detail["reason_codes"], ["internal_notice"])
+            self.assertEqual(
+                audit_event.detail["internal_notice"],
+                "telegram_group_not_enabled",
             )
 
     def test_build_error_summary_prefers_execution_error_then_last_error_then_fallback(


### PR DESCRIPTION
## Summary

- reply visibly in non-allowlisted Telegram groups and supergroups instead of dropping those messages silently
- reuse the existing internal-notice worker path so group notices behave the same way as channel notices
- document the new group behavior and cover it with handler and worker tests

## Testing

- `python3 -m unittest tests.test_worker_runtime`
- `go test ./internal/connectors/telegram ./internal/dispatch ./internal/egress`
