### PR TITLE
Handle clean handler shutdown during split-mode e2e

### DIFF
--- a/go/handler/internal/runtime/runtime.go
+++ b/go/handler/internal/runtime/runtime.go
@@ -150,9 +150,15 @@ func (runner *Runner) Run(ctx context.Context) error {
 		loopCount++
 		published, err := runner.PublishIngress(ctx)
 		if err != nil {
+			if isGracefulContextStop(ctx, err) {
+				return nil
+			}
 			return err
 		}
 		if err := runner.cleanupTelegramAttachments(ctx); err != nil {
+			if isGracefulContextStop(ctx, err) {
+				return nil
+			}
 			return err
 		}
 		if runner.metrics != nil {
@@ -165,6 +171,13 @@ func (runner *Runner) Run(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+func isGracefulContextStop(ctx context.Context, err error) bool {
+	if err == nil || ctx == nil || ctx.Err() == nil {
+		return false
+	}
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (runner *Runner) cleanupTelegramAttachments(ctx context.Context) error {

--- a/go/handler/internal/runtime/runtime_test.go
+++ b/go/handler/internal/runtime/runtime_test.go
@@ -390,6 +390,28 @@ func TestRunReturnsWhenContextIsCancelledDuringSleep(t *testing.T) {
 	}
 }
 
+func TestRunReturnsWhenContextIsCancelledDuringConnectorPoll(t *testing.T) {
+	broker := &fakeBroker{}
+	handler := &fakeEgressHandler{}
+	config := handlerconfig.Defaults()
+	config.MaxLoops = 0
+	ctx, cancel := context.WithCancel(context.Background())
+	connector := &fakeCancelingConnector{onPoll: cancel}
+	runner, err := NewRunner(
+		config,
+		broker,
+		handler,
+		WithIngress(newFakeIngressState(), connector),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRunRecordsLoopAndEgressMetrics(t *testing.T) {
 	broker := &fakeBroker{
 		picked: []*bbmb.PickedMessage{
@@ -568,6 +590,17 @@ func (connector *fakeAckingConnector) Poll(ctx context.Context) ([]contracts.Tas
 func (connector *fakeAckingConnector) AckEnvelope(ctx context.Context, envelopeID string) error {
 	connector.acked = append(connector.acked, envelopeID)
 	return nil
+}
+
+type fakeCancelingConnector struct {
+	onPoll func()
+}
+
+func (connector *fakeCancelingConnector) Poll(ctx context.Context) ([]contracts.TaskEnvelope, error) {
+	if connector.onPoll != nil {
+		connector.onPoll()
+	}
+	return nil, context.Canceled
 }
 
 type fakeMetricsClock struct {

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,8 @@
+## Summary
+- treat handler context cancellation during connector polling/cleanup as clean shutdown
+- add runtime coverage for the mid-poll cancellation path
+
+## Testing
+- go test ./...
+- CHATTING_BBMB_SERVER_BIN=/srv/chatting/workspace/.tmp-bin/bbmb-server-linux-amd64 CHATTING_E2E_HANDLER_BINARY=/srv/chatting/workspace/.tmp-bin/postmerge-fix/chatting-handler PYTHONPATH=/srv/chatting/workspace/.tmp/worktrees/chatting-postmerge-fix /run/current-system/sw/bin/python3 -m unittest tests.test_split_mode_e2e
+- repeated the split-mode e2e test 8 times with the patched handler binary


### PR DESCRIPTION
## Summary
- treat handler context cancellation during connector polling/cleanup as clean shutdown
- add runtime coverage for the mid-poll cancellation path

## Testing
- go test ./...
- CHATTING_BBMB_SERVER_BIN=/srv/chatting/workspace/.tmp-bin/bbmb-server-linux-amd64 CHATTING_E2E_HANDLER_BINARY=/srv/chatting/workspace/.tmp-bin/postmerge-fix/chatting-handler PYTHONPATH=/srv/chatting/workspace/.tmp/worktrees/chatting-postmerge-fix /run/current-system/sw/bin/python3 -m unittest tests.test_split_mode_e2e
- repeated the split-mode e2e test 8 times with the patched handler binary
